### PR TITLE
Improve TritonParse Log Organization and Force Overwrite

### DIFF
--- a/tritonbench/utils/tritonparse_utils.py
+++ b/tritonbench/utils/tritonparse_utils.py
@@ -11,14 +11,9 @@ def tritonparse_init(tritonparse_log_path):
     """Initializes TritonParse structured logging.
 
         This function sets up the logging hook to capture Triton compilation
-    <<<<<<< HEAD
-        and launch events. For more details, see:
-        https://github.com/meta-pytorch/tritonparse
-    =======
         and launch events. The logs will be stored in a 'raw_logs' subdirectory
         within the specified path. For more details, see:
         https://github.com/pytorch-labs/tritonparse
-    >>>>>>> bbb70b4 (# PR Summary: Improve TritonParse Log Organization)
 
         Args:
             tritonparse_log_path (str or None): The path to the directory where

--- a/tritonbench/utils/tritonparse_utils.py
+++ b/tritonbench/utils/tritonparse_utils.py
@@ -56,6 +56,6 @@ def tritonparse_parse(tritonparse_log_path):
         try:
             from tritonparse.utils import unified_parse
 
-            unified_parse(tritonparse_log_path)
+            unified_parse(tritonparse_log_path, overwrite=True)
         except Exception as e:
             print(f"Warning: Failed to parse tritonparse log: {e}")

--- a/tritonbench/utils/tritonparse_utils.py
+++ b/tritonbench/utils/tritonparse_utils.py
@@ -10,14 +10,21 @@ import importlib.util
 def tritonparse_init(tritonparse_log_path):
     """Initializes TritonParse structured logging.
 
