### PR TITLE
Fixing naming convention of gemms

### DIFF
--- a/tritonbench/operators/gemm/operator.py
+++ b/tritonbench/operators/gemm/operator.py
@@ -322,7 +322,7 @@ class Operator(BenchmarkOperator):
         return lambda: compiled(a, b)
 
     @register_benchmark(enabled=not is_cuda())
-    def streamk_matmul(self, a, b, bias) -> Callable:
+    def streamk_matmul_amd(self, a, b, bias) -> Callable:
         return (
             lambda: streamk_amd_matmul(a, b, bias) if bias else streamk_amd_matmul(a, b)
         )


### PR DESCRIPTION
Summary: amd and nvidia have the same function name for the gemm kernels they have. Renaming to fix

Reviewed By: nmacchioni, karthik-man

Differential Revision: D80640938


