### PR TITLE
Verify experimental_descriptor in Triton version

### DIFF
--- a/tritonbench/operators/fp8_gemm/fp8_gemm.py
+++ b/tritonbench/operators/fp8_gemm/fp8_gemm.py
@@ -15,6 +15,8 @@ from tritonbench.utils.triton_op import (
     register_metric,
 )
 
+from tritonbench.utils.triton_utils import has_experimental_descriptor
+
 from .tutorial import matmul as tutorial_matmul
 
 logger = logging.getLogger(__name__)
@@ -175,7 +177,7 @@ class Operator(BenchmarkOperator):
     def triton_persistent_fp8_gemm(self, a, b, scale_a, scale_b):
         return lambda: matmul_persistent(a, b)
 
-    @register_benchmark(enabled=HAS_TMA)
+    @register_benchmark(enabled=HAS_TMA and has_experimental_descriptor())
     def triton_tma_persistent_fp8_gemm(self, a, b, scale_a, scale_b):
         b = b.T.contiguous()
         c, desc_a, desc_b, desc_c = allocate_matmul_tma(a, b)

--- a/tritonbench/utils/triton_utils.py
+++ b/tritonbench/utils/triton_utils.py
@@ -49,3 +49,9 @@ def has_tlx():
     tlx_module = "triton.language.extra.tlx"
     spec = importlib.util.find_spec(tlx_module)
     return spec is not None
+
+
+def has_experimental_descriptor():
+    import triton.language as tl
+
+    return hasattr(getattr(tl, "tools", None), "experimental_descriptor")


### PR DESCRIPTION
Summary: Add utils function which verifies that `triton.tools.experimental_descriptor` is available in the current Triton version. This diff expands the work in this [GitHub PR](https://github.com/pytorch/pytorch/pull/155723), which finds that Triton 3.4.0+ deprecated the experimental descriptor.

Differential Revision: D82551608


