### PR TITLE
[EZ] Replace `pytorch-labs` with `meta-pytorch`

### DIFF
--- a/tritonbench/operators/int4_gemm/int4_gemm.py
+++ b/tritonbench/operators/int4_gemm/int4_gemm.py
@@ -1,6 +1,6 @@
 """
 Compute a bf16 (activation) x int4 (weight) gemm.
-Inspired by [gpt-fast](https://github.com/pytorch-labs/gpt-fast)
+Inspired by [gpt-fast](https://github.com/meta-pytorch/gpt-fast)
 ATen kernels from tinygemm
 Triton implementation by @jlebar: https://gist.github.com/jlebar/3435b2c00deea53258887ce37231e5e2
 """


### PR DESCRIPTION
This PR replaces all instances of `pytorch-labs` with `meta-pytorch` in this repository now that the `pytorch-labs` org has been renamed to `meta-pytorch`

## Changes Made
- Replaced all occurrences of `pytorch-labs` with `meta-pytorch`
- Skipped binary files and files larger than 1MB due to GitHub api payload limits in the script to cover all repos in this org. Will do a more manual second pass later to cover any larger files

## Files Modified
This PR updates files that contained the target text.

Generated by automated script on 2025-08-22T23:26:50.180453+00:00Z