### PR TITLE
Add a Blackwell-specific scaled persistent + TMA template for GEMMs

### DIFF
--- a/tritonbench/operators/fp8_gemm/fp8_gemm.py
+++ b/tritonbench/operators/fp8_gemm/fp8_gemm.py
@@ -198,7 +198,12 @@ class Operator(BenchmarkOperator):
                 autotune_fallback_to_aten=False,
             ):
                 f = lambda a, b: torch._scaled_mm(
-                    a, b, scale_a, scale_b, use_fast_accum=True, out_dtype=self._get_dtype()
+                    a, 
+                    b, 
+                    scale_a, 
+                    scale_b, 
+                    use_fast_accum=True, 
+                    out_dtype=self._get_dtype()
                 )
                 compiled = torch.compile(f, dynamic=False)
                 compiled(a, b)


### PR DESCRIPTION
Summary:
Add a Blackwell-specific scaled persistent + TMA Triton template to Inductor. This diff builds on D82515450 by adding a new set of mixins which inherit the scaling epilogue and add scaled persistent + TMA kwargs to the template.

This diff also adds a benchmark for the scaled Blackwell persistent + TMA template to TritonBench `fp8_gemm`.

Note that this diff is a minimal extension to the above diff; rather than adding a new kernel for the scaled version, we opted to simply extend the epilogue to account for scaling. This template is accurate for per-tensor and per-row scaling but may require modifications for other scaling modes, such as deepseek-style scaling, which apply scaling prior to the GEMM computation.

In addition, note that epilogue subtiling is currently unsupported for both the scaled and non-scaled Blackwell templates, and functionality will be added in a subsequent diff.

Differential Revision: D82597111


