### PR TITLE
Add multi-blocks support to sum triton kernel, to enable large input size

### DIFF
--- a/tritonbench/operators/sum/kernels.py
+++ b/tritonbench/operators/sum/kernels.py
@@ -36,7 +36,8 @@ def triton_sum_kernel_scalar_result(
     )  # create offsets for scalar output pointer (output shape == (1,))
 
     # stored pointers have shape equal to output shape
-    tl.store(
+    # Use atomic add to accumulate results from multiple blocks
+    tl.atomic_add(
         output_ptr + output_offsets, output
     )  # store output, where the stored pointers are in the desired output shape
 

--- a/tritonbench/operators/sum/operator.py
+++ b/tritonbench/operators/sum/operator.py
@@ -73,9 +73,9 @@ def parse_op_args(args: List[str]):
 def execute_kernel_scalar_result(x):
     kernel_input = x.view(-1)
     M = kernel_input.shape[0]
-    BLOCK_SIZE_M = triton.next_power_of_2(
-        M
-    )  # race condition in cases where BLOCK_SIZE < n_elements^2
+    # Limit block size to avoid exceeding Triton's maximum tensor size (1048576)
+    MAX_BLOCK_SIZE = 1048576
+    BLOCK_SIZE_M = min(triton.next_power_of_2(M), MAX_BLOCK_SIZE)
     grid = lambda meta: (triton.cdiv(M, meta["BLOCK_SIZE_M"]),)
     kernel_output = torch.zeros(
         (), device=x.device, dtype=x.dtype


### PR DESCRIPTION
Currently, running `python run.py --op sum` fails with this error when tensor size is large:
```python
Traceback (most recent call last):
  File "/home/willfeng/local/pytorch-nightly/triton/language/core.py", line 34, in wrapper
    return fn(*args, **kwargs)
  File "/home/willfeng/local/pytorch-nightly/triton/language/core.py", line 1451, in arange
    return semantic.arange(start, end, _builder)
           ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "/home/willfeng/local/pytorch-nightly/triton/language/semantic.py", line 625, in arange
    ret_ty = tl.block_type(tl.int32, shape)
  File "/home/willfeng/local/pytorch-nightly/triton/language/core.py", line 648, in __init__
    self.numel = validate_block_shape(self.shape)
                 ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
  File "/home/willfeng/local/pytorch-nightly/triton/language/_utils.py", line 20, in validate_block_shape
    raise ValueError(f"numel ({numel}) exceeds triton maximum tensor numel ({TRITON_MAX_TENSOR_NUMEL})")
ValueError: numel (2097152) exceeds triton maximum tensor numel (1048576)
```
This PR fixes the error by splitting M into multiple blocks when M's next power of 2 is too large.