### PR TITLE
Update repo owner (pytorch-labs -> meta-pytorch)

### DIFF
--- a/.ci/test_infra/oss_ci_benchmark_v3.py
+++ b/.ci/test_infra/oss_ci_benchmark_v3.py
@@ -34,7 +34,7 @@ def parse_dependencies(envs: Dict[str, str]) -> Dict[str, Dict[str, Any]]:
     dependencies = {
         "pytorch": "pytorch/pytorch",
         "triton": "triton-lang/triton",
-        "tritonbench": "pytorch-labs/tritonbench",
+        "tritonbench": "meta-pytorch/tritonbench",
     }
     out = {}
     for dep in dependencies:

--- a/.github/workflows/_linux-benchmark-abtest-h100.yml
+++ b/.github/workflows/_linux-benchmark-abtest-h100.yml
@@ -37,7 +37,7 @@ on:
 
 jobs:
   linux-benchmark-h100:
-    if: github.repository_owner == 'pytorch-labs'
+    if: github.repository_owner == 'meta-pytorch'
     runs-on: [gcp-h100-runner]
     timeout-minutes: 240
     environment: docker-s3-upload

--- a/.github/workflows/_linux-benchmark-h100.yml
+++ b/.github/workflows/_linux-benchmark-h100.yml
@@ -30,7 +30,7 @@ on:
 
 jobs:
   linux-benchmark-h100:
-    if: github.repository_owner == 'pytorch-labs'
+    if: github.repository_owner == 'meta-pytorch'
     runs-on: [gcp-h100-runner]
     timeout-minutes: 240
     environment: docker-s3-upload

--- a/.github/workflows/_linux-test-h100.yml
+++ b/.github/workflows/_linux-test-h100.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   linux-test-h100:
-    if: github.repository_owner == 'pytorch-labs'
+    if: github.repository_owner == 'meta-pytorch'
     runs-on: [gcp-h100-runner]
     timeout-minutes: 240
     environment: docker-s3-upload

--- a/.github/workflows/docker-rocm.yaml
+++ b/.github/workflows/docker-rocm.yaml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   build-push-docker:
-    if: ${{ github.repository_owner == 'pytorch-labs' }}
+    if: ${{ github.repository_owner == 'meta-pytorch' }}
     runs-on: 32-core-ubuntu
     environment: docker-s3-upload
     steps:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -25,7 +25,7 @@ env:
 
 jobs:
   build-push-docker:
-    if: ${{ github.repository_owner == 'pytorch-labs' }}
+    if: ${{ github.repository_owner == 'meta-pytorch' }}
     runs-on: 32-core-ubuntu
     environment: docker-s3-upload
     steps:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The benchmark suite should be self-contained of its dependencies. To install, fo
 Step 1: clone the repository and checkout all submodules
 
 ```
-$ git clone https://github.com/pytorch-labs/tritonbench.git
+$ git clone https://github.com/meta-pytorch/tritonbench.git
 $ git submodule update --init --recursive
 ```
 

--- a/docker/infra/values.yaml
+++ b/docker/infra/values.yaml
@@ -1,6 +1,6 @@
 ## githubConfigUrl is the GitHub url for where you want to configure runners
 ## ex: https://github.com/myorg/myrepo or https://github.com/myorg
-githubConfigUrl: "https://github.com/pytorch-labs/tritonbench"
+githubConfigUrl: "https://github.com/meta-pytorch/tritonbench"
 
 ## githubConfigSecret is the k8s secrets to use when auth with GitHub API.
 ## You can choose to use GitHub App or a PAT token

--- a/docker/tritonbench-nightly.dockerfile
+++ b/docker/tritonbench-nightly.dockerfile
@@ -28,7 +28,7 @@ RUN sudo mkdir -p /workspace; sudo chown runner:runner /workspace
 # We assume that the host NVIDIA driver binaries and libraries are mapped to the docker filesystem
 # Install CUDA 12.8 build toolchains
 RUN cd /workspace; mkdir -p pytorch-ci; cd pytorch-ci; wget https://raw.githubusercontent.com/pytorch/pytorch/main/.ci/docker/common/install_cuda.sh
-RUN cd /workspace/pytorch-ci; wget https://raw.githubusercontent.com/pytorch/pytorch/main/.ci/docker/common/install_cudnn.sh && \
+RUN cd /workspace/pytorch-ci; wget https://raw.githubusercontent.com/pytorch/pytorch/main/.ci/docker/common/install_cudnn.sh || true && \
     wget https://raw.githubusercontent.com/pytorch/pytorch/main/.ci/docker/common/install_nccl.sh && \
     wget https://raw.githubusercontent.com/pytorch/pytorch/main/.ci/docker/common/install_cusparselt.sh && \
     mkdir ci_commit_pins && cd ci_commit_pins && \

