### PR TITLE
adding docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,16 @@
+services:
+  tritonbench:
+    image: ghcr.io/meta-pytorch/tritonbench:nightly
+    pull_policy: always
+    volumes:
+      - .:/tritonbench
+    environment:
+      - PYTHONPATH=/tritonbench
+  tritonbench-local:
+    build:
+      context: .
+      dockerfile: docker/tritonbench-nightly.dockerfile
+    volumes:
+      - .:/tritonbench
+    environment:
+      - PYTHONPATH=/tritonbench


### PR DESCRIPTION
Summary: adding docker-compose file so that we can mount volumes for easier development and sharing. 2 options built here. 1 uses the nightly build the other builds locally.

Differential Revision: D81244309


