### PR TITLE
Add `--latency-measure-mode=profiler` support

### DIFF
--- a/tritonbench/components/do_bench/run.py
+++ b/tritonbench/components/do_bench/run.py
@@ -9,6 +9,9 @@ from torch._inductor.runtime.benchmarking import benchmarker
 
 NS_TO_MS = 1e-6
 
+# Kernel name for L2 cache clearing - we want to exclude this from latency measurements
+CACHE_CLEAR_KERNEL = "void at::native::vectorized_elementwise_kernel<4, at::native::FillFunctor<int>, std::array<char*, 1ul> >(int, at::native::FillFunctor<int>, std::array<char*, 1ul>)"
+
 
 class Latency:
     times: List[float]
@@ -177,6 +180,9 @@ def _do_bench_profiler(fn, warmup, rep, return_mode="all", grad_to_none=None):
     Returns:
         List of measured kernel times in milliseconds (if return_mode="all") or single value.
     """
+    # Get cache for L2 cache clearing
+    cache = triton.runtime.driver.active.get_empty_cache_for_benchmark()
+
     # First, estimate the runtime to calculate iterations
     estimate_ms = benchmarker.benchmark_gpu(fn, estimation_iters=5, benchmark_iters=10)
 
@@ -195,6 +201,7 @@ def _do_bench_profiler(fn, warmup, rep, return_mode="all", grad_to_none=None):
         if grad_to_none is not None:
             for x in grad_to_none:
                 x.grad = None
+        cache.zero_()
         fn()
     torch.cuda.synchronize()
 
@@ -216,6 +223,7 @@ def _do_bench_profiler(fn, warmup, rep, return_mode="all", grad_to_none=None):
             profile_memory=False,
             with_stack=False,
         ) as prof:
+            cache.zero_()
             fn()
             torch.cuda.synchronize()
 
@@ -227,9 +235,11 @@ def _do_bench_profiler(fn, warmup, rep, return_mode="all", grad_to_none=None):
 
         # Get raw function events and collect time intervals
         for evt in prof.events():
-            # Check for CUDA kernel events
-            if evt.device_type == torch.autograd.DeviceType.CUDA and hasattr(
-                evt, "time_range"
+            # Check for CUDA kernel events, excluding cache clear kernel
+            if (
+                evt.device_type == torch.autograd.DeviceType.CUDA
+                and hasattr(evt, "time_range")
+                and evt.name != CACHE_CLEAR_KERNEL
             ):
                 # time_range has start and end attributes in microseconds
                 start_us = evt.time_range.start

--- a/tritonbench/utils/parser.py
+++ b/tritonbench/utils/parser.py
@@ -189,8 +189,8 @@ def get_parser(args=None):
     parser.add_argument(
         "--latency-measure-mode",
         default="triton_do_bench",
-        choices=["triton_do_bench", "inductor_benchmarker"],
-        help="Method to measure latency: triton_do_bench (default) or inductor_benchmarker.",
+        choices=["triton_do_bench", "inductor_benchmarker", "profiler"],
+        help="Method to measure latency: triton_do_bench (default), inductor_benchmarker, profiler.",
     )
     parser.add_argument(
         "--isolate",

--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -744,6 +744,13 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
             if tb_args.metrics
             else self.DEFAULT_METRICS
         )
+        # Add deprecation warning for cuda_time metric
+        if "cuda_time" in self.required_metrics:
+            print(
+                "\033[93mWARNING: The 'cuda_time' metric is deprecated and will be removed in a future release. "
+                "Please use '--metrics=latency --latency-measure-mode=profiler' instead, which provides the same "
+                "functionality with L2 cache handling and kernel time measurement.\033[0m"
+            )
         if "compile_time" in self.required_metrics and is_fbcode():
             self.required_metrics.append("compile_time_by_stage")
         self.extra_args = extra_args


### PR DESCRIPTION
Having a latency measurement method that only measures GPU kernel runtime is important. I believe existing options such as Triton `do_bench` or inductor benchmarker still includes CPU overhead in the measurement, and `--cudagraph` doesn't work for all kernels. Using profiler to measure GPU kernel runtime is a good middle ground that gives us relatively reliable timing measurement.

Triton `do_bench` (includes CPU overhead):
```
      (M, N)    torch_layer_norm-latency    triton_layer_norm-latency    torch_compile_layer_norm-latency    liger_layer_norm-latency    helion_layer_norm_fwd-latency
------------  --------------------------  ---------------------------  ----------------------------------  --------------------------  -------------------------------
(4096, 1024)           0.023936 (±2.27%)            0.021888 (±6.87%)                   0.020288 (±7.73%)           0.020960 (±7.02%)                0.020064 (±4.63%)
```

`--cudagraph` (i.e. ground truth GPU kernel execution time):
```
      (M, N)    torch_layer_norm-latency    triton_layer_norm-latency    torch_compile_layer_norm-latency    liger_layer_norm-latency    helion_layer_norm_fwd-latency
------------  --------------------------  ---------------------------  ----------------------------------  --------------------------  -------------------------------
(4096, 1024)           0.014104 (±0.13%)            0.008505 (±0.12%)                   0.007519 (±0.08%)           0.006929 (±0.09%)                0.006659 (±0.06%)
```

Profiler (i.e. this PR):
```
      (M, N)    torch_layer_norm-latency    triton_layer_norm-latency    torch_compile_layer_norm-latency    liger_layer_norm-latency    quack_layer_norm-latency
------------  --------------------------  ---------------------------  ----------------------------------  --------------------------  --------------------------
(4096, 1024)           0.014304 (±1.36%)            0.008640 (±2.97%)                   0.007584 (±1.67%)           0.007168 (±3.57%)           0.008192 (±3.13%)
```

As seen above, the profiler approach is much closer to cudagraph (i.e. ground truth) wrt. measured GPU kernel execution time.