### PR TITLE
Add --list-metrics command to display available metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ build/
 /*.csv
 *.hatchet
 autotuner.log
+.venv/

--- a/run.py
+++ b/run.py
@@ -16,6 +16,7 @@ from tritonbench.operators import load_opbench_by_name
 from tritonbench.operators_collection import list_operators_by_collection
 from tritonbench.utils.env_utils import is_fbcode
 from tritonbench.utils.gpu_utils import gpu_lockdown
+from tritonbench.utils.list_metrics import list_metrics
 from tritonbench.utils.parser import get_parser
 from tritonbench.utils.run_utils import run_config, run_in_task
 
@@ -106,11 +107,17 @@ def run(args: List[str] = []):
     usage_report_logger(benchmark_name="tritonbench")
     parser = get_parser()
     args, extra_args = parser.parse_known_args(args)
+
     tritonparse_init(args.tritonparse)
     if args.op:
         ops = args.op.split(",")
     else:
         ops = list_operators_by_collection(args.op_collection)
+
+    # Handle --list-metrics after determining operators list
+    if args.list_metrics:
+        print(list_metrics(operators=ops if ops else []))
+        return
 
     # Force isolation in subprocess if testing more than one op.
     if len(ops) >= 2:

--- a/tritonbench/utils/list_metrics.py
+++ b/tritonbench/utils/list_metrics.py
@@ -1,0 +1,137 @@
+"""
+Utilities for listing available metrics in tritonbench.
+"""
+
+import sys
+from dataclasses import fields
+from typing import Dict, List, Set
+
+from tritonbench.operators import load_opbench_by_name
+from tritonbench.operators_collection import list_operators_by_collection
+
+from tritonbench.utils.triton_op import (
+    BenchmarkOperatorMetrics,
+    OVERRIDDEN_METRICS,
+    REGISTERED_METRICS,
+)
+
+
+def get_builtin_metrics() -> List[str]:
+    """Get all built-in metrics from BenchmarkOperatorMetrics dataclass."""
+    return [
+        field.name
+        for field in fields(BenchmarkOperatorMetrics)
+        if field.name != "extra_metrics"
+    ]
+
+
+def load_operators_to_register_metrics(operators: List[str]) -> None:
+    """Load operators to trigger metrics registration."""
+    for op_name in operators:
+        try:
+            load_opbench_by_name(op_name)
+        except Exception as e:
+            print(f"Warning: Failed to load operator '{op_name}': {e}", file=sys.stderr)
+
+
+def get_custom_metrics_for_operators(operators: List[str]) -> Dict[str, List[str]]:
+    """Get custom metrics for specific operators."""
+    # Load operators to ensure their metrics are registered
+    load_operators_to_register_metrics(operators)
+
+    result = {}
+    for op_name in operators:
+        result[op_name] = REGISTERED_METRICS.get(op_name, [])
+    return result
+
+
+def get_overridden_metrics_for_operators(operators: List[str]) -> Dict[str, List[str]]:
+    """Get overridden metrics for specific operators."""
+    # Load operators to ensure their metrics are registered
+    load_operators_to_register_metrics(operators)
+
+    result = {}
+    for op_name in operators:
+        result[op_name] = OVERRIDDEN_METRICS.get(op_name, [])
+    return result
+
+
+def get_all_metrics_for_collection(
+    collection_name: str,
+) -> Dict[str, Dict[str, List[str]]]:
+    """Get all metrics for operators in a collection."""
+    operators = list_operators_by_collection(collection_name)
+    load_operators_to_register_metrics(operators)
+
+    result = {}
+    for op_name in operators:
+        result[op_name] = {
+            "custom": REGISTERED_METRICS.get(op_name, []),
+            "overridden": OVERRIDDEN_METRICS.get(op_name, []),
+        }
+    return result
+
+
+def format_operator_specific_metrics(
+    operators: List[str],
+    builtin_metrics: List[str],
+    custom_metrics: Dict[str, List[str]],
+    overridden_metrics: Dict[str, List[str]],
+) -> str:
+    """Format metrics output for specific operators."""
+    output = []
+
+    # Show built-in metrics (common to all operators)
+    output.append("Built-in metrics (available for all operators):")
+    for metric in sorted(builtin_metrics):
+        output.append(f"  {metric}")
+
+    # Show metrics for each operator
+    for op_name in sorted(operators):
+        custom = custom_metrics.get(op_name, [])
+        overridden = overridden_metrics.get(op_name, [])
+
+        if not custom and not overridden:
+            continue
+
+        output.append(f"\nOperator: {op_name}")
+
+        if custom:
+            output.append("  Custom metrics:")
+            for metric in sorted(custom):
+                output.append(f"    {metric}")
+
+        if overridden:
+            output.append("  Overridden metrics:")
+            for metric in sorted(overridden):
+                output.append(f"    {metric}")
+
+    return "\n".join(output)
+
+
+def list_metrics(operators: List[str] = None) -> str:
+    """
+    List available metrics based on the provided operators.
+
+    Args:
+        operators: List of specific operators to show metrics for
+
+    Returns:
+        Formatted string with metrics information
+    """
+    builtin_metrics = get_builtin_metrics()
+
+    if operators:
+        # Specific operators case
+        custom_metrics = get_custom_metrics_for_operators(operators)
+        overridden_metrics = get_overridden_metrics_for_operators(operators)
+        return format_operator_specific_metrics(
+            operators, builtin_metrics, custom_metrics, overridden_metrics
+        )
+    else:
+        # Global case - show built-in metrics only
+        output = []
+        output.append("Built-in metrics (available for all operators):")
+        for metric in sorted(builtin_metrics):
+            output.append(f"  {metric}")
+        return "\n".join(output)

--- a/tritonbench/utils/parser.py
+++ b/tritonbench/utils/parser.py
@@ -97,6 +97,11 @@ def get_parser(args=None):
         help="Metrics to collect, split with comma. E.g., --metrics latency,tflops,speedup.",
     )
     parser.add_argument(
+        "--list-metrics",
+        action="store_true",
+        help="List all available metrics. Can be used with --op or --op-collection to show operator-specific metrics.",
+    )
+    parser.add_argument(
         "--metrics-gpu-backend",
         choices=["torch", "nvml"],
         default="torch",


### PR DESCRIPTION
Implements issue #115: Add --list-metrics CLI option to provide a list of available metrics categorized as:
- Built-in metrics
- User customized metrics per operator
- User overridden metrics per operator

Features:
- Global listing (operators are default to "default" collection): python run.py --list-metrics
- Operator-specific: python run.py --list-metrics --op gemm
- Multiple operators: python run.py --list-metrics --op gemm,vector_add
- Collection-based: python run.py --list-metrics --op-collection default

Test commands:
```
$ python run.py --list-metrics
TMA benchmarks will be running without grid constant TMA descriptor.
Warning: Failed to load operator 'decoding_attention': No module named 'gen_ai'
INFO:root:TMA benchmarks will be running without grid constant TMA descriptor.
Warning: Failed to load operator 'fp8_fused_quant_gemm_rowwise': No module named 'fbgemm_gpu'
WARNING:tritonbench.operators.fp8_gemm.fp8_gemm:Failed to import TMA due to module not being found
Warning: Failed to load operator 'fp8_gemm_blockwise': No module named 'fbgemm_gpu'
Warning: Failed to load operator 'fp8_gemm_rowwise': name 'get_fp8_constants' is not defined
Warning: Failed to load operator 'fp8_gemm_rowwise_grouped': name 'get_fp8_constants' is not defined
WARNING: temporarily disabled some autotune configs for CUDA 12.8+
Warning: Failed to load operator 'decoding_attention': No module named 'gen_ai'
Warning: Failed to load operator 'fp8_fused_quant_gemm_rowwise': No module named 'fbgemm_gpu'
Warning: Failed to load operator 'fp8_gemm_blockwise': No module named 'fbgemm_gpu'
Warning: Failed to load operator 'fp8_gemm_rowwise': name 'get_fp8_constants' is not defined
Warning: Failed to load operator 'fp8_gemm_rowwise_grouped': name 'get_fp8_constants' is not defined
Built-in metrics (available for all operators):
  accuracy
  all_configs
  att_trace
  best_config
  compile_time
  compile_time_by_stage
  compile_trace
  cpu_peak_mem
  cuda_time
  error_msg
  gpu_peak_mem
  hw_roofline
  kernel_source_hash
  kineto_trace
  latency
  mem_footprint_compression_ratio
  ncu_rep
  ncu_rep_ir
  nsys_gpu_speedup
  nsys_rep
  speedup
  tflops
  walltime

Operator: addmm
  Custom metrics:
    flops
    gbps

Operator: bf16xint16_gemm
  Custom metrics:
    flops
    gbps
  Overridden metrics:
    best_config

Operator: blackwell_attentions
  Custom metrics:
    flops

Operator: flash_attention
  Custom metrics:
    flops

Operator: flex_attention
  Custom metrics:
    flops
    tbps

Operator: fp8_attention
  Custom metrics:
    flops

Operator: fp8_gemm
  Custom metrics:
    flops
    gbps

Operator: gather_gemv
  Custom metrics:
    gbps

Operator: gemm
  Custom metrics:
    gbps
  Overridden metrics:
    tflops

Operator: grouped_gemm
  Custom metrics:
    flops

Operator: int4_gemm
  Custom metrics:
    flops
    gbps

Operator: jagged_layer_norm
  Custom metrics:
    gbps
    input_shape

Operator: jagged_mean
  Custom metrics:
    gbps
    input_shape

Operator: jagged_softmax
  Custom metrics:
    gbps
    input_shape

Operator: jagged_sum
  Custom metrics:
    gbps
    input_shape
    occupancy
  Overridden metrics:
    accuracy

Operator: layer_norm
  Custom metrics:
    gbps

Operator: low_mem_dropout
  Custom metrics:
    flops
    gbps

Operator: ragged_attention
  Custom metrics:
    flops

Operator: softmax
  Custom metrics:
    gbps

Operator: sum
  Custom metrics:
    gbps
    input_shape

Operator: test_op
  Custom metrics:
    test_metric
    test_metric_per_benchmark

Operator: vector_add
  Custom metrics:
    gbps

Operator: vector_exp
  Custom metrics:
    duration
    gbps
  Overridden metrics:
    accuracy
```

```
python run.py --list-metrics --op gemm
Built-in metrics (available for all operators):
  accuracy
  all_configs
  att_trace
  best_config
  compile_time
  compile_time_by_stage
  compile_trace
  cpu_peak_mem
  cuda_time
  error_msg
  gpu_peak_mem
  hw_roofline
  kernel_source_hash
  kineto_trace
  latency
  mem_footprint_compression_ratio
  ncu_rep
  ncu_rep_ir
  nsys_gpu_speedup
  nsys_rep
  speedup
  tflops
  walltime

Operator: gemm
  Custom metrics:
    gbps
  Overridden metrics:
    tflops
```