### PR TITLE
Rename `inductor_` prefix to `torch_compile_`; improve torch.compile config

### DIFF
--- a/tritonbench/operators/cross_entropy/operator.py
+++ b/tritonbench/operators/cross_entropy/operator.py
@@ -68,7 +68,7 @@ class Operator(BenchmarkOperator):
         return lambda: self.liger_model(input, target)
 
     @register_benchmark()
-    def inductor_cross_entropy_loss(self, input, target) -> Callable:
+    def torch_compile_cross_entropy_loss(self, input, target) -> Callable:
         compiled = torch.compile(
             self.baseline_model, dynamic=False, mode="max-autotune-no-cudagraphs"
         )

--- a/tritonbench/operators/embedding/operator.py
+++ b/tritonbench/operators/embedding/operator.py
@@ -50,7 +50,7 @@ class Operator(BenchmarkOperator):
         return lambda: self.liger_op(input)
 
     @register_benchmark()
-    def inductor_embedding(self, V, D, input, shared_weight) -> Callable:
+    def torch_compile_embedding(self, V, D, input, shared_weight) -> Callable:
         self.baseline_op = Embedding(V, D).to(self.device).to(self.dtype)
         self.baseline_op.weight.data.copy_(shared_weight)
         compiled = torch.compile(self.baseline_op, mode="max-autotune-no-cudagraphs")

--- a/tritonbench/operators/fused_linear_cross_entropy/operator.py
+++ b/tritonbench/operators/fused_linear_cross_entropy/operator.py
@@ -99,8 +99,10 @@ class Operator(BenchmarkOperator):
         return lambda: self.liger_model(input, weight, target)
 
     @register_benchmark()
-    def inductor_fused_linear_cross_entropy(self, input, weight, target) -> Callable:
-        compiled = torch.compile(self.baseline_model)
+    def torch_compile_fused_linear_cross_entropy(
+        self, input, weight, target
+    ) -> Callable:
+        compiled = torch.compile(self.baseline_model, mode="max-autotune-no-cudagraphs")
         return lambda: compiled(input, weight, target)
 
     @register_x_val(label="(B*T, H)")

--- a/tritonbench/operators/fused_linear_jsd/operator.py
+++ b/tritonbench/operators/fused_linear_jsd/operator.py
@@ -163,8 +163,8 @@ class Operator(BenchmarkOperator):
         return lambda: self.liger_op(student_input, teacher_input)
 
     @register_benchmark()
-    def inductor_lm_head_jsd(self, student_input, teacher_input) -> Callable:
-        compiled = torch.compile(self.baseline_op)
+    def torch_compile_lm_head_jsd(self, student_input, teacher_input) -> Callable:
+        compiled = torch.compile(self.baseline_op, mode="max-autotune-no-cudagraphs")
         return lambda: compiled(student_input, teacher_input)
 
     @register_x_val(label="(B*T, H)")

--- a/tritonbench/operators/geglu/operator.py
+++ b/tritonbench/operators/geglu/operator.py
@@ -59,7 +59,7 @@ class Operator(BenchmarkOperator):
         return lambda: self.liger_model(input)
 
     @register_benchmark()
-    def inductor_geglu(self, input) -> Callable:
+    def torch_compile_geglu(self, input) -> Callable:
         # TODO: remove this once we have a better way to handle backward benchmarking
         # We need to run backward multiple times for proper benchmarking
         # so donated buffer have to be disabled
@@ -68,7 +68,7 @@ class Operator(BenchmarkOperator):
 
             functorch_config.donated_buffer = False
 
-        compiled = torch.compile(self.baseline_model)
+        compiled = torch.compile(self.baseline_model, mode="max-autotune-no-cudagraphs")
         return lambda: compiled(input)
 
     @register_x_val(label="(B, T, H)")

--- a/tritonbench/operators/jsd/operator.py
+++ b/tritonbench/operators/jsd/operator.py
@@ -85,8 +85,8 @@ class Operator(BenchmarkOperator):
         return lambda: self.liger_op(_input, target)
 
     @register_benchmark()
-    def inductor_jsd(self, _input, target) -> Callable:
-        compiled = torch.compile(self.baseline_op)
+    def torch_compile_jsd(self, _input, target) -> Callable:
+        compiled = torch.compile(self.baseline_op, mode="max-autotune-no-cudagraphs")
         return lambda: compiled(_input, target)
 
     @register_x_val(label="(B, T, V)")

--- a/tritonbench/operators/kl_div/operator.py
+++ b/tritonbench/operators/kl_div/operator.py
@@ -45,8 +45,8 @@ class Operator(BenchmarkOperator):
         return lambda: self.liger_op(input, target)
 
     @register_benchmark()
-    def inductor_kl_div(self, input, target) -> Callable:
-        compiled = torch.compile(self.baseline_op)
+    def torch_compile_kl_div(self, input, target) -> Callable:
+        compiled = torch.compile(self.baseline_op, mode="max-autotune-no-cudagraphs")
         return lambda: compiled(input, target)
 
     @register_x_val(label="(B, T, V)")

--- a/tritonbench/operators/rms_norm/operator.py
+++ b/tritonbench/operators/rms_norm/operator.py
@@ -107,7 +107,7 @@ class Operator(BenchmarkOperator):
         return lambda: self.quack_rms_op(input)
 
     @register_benchmark()
-    def inductor_rms(self, H, input) -> Callable:
+    def torch_compile_rms(self, H, input) -> Callable:
         if self.llama_rms_op is None:
             self.llama_rms_op = LlamaRMSNorm(hidden_size=H, eps=self.eps).to(
                 self.device

--- a/tritonbench/operators/swiglu/operator.py
+++ b/tritonbench/operators/swiglu/operator.py
@@ -59,7 +59,7 @@ class Operator(BenchmarkOperator):
         return lambda: self.liger_op(input)
 
     @register_benchmark()
-    def inductor_swiglu(self, input) -> Callable:
+    def torch_compile_swiglu(self, input) -> Callable:
         # TODO: remove this once we have a better way to handle backward benchmarking
         # We need to run backward multiple times for proper benchmarking
         # so donated buffer have to be disabled
@@ -68,7 +68,7 @@ class Operator(BenchmarkOperator):
 
             functorch_config.donated_buffer = False
 
-        compiled = torch.compile(self.baseline_op)
+        compiled = torch.compile(self.baseline_op, mode="max-autotune-no-cudagraphs")
         return lambda: compiled(input)
 
     @register_x_val(label="(B, T, H)")


### PR DESCRIPTION
As titled. Unifying the prefix to `torch_compile_` makes it easier for Helion perf CI to filter the results by backend.