-    This function sets up the logging hook to capture Triton compilation
-    and launch events. For more details, see:
-    https://github.com/meta-pytorch/tritonparse
+        This function sets up the logging hook to capture Triton compilation
+    <<<<<<< HEAD
+        and launch events. For more details, see:
+        https://github.com/meta-pytorch/tritonparse
+    =======
+        and launch events. The logs will be stored in a 'raw_logs' subdirectory
+        within the specified path. For more details, see:
+        https://github.com/pytorch-labs/tritonparse
+    >>>>>>> bbb70b4 (# PR Summary: Improve TritonParse Log Organization)
 
-    Args:
-        tritonparse_log_path (str or None): The path to the directory where
-            TritonParse logs should be stored. If None, this function
-            does nothing.
+        Args:
+            tritonparse_log_path (str or None): The path to the directory where
+                TritonParse logs should be stored. Raw logs will be saved in
+                {tritonparse_log_path}/raw_logs/. If None, this function
+                does nothing.
     """
     if tritonparse_log_path is not None:
         # capture errors but don't fail the entire script
@@ -30,7 +37,7 @@ def tritonparse_init(tritonparse_log_path):
             import tritonparse.structured_logging
 
             tritonparse.structured_logging.init(
-                tritonparse_log_path, enable_trace_launch=True
+                f"{tritonparse_log_path}/raw_logs", enable_trace_launch=True
             )
             print(
                 f"TritonParse structured logging initialized with log path: {tritonparse_log_path}"
@@ -42,13 +49,16 @@ def tritonparse_init(tritonparse_log_path):
 def tritonparse_parse(tritonparse_log_path):
     """Parses the generated TritonParse logs.
 
-    This function processes the raw logs generated during the run and
-    creates unified, structured trace files. For more details, see:
-    https://github.com/meta-pytorch/tritonparse
+    This function processes the raw logs from the 'raw_logs' subdirectory
+    and creates unified, structured trace files in the 'parsed_logs'
+    subdirectory. For more details, see:
+    https://github.com/pytorch-labs/tritonparse
 
     Args:
-        tritonparse_log_path (str or None): The path to the directory containing
-            the TritonParse logs to be parsed. If None, this function
+        tritonparse_log_path (str or None): The base path to the directory
+            containing TritonParse logs. Raw logs will be read from
+            {tritonparse_log_path}/raw_logs/ and parsed logs will be saved to
+            {tritonparse_log_path}/parsed_logs/. If None, this function
             does nothing.
     """
     if tritonparse_log_path is not None:
@@ -56,6 +66,10 @@ def tritonparse_parse(tritonparse_log_path):
         try:
             from tritonparse.utils import unified_parse
 
-            unified_parse(tritonparse_log_path, overwrite=True)
+            unified_parse(
+                f"{tritonparse_log_path}/raw_logs",
+                f"{tritonparse_log_path}/parsed_logs",
+                overwrite=True,
+            )
         except Exception as e:
             print(f"Warning: Failed to parse tritonparse log: {e}")

--- a/tritonbench/utils/tritonparse_utils.py
+++ b/tritonbench/utils/tritonparse_utils.py
@@ -8,18 +8,19 @@ import importlib.util
 
 
 def tritonparse_init(tritonparse_log_path):
-    """Initializes TritonParse structured logging.
+    """
+    Initializes TritonParse structured logging.
 
-        This function sets up the logging hook to capture Triton compilation
-        and launch events. The logs will be stored in a 'raw_logs' subdirectory
-        within the specified path. For more details, see:
-        https://github.com/pytorch-labs/tritonparse
+    This function sets up the logging hook to capture Triton compilation
+    and launch events. The logs will be stored in a 'raw_logs' subdirectory
+    within the specified path. For more details, see:
+    https://github.com/pytorch-labs/tritonparse
 
-        Args:
-            tritonparse_log_path (str or None): The path to the directory where
-                TritonParse logs should be stored. Raw logs will be saved in
-                {tritonparse_log_path}/raw_logs/. If None, this function
-                does nothing.
+    Args:
+        tritonparse_log_path (str or None): The path to the directory where
+            TritonParse logs should be stored. Raw logs will be saved in
+            {tritonparse_log_path}/raw_logs/. If None, this function
+            does nothing.
     """
     if tritonparse_log_path is not None:
         # capture errors but don't fail the entire script
@@ -42,7 +43,8 @@ def tritonparse_init(tritonparse_log_path):
 
 
 def tritonparse_parse(tritonparse_log_path):
-    """Parses the generated TritonParse logs.
+    """
+    Parses the generated TritonParse logs.
 
     This function processes the raw logs from the 'raw_logs' subdirectory
     and creates unified, structured trace files in the 'parsed_logs'


### PR DESCRIPTION
This pull request introduces two key improvements to the TritonParse integration in `tritonbench`:

1.  **Improved Log Organization**: Raw Triton logs and parsed logs are now stored in separate subdirectories (`raw_logs/` and `parsed_logs/`) within the specified `tritonparse_log_path`. This keeps the output directory clean and makes it easier to distinguish between raw data and processed results.

2.  **Force Overwrite of Parsed Logs**: The parsing utility (`unified_parse`) is now configured to always overwrite existing parsed logs. Since the `overwrite` option in `tritonparse` is not exposed through `tritonbench`, this change ensures that each benchmark run generates fresh results from the latest raw logs, preventing the use of stale data.

These changes enhance the robustness and usability of the Triton parsing functionality.

## Test Plan

```bash
% python run.py --op vector_add --num-inputs 1 --tritonparse
TritonParse structured logging initialized with log path: ./tritonparse_logs/
  0%|                                                                                                                   | 0/1 [00:00<?, ?it/s]Removed 7 outliers from 150 samples
Removed 8 outliers from 227 samples
Removed 31 outliers from 242 samples
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:01<00:00,  1.98s/it]
  x_val    torch_add-latency                                              torch_add-gbps    triton_add-latency                                                  triton_add-gbps    torch_compile_add-latency                                           torch_compile_add-gbps
-------  -------------------  ----------------------------------------------------------  --------------------  ---------------------------------------------------------------  ---------------------------  ---------------------------------------------------------------
   4096    0.004832 (±5.30%)  (10.17218541785304, 9.660377182569514, 10.666666289377556)     0.266336 (±8.52%)  (0.18454884471619615, 0.17006200447843253, 0.19599335723105937)           0.235392 (±26.64%)  (0.20880913162831416, 0.16487762712128054, 0.22952778755213377)
average
tritonparse log file list: /tmp/tmpypm52ntx/log_file_list.json
INFO:tritonparse:Copying parsed logs from /tmp/tmpypm52ntx to /home/yhao/tritonbench/tritonparse_logs/parsed_logs

================================================================================
📁 TRITONPARSE PARSING RESULTS
================================================================================
📂 Parsed files directory: /home/yhao/tritonbench/tritonparse_logs/parsed_logs
📊 Total files generated: 3

📄 Generated files:
--------------------------------------------------
   1. 📝 dedicated_log_triton_trace_yhao__mapped.ndjson.gz (17.8KB)
   2. 📝 f0_fc0_a0_cai-.ndjson.gz (7.9KB)
   3. 📝 log_file_list.json (216B)
================================================================================
✅ Parsing completed successfully!
================================================================================
```
