### PR TITLE
Refactor imports to conditionally include TLX based on availability

### DIFF
--- a/tritonbench/operators/gdpa/gdpa_blackwell_tlx.py
+++ b/tritonbench/operators/gdpa/gdpa_blackwell_tlx.py
@@ -5,11 +5,15 @@ import math
 import torch
 import triton
 import triton.language as tl
-import triton.language.extra.tlx as tlx
 from triton.tools.tensor_descriptor import TensorDescriptor
+
+from tritonbench.utils import has_tlx
 
 from .gdpa_utils import get_num_sms
 from .math import activation_string_to_int
+
+if has_tlx():
+    import triton.language.extra.tlx as tlx
 
 
 def _host_descriptor_pre_hook(nargs):

--- a/tritonbench/operators/gemm/tlx_matmul.py
+++ b/tritonbench/operators/gemm/tlx_matmul.py
@@ -3,8 +3,12 @@ import torch
 
 import triton
 import triton.language as tl
-import triton.language.extra.tlx as tlx
 from triton.tools.tensor_descriptor import TensorDescriptor
+
+from tritonbench.utils import has_tlx
+
+if has_tlx():
+    import triton.language.extra.tlx as tlx
 
 
 def get_cuda_autotune_config():


### PR DESCRIPTION
- Added a utility check for TLX support before importing `triton.language.extra.tlx` in both `gdpa_blackwell_tlx.py` and `tlx_matmul.py`.
fix internal test: test_gpu_tritonbench_gdpa