### PR TITLE
[DO NOT LAND] Try always enabling cuda graph

### DIFF
--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -693,7 +693,7 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
     _input_iter: Optional[Generator] = None
     extra_args: List[str] = []
     example_inputs: Any = None
-    use_cuda_graphs: bool = False
+    use_cuda_graphs: bool = True
     is_compute_bound = True
     # reset dynamo to avoid errors like https://github.com/meta-pytorch/tritonbench/issues/90
     reset_dynamo = True


### PR DESCRIPTION
Several operators will fail on cudagraph - let's see which operators are blockers towards enabling cudagraph as the default.