### PR TITLE
[gdpa] Turn on on-host TMA for TLX fwd

### DIFF
--- a/tritonbench/operators/gdpa/gdpa_blackwell_tlx.py
+++ b/tritonbench/operators/gdpa/gdpa_blackwell_tlx.py
@@ -1217,8 +1217,8 @@ def gdpa_forward_tlx(
     NUM_SMS = (
         get_num_sms() or 1000000
     ) * 8  # if num sms is None, use a large number so that it is a no-op
-    print("NUM_SMS", NUM_SMS)
-    print(triton.cdiv(max_seq_len_q, 256) * BATCH * nheads)
+    # print("NUM_SMS", NUM_SMS)
+    # print(triton.cdiv(max_seq_len_q, 256) * BATCH * nheads)
 
     q = expect_contiguous(query)
     k = expect_contiguous(key)
@@ -1233,7 +1233,7 @@ def gdpa_forward_tlx(
     H = nheads
     y_dim = N_CTX_KV * Z
     x_dim = HEAD_DIM * H // G
-    USE_ON_DEVICE_TMA = True
+    USE_ON_DEVICE_TMA = False
     if not USE_ON_DEVICE_TMA:
         desc_q = TensorDescriptor(
             q,
@@ -1268,7 +1268,7 @@ def gdpa_forward_tlx(
         )
 
     activation_enum_int = activation_string_to_int(activation)
-    print(q.shape, k.shape, v.shape)
+    # print(q.shape, k.shape, v.shape)
     # print("activation_enum_int", activation, activation_enum_int)
     # print(query_offset)
     # print(key_offset)


### PR DESCRIPTION
python run.py --op gdpa --only gdpa,tlx_gdpa_fwd --sparsity 1.0 --head 4 --dim 512 --max_seq_len 1000 --batch 1152

On-host TMA:

```
         config_name    tlx_gdpa_fwd-latency
--------------------  ----------------------
long_event_self_attn       2.328640 (±0.67%)
```

On-device TMA:
```
         config_name    tlx_gdpa_fwd-latency
--------------------  ----------------------
long_event_self_attn       2.506944 (±0.40%)
```
