### PR TITLE
Update Blackwell attention Triton Bench

### DIFF
--- a/tritonbench/operators/blackwell_attentions/generate_inputs.py
+++ b/tritonbench/operators/blackwell_attentions/generate_inputs.py
@@ -76,5 +76,5 @@ def fa3_paper_inputs(dtype, device) -> Generator:
     for BATCH in [32, 16, 8, 4, 2, 1]:
         N_CTX = 16384 // BATCH
         yield _generated_qkv_inputs(
-            shape=(BATCH, H, N_CTX, N_CTX, D_HEAD), dtype=dtype, device=device
+            shape=(BATCH, H, H, N_CTX, N_CTX, D_HEAD), dtype=dtype, device=device
         )


### PR DESCRIPTION
Summary:
Update Blackwell attention Triton Bench

- Ensure that FAv4 runs
- Fix Cudnn attention to run only when it's available
- Benchmark Cutlass Blackwell instead of the old Cutlass in xformers
- Make sure that Cutlass inputs are contiguous for fair comparison
- Fix FAv3 input generation

Reviewed By: henrylhtsang

Differential Revision: D82043292


