### PR TITLE
Profiler mode: Add ProfilerActivity.CPU to tracked activities

### DIFF
--- a/tritonbench/components/do_bench/run.py
+++ b/tritonbench/components/do_bench/run.py
@@ -227,7 +227,10 @@ def _do_bench_profiler(
     # Benchmark phase - collect kernel times for each iteration
     all_kernel_times = []
     profiler_config = {
-        "activities": [torch.autograd.ProfilerActivity.CUDA],
+        "activities": [
+            torch.profiler.ProfilerActivity.CPU,
+            torch.profiler.ProfilerActivity.CUDA,
+        ],
         "record_shapes": False,
         "profile_memory": False,
         "with_stack": False,


### PR DESCRIPTION
When using profiler for latency measurement, I've been seeing cases where no CUDA kernel events were found in the profiler trace. I am still trying to root-cause this, but want to make the change in the PR as a defensive fix in case we are hitting some corner case when CPU activity not being recorded is causing a CUDA kernel event recording problem.