--- a/docker/tritonbench-nightly.dockerfile
+++ b/docker/tritonbench-nightly.dockerfile
@@ -59,7 +59,7 @@ RUN echo ". /workspace/setup_instance.sh\n" >> ${HOME}/.bashrc
 
 # Checkout TritonBench and submodules
 RUN git clone --recurse-submodules -b "${TRITONBENCH_BRANCH}" --single-branch \
-    https://github.com/pytorch-labs/tritonbench /workspace/tritonbench
+    https://github.com/meta-pytorch/tritonbench /workspace/tritonbench
 
 # Setup conda env and CUDA
 RUN cd /workspace/tritonbench && \

--- a/docker/tritonbench-rocm-nightly.dockerfile
+++ b/docker/tritonbench-rocm-nightly.dockerfile
@@ -22,7 +22,7 @@ RUN echo ". /workspace/setup_instance.sh\n" >> ${HOME}/.bashrc
 
 # Checkout TritonBench and submodules
 RUN git clone --recurse-submodules -b "${TRITONBENCH_BRANCH}" --single-branch \
-    https://github.com/pytorch-labs/tritonbench /workspace/tritonbench
+    https://github.com/meta-pytorch/tritonbench /workspace/tritonbench
 
 # Setup conda env
 RUN cd /workspace/tritonbench && \

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -29,6 +29,6 @@ Additionally, users can define customized metrics or override  in `operator.py` 
 
 Here are some examples:
 
-- [tflops](https://github.com/pytorch-labs/tritonbench/blob/70264720fbfbb13020f63d4f8ddf9389abd54841/tritonbench/operators/grouped_gemm/operator.py#L47)
-- [occupacy](https://github.com/pytorch-labs/tritonbench/blob/70264720fbfbb13020f63d4f8ddf9389abd54841/tritonbench/operators/jagged_sum/operator.py#L251)
-- [gbps](https://github.com/pytorch-labs/tritonbench/blob/70264720fbfbb13020f63d4f8ddf9389abd54841/tritonbench/operators/softmax/operator.py#L125)
+- [tflops](https://github.com/meta-pytorch/tritonbench/blob/70264720fbfbb13020f63d4f8ddf9389abd54841/tritonbench/operators/grouped_gemm/operator.py#L47)
+- [occupacy](https://github.com/meta-pytorch/tritonbench/blob/70264720fbfbb13020f63d4f8ddf9389abd54841/tritonbench/operators/jagged_sum/operator.py#L251)
+- [gbps](https://github.com/meta-pytorch/tritonbench/blob/70264720fbfbb13020f63d4f8ddf9389abd54841/tritonbench/operators/softmax/operator.py#L125)

--- a/install.py
+++ b/install.py
@@ -108,7 +108,7 @@ def install_tritonparse():
         "pip",
         "install",
         "-e",
-        "git+https://github.com/pytorch-labs/tritonparse.git#egg=tritonparse",
+        "git+https://github.com/meta-pytorch/tritonparse.git#egg=tritonparse",
         "--no-deps",
     ]
     subprocess.check_call(cmd)

--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -683,7 +683,7 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
     example_inputs: Any = None
     use_cuda_graphs: bool = False
     is_compute_bound = True
-    # reset dynamo to avoid errors like https://github.com/pytorch-labs/tritonbench/issues/90
+    # reset dynamo to avoid errors like https://github.com/meta-pytorch/tritonbench/issues/90
     reset_dynamo = False
 
     """

--- a/tritonbench/utils/tritonparse_utils.py
+++ b/tritonbench/utils/tritonparse_utils.py
@@ -1,7 +1,7 @@
 """
 This module provides utility functions for integrating with TritonParse.
 TritonParse is a tool for tracing, visualizing, and analyzing Triton kernels.
-For more details, see: https://github.com/pytorch-labs/tritonparse
+For more details, see: https://github.com/meta-pytorch/tritonparse
 """
 
 import importlib.util
@@ -12,7 +12,7 @@ def tritonparse_init(tritonparse_log_path):
 
     This function sets up the logging hook to capture Triton compilation
     and launch events. For more details, see:
-    https://github.com/pytorch-labs/tritonparse
+    https://github.com/meta-pytorch/tritonparse
 
     Args:
         tritonparse_log_path (str or None): The path to the directory where
@@ -44,7 +44,7 @@ def tritonparse_parse(tritonparse_log_path):
 
     This function processes the raw logs generated during the run and
     creates unified, structured trace files. For more details, see:
-    https://github.com/pytorch-labs/tritonparse
+    https://github.com/meta-pytorch/tritonparse
 
     Args:
         tritonparse_log_path (str or None): The path to the directory containing


### PR DESCRIPTION
tritonbench was moved from pytorch-labs/tritonbench to meta-pytorch/tritonbench. This should allow CI to run.