### PR TITLE
Add more options to triton bench

### DIFF
--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -1439,6 +1439,8 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
                 self.dump_ir(input_id, fn)
         except torch.cuda.OutOfMemoryError:
             metrics.error_msg = "CUDA OOM"
+        except NotImplementedError:
+            metrics.error_msg = "not supported"
         except Exception as e:
             if not self.tb_args.keep_going:
                 raise


### PR DESCRIPTION
Stacked PRs:
 * __->__#292


--- --- ---

Add more options to triton bench

```Shell
                 (B, Hq, M, Hkv, N, D) | Mask Type        eager-latency    eager-tflops    eager-tbps     compiled-latency    compiled-tflops    compiled-tbps    sdpa_cudnn-latency    sdpa_cudnn-tflops    sdpa_cudnn-tbps
--------------------------------------------------  -------------------  --------------  ------------  -------------------  -----------------  ---------------  --------------------  -------------------  -----------------
      (8, 16, 128, 16, 128, 128) |            noop    4.426528 (±7.46%)        0.24257     0.00379015   0.028768 (±70.75%)            37.47          0.58319       0.016736 (±6.69%)              64.1576          1.00246
      (8, 16, 128, 16, 128, 128) |          causal    4.064640 (±3.93%)        0.264167    0.0041276     0.017472 (±4.58%)            61.6951        0.960234      0.017152 (±8.21%)              31.3008          0.978149
      (8, 16, 128, 16, 128, 128) |             rel    4.470176 (±5.85%)        0.240201    0.00375314  0.031264 (±101.33%)            34.4785        0.536631          not supported
      (8, 16, 128, 16, 128, 128) |       head_bias   4.532448 (±36.08%)        0.236901    0.00370158  0.031264 (±125.49%)            34.4785        0.536631          not supported
      (8, 16, 128, 16, 128, 128) |           alibi    4.075040 (±4.43%)        0.263492    0.00411707    0.018624 (±7.56%)            57.8789        0.900838          not supported
      (8, 16, 128, 16, 128, 128) |  sliding_window    4.190176 (±9.48%)        0.256252    0.00400394    0.018624 (±7.39%)            57.8789        0.900838          not supported
    (1, 16, 1024, 16, 1024, 128) |   document_mask   10.817824 (±4.26%)        0.794054    0.00155089    0.040192 (±3.42%)            46.9344        0.417427          not supported
      (8, 16, 128, 16, 128, 128) |       prefix_lm    4.156096 (±3.87%)        0.258353    0.00403677    0.017888 (±6.98%)            60.2603        0.937903          not supported
      (8, 16, 128, 16, 128, 128) |         softcap    4.060992 (±5.28%)        0.264404    0.00413131    0.018432 (±7.12%)            58.4818        0.910222          not supported
      (8, 16, 256, 16, 256, 128) |            noop    4.413952 (±2.70%)        0.973044    0.0076019     0.042528 (±9.71%)           101.386         0.788996      0.026496 (±6.64%)             162.099           1.2664
      (8, 16, 256, 16, 256, 128) |          causal    4.032640 (±4.40%)        1.06505     0.00832071    0.033856 (±3.97%)            95.5165        0.991093      0.027392 (±5.14%)              78.3982          1.22497
      (8, 16, 256, 16, 256, 128) |             rel   4.677728 (±12.13%)        0.918174    0.00717323    0.043200 (±3.48%)            99.8089        0.776723          not supported
      (8, 16, 256, 16, 256, 128) |       head_bias    4.552064 (±7.90%)        0.943521    0.00737126    0.042688 (±3.52%)           101.006         0.786039          not supported
      (8, 16, 256, 16, 256, 128) |           alibi    4.091296 (±3.59%)        1.04978     0.00820142    0.034560 (±3.98%)            93.5708        0.970904          not supported
      (8, 16, 256, 16, 256, 128) |  sliding_window    4.180032 (±3.86%)        1.0275      0.00802732    0.033568 (±2.10%)            96.336         0.999596          not supported
    (1, 16, 2048, 16, 2048, 128) |   document_mask  12.032160 (±21.18%)        2.85566     0.00278873    0.106400 (±1.80%)            49.3885        0.315361          not supported
      (8, 16, 256, 16, 256, 128) |       prefix_lm    4.238496 (±4.48%)        1.01332     0.00791659    0.033760 (±4.08%)            95.7882        0.993911          not supported
      (8, 16, 256, 16, 256, 128) |         softcap    4.134464 (±2.80%)        1.03882     0.00811579    0.034976 (±1.65%)            92.4579        0.959356          not supported
      (8, 16, 512, 16, 512, 128) |            noop    4.619904 (±7.42%)        3.71866     0.014526      0.084128 (±1.64%)           205.009         0.7977        0.046112 (±3.75%)             372.568           1.45534
      (8, 16, 512, 16, 512, 128) |          causal    4.261248 (±3.97%)        4.03165     0.0157486     0.066944 (±2.06%)           161.021         1.00246       0.045792 (±4.40%)             187.586           1.46552
      (8, 16, 512, 16, 512, 128) |             rel    4.662208 (±4.13%)        3.68492     0.0143942     0.084320 (±2.20%)           204.542         0.795883          not supported
      (8, 16, 512, 16, 512, 128) |       head_bias    4.601120 (±3.91%)        3.73385     0.0145853     0.084224 (±1.94%)           204.775         0.79679           not supported
      (8, 16, 512, 16, 512, 128) |           alibi    4.219424 (±5.61%)        4.07162     0.0159047     0.068064 (±1.88%)           158.371         0.985967          not supported
      (8, 16, 512, 16, 512, 128) |  sliding_window    4.388608 (±4.91%)        3.91465     0.0152916     0.060032 (±1.01%)           125.692         1.11788           not supported
    (1, 16, 4096, 16, 4096, 128) |   document_mask   11.113472 (±0.10%)       12.3669      0.00603851    0.216576 (±1.27%)            68.4361        0.309863          not supported
      (8, 16, 512, 16, 512, 128) |       prefix_lm    4.392416 (±3.83%)        3.91126     0.0152783     0.066912 (±1.82%)           161.098         1.00294           not supported
      (8, 16, 512, 16, 512, 128) |         softcap    4.262528 (±2.63%)        4.03044     0.0157439     0.069920 (±1.78%)           154.167         0.959795          not supported
    (8, 16, 1024, 16, 1024, 128) |            noop    5.835712 (±0.11%)       11.7757      0.0229994     0.224448 (±0.84%)           307.367         0.59799       0.122656 (±0.89%)             560.262           1.09426
    (8, 16, 1024, 16, 1024, 128) |          causal    5.684512 (±0.19%)       12.0889      0.0236111     0.156800 (±1.29%)           247.485         0.85598       0.088352 (±2.61%)             388.896           1.51912
    (8, 16, 1024, 16, 1024, 128) |             rel    5.835264 (±3.20%)       11.7766      0.0230011     0.227424 (±1.32%)           303.345         0.590165          not supported
    (8, 16, 1024, 16, 1024, 128) |       head_bias    5.837312 (±0.24%)       11.7725      0.0229931     0.226432 (±1.64%)           304.674         0.592751          not supported
    (8, 16, 1024, 16, 1024, 128) |           alibi    5.675040 (±0.22%)       12.1091      0.0236505     0.163936 (±1.33%)           236.712         0.81872           not supported
    (8, 16, 1024, 16, 1024, 128) |  sliding_window    5.659008 (±0.13%)       12.1434      0.0237175     0.107456 (±1.58%)           150.471         1.24905           not supported
    (1, 16, 8192, 16, 8192, 128) |   document_mask   45.349472 (±0.07%)       12.1227      0.00295963    0.457536 (±0.84%)           101.601         0.293349          not supported
    (8, 16, 1024, 16, 1024, 128) |       prefix_lm    5.723616 (±0.15%)       12.0063      0.0234498     0.157120 (±0.90%)           246.981         0.854237          not supported
    (8, 16, 1024, 16, 1024, 128) |         softcap    5.685888 (±0.18%)       12.086       0.0236054     0.170816 (±0.75%)           227.178         0.785744          not supported
    (8, 16, 2048, 16, 2048, 128) |            noop   22.207808 (±0.06%)       12.3775      0.0120874     0.744672 (±0.28%)           370.568         0.360475      0.442912 (±2.41%)             620.615           0.606069
    (8, 16, 2048, 16, 2048, 128) |          causal   21.890368 (±0.13%)       12.557       0.0122627     0.465312 (±1.03%)           315.056         0.576893      0.257280 (±1.00%)             534.2             1.04336
    (8, 16, 2048, 16, 2048, 128) |             rel   22.207745 (±0.10%)       12.3776      0.0120875     0.757280 (±0.38%)           364.398         0.354473          not supported
    (8, 16, 2048, 16, 2048, 128) |       head_bias   22.213120 (±0.05%)       12.3746      0.0120845     0.749952 (±0.38%)           367.959         0.357937          not supported
    (8, 16, 2048, 16, 2048, 128) |           alibi   21.885281 (±0.08%)       12.5599      0.0122656     0.494016 (±1.15%)           296.75          0.543374          not supported
    (8, 16, 2048, 16, 2048, 128) |  sliding_window   21.611904 (±0.09%)       12.7188      0.0124207     0.198304 (±0.58%)           168.509         1.35366           not supported
  (1, 16, 16384, 16, 16384, 128) |   document_mask  172.090302 (±0.00%)       12.7783      0.00155985    1.081024 (±0.50%)           149.572         0.248316          not supported
    (8, 16, 2048, 16, 2048, 128) |       prefix_lm   22.024639 (±0.28%)       12.4805      0.012188      0.462816 (±0.26%)           316.755         0.580005          not supported
    (8, 16, 2048, 16, 2048, 128) |         softcap   21.851871 (±0.09%)       12.5791      0.0122843     0.508480 (±1.08%)           288.309         0.527917          not supported
    (8, 16, 4096, 16, 4096, 128) |            noop   88.047394 (±0.00%)       12.4877      0.00609752    2.731840 (±0.12%)           404.052         0.196524      1.750848 (±1.80%)             627.988           0.306635
    (8, 16, 4096, 16, 4096, 128) |          causal   88.757248 (±0.00%)       12.3879      0.00604876    1.581632 (±0.10%)           359.85          0.339441      0.947552 (±2.24%)             580.185           0.566587
    (8, 16, 4096, 16, 4096, 128) |             rel   88.136063 (±0.00%)       12.4752      0.00609139    2.784288 (±0.77%)           396.441         0.192822          not supported
    (8, 16, 4096, 16, 4096, 128) |       head_bias   88.128960 (±0.00%)       12.4762      0.00609188    2.752768 (±0.09%)           400.981         0.195029          not supported
    (8, 16, 4096, 16, 4096, 128) |           alibi   88.749245 (±0.00%)       12.389       0.0060493     1.680704 (±0.84%)           338.638         0.319432          not supported
    (8, 16, 4096, 16, 4096, 128) |  sliding_window   87.892639 (±0.00%)       12.5097      0.00610826    0.378848 (±0.39%)           179.254         1.41711           not supported
  (1, 16, 32768, 16, 32768, 128) |   document_mask             CUDA OOM                                  3.044864 (±0.90%)           196.967         0.17632           not supported
    (8, 16, 4096, 16, 4096, 128) |       prefix_lm   89.252319 (±0.00%)       12.3191      0.0060152     1.562080 (±0.06%)           364.354         0.34369           not supported
    (8, 16, 4096, 16, 4096, 128) |         softcap   88.779778 (±0.00%)       12.3847      0.00604722    1.742880 (±0.21%)           326.557         0.308037          not supported
    (8, 16, 8192, 16, 8192, 128) |            noop             CUDA OOM                                 10.497600 (±0.31%)           420.594         0.102285      6.839424 (±5.52%)             643.043           0.156993
    (8, 16, 8192, 16, 8192, 128) |          causal             CUDA OOM                                  5.824864 (±1.11%)           384.92          0.184338      3.647488 (±7.14%)             602.887           0.294378
    (8, 16, 8192, 16, 8192, 128) |             rel             CUDA OOM                                 10.668896 (±1.21%)           413.841         0.100642          not supported
    (8, 16, 8192, 16, 8192, 128) |       head_bias             CUDA OOM                                 10.575296 (±0.92%)           417.504         0.101533          not supported
    (8, 16, 8192, 16, 8192, 128) |           alibi             CUDA OOM                                  6.205984 (±0.01%)           361.281         0.173017          not supported
    (8, 16, 8192, 16, 8192, 128) |  sliding_window             CUDA OOM                                  0.740128 (±0.22%)           184.965         1.45075           not supported
  (1, 16, 65536, 16, 65536, 128) |   document_mask             CUDA OOM                                  9.535872 (±0.18%)           241.51          0.1126            not supported
    (8, 16, 8192, 16, 8192, 128) |       prefix_lm             CUDA OOM                                  5.712224 (±0.44%)           392.51          0.187973          not supported
    (8, 16, 8192, 16, 8192, 128) |         softcap             CUDA OOM                                  6.436768 (±0.03%)           348.328         0.166814          not supported
  (8, 16, 16384, 16, 16384, 128) |            noop             CUDA OOM                                 41.139198 (±0.22%)           429.296         0.0522004    26.297279 (±0.39%)             668.974           0.0816618
  (8, 16, 16384, 16, 16384, 128) |          causal             CUDA OOM                                 21.781824 (±0.01%)           408.572         0.0985906    13.656320 (±3.72%)             644.104           0.157252
  (8, 16, 16384, 16, 16384, 128) |             rel             CUDA OOM                                 41.504192 (±0.57%)           425.521         0.0517414         not supported
  (8, 16, 16384, 16, 16384, 128) |       head_bias             CUDA OOM                                 41.532578 (±0.00%)           425.23          0.051706          not supported
  (8, 16, 16384, 16, 16384, 128) |           alibi             CUDA OOM                                 23.624352 (±0.47%)           376.706         0.0909013         not supported
  (8, 16, 16384, 16, 16384, 128) |  sliding_window             CUDA OOM                                  1.419648 (±0.12%)           193.621         1.51269           not supported
(1, 16, 131072, 16, 131072, 128) |   document_mask             CUDA OOM                                 31.536961 (±0.12%)           286.045         0.0680942         not supported
  (8, 16, 16384, 16, 16384, 128) |       prefix_lm             CUDA OOM                                 22.351904 (±0.01%)           398.151         0.0960761         not supported
  (8, 16, 16384, 16, 16384, 128) |         softcap             CUDA OOM                                 24.193279 (±0.70%)           367.848         0.0887636         not supported
                                           average                             5.24004     0.00783359                                235.072         0.579935                                     93.9898          0.183599
```