### PR TITLE
Link to fbsource

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,12 @@
-# Contributing to Meta Open Source Projects
-
+# Contributing to Kraken
 We want to make contributing to this project as easy and transparent as
 possible.
 
+## Our Development Process
+TBD
+
 ## Pull Requests
 We actively welcome your pull requests.
-
-Note: pull requests are not imported into the GitHub directory in the usual way. There is an internal Meta repository that is the "source of truth" for the project. The GitHub repository is generated *from* the internal Meta repository. So we don't merge GitHub PRs directly to the GitHub repository -- they must first be imported into internal Meta repository. When Meta employees look at the GitHub PR, there is a special button visible only to them that executes that import. The changes are then automatically reflected from the internal Meta repository back to GitHub. This is why you won't see your PR having being directly merged, but you still see your changes in the repository once it reflects the imported changes.
 
 1. Fork the repo and create your branch from `main`.
 2. If you've added code that should be tested, add tests.
@@ -25,10 +25,22 @@ Complete your CLA here: <https://code.facebook.com/cla>
 We use GitHub issues to track public bugs. Please ensure your description is
 clear and has sufficient instructions to be able to reproduce the issue.
 
-Meta has a [bounty program](https://www.facebook.com/whitehat/) for the safe
+Meta has a [bounty program](https://bugbounty.meta.com/) for the safe
 disclosure of security bugs. In those cases, please go through the process
 outlined on that page and do not file a public issue.
 
+## Coding Style
+`ruff==0.11.9`
+To Install ruff:
+```python
+pip install ruff==0.11.9
+```
+To run lint:
+```shell
+$ ruff format
+$ ruff check --fix
+```
+
 ## License
-By contributing to this project, you agree that your contributions will be licensed
+By contributing to Kraken, you agree that your contributions will be licensed
 under the LICENSE file in the root directory of this source tree.


### PR DESCRIPTION
Summary:
This is an automatically generated diff to link meta-pytorch/kraken to fbsource.

<< DO NOT EDIT BELOW THIS LINE >>
diff-train-skip-merge
diff-train-source-id: d1b625a70d40b36020f69cda40f7bc9327784e07

Generated by: https://www.internalfb.com/intern/sandcastle/job/4503601754641067/

GitHub Repo: meta-pytorch/kraken

Reviewed By: YUNQIUGUO, fegin

Differential Revision: D81714673


