### PR TITLE
[rope][inductor] Always reset dynamo

### DIFF
--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -684,7 +684,7 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
     use_cuda_graphs: bool = False
     is_compute_bound = True
     # reset dynamo to avoid errors like https://github.com/meta-pytorch/tritonbench/issues/90
-    reset_dynamo = False
+    reset_dynamo = True
 
     """
     A base class for adding operators to torch benchmark.


### PR DESCRIPTION
By default, when running with multiple shapes, dynamo/inductor will always use the autotune result of the first shape across ALL shapes, which will give bad perf on the subsequent shapes of the same kernel.

We had the `reset_dynamo` option to let dynamo always tune on each shape, but it was not always on, causing user confusion. This PR will set it by default.

Fixes https://github.com/meta-pytorch/tritonbench/issues/346