### PR TITLE
[Fix] gather_gemv small fix

### DIFF
--- a/tritonbench/operators/gather_gemv/operator.py
+++ b/tritonbench/operators/gather_gemv/operator.py
@@ -42,7 +42,7 @@ class Operator(BenchmarkOperator):
     def test_0(self, p1, p2, p3) -> Callable:
         return lambda: triton_test_0(p1, p2, p3)
 
-    @register_benchmark(baseline=True)
+    @register_benchmark()
     def test_eager(self, w, idx, x):
         return lambda: w[idx].to(x.dtype) @ x
 

--- a/tritonbench/operators/gather_gemv/operator.py
+++ b/tritonbench/operators/gather_gemv/operator.py
@@ -38,11 +38,11 @@ class Operator(BenchmarkOperator):
     ):
         super().__init__(tb_args, extra_args)
 
-    @register_benchmark(baseline=True)
+    @register_benchmark()
     def test_0(self, p1, p2, p3) -> Callable:
         return lambda: triton_test_0(p1, p2, p3)
 
-    @register_benchmark()
+    @register_benchmark(baseline=True)
     def test_eager(self, w, idx, x):
         return lambda: w[idx].to(x.dtype) @ x
 

--- a/tritonbench/operators/gather_gemv/triton_gather_gemv.py
+++ b/tritonbench/operators/gather_gemv/triton_gather_gemv.py
@@ -126,4 +126,4 @@ def triton_gemv_0(arg0_1, arg1_1, arg2_1):
 
         grid = lambda META: (triton.cdiv(2 * S, META["XBLOCK"]),)
         triton_red_fused_mv_0[grid](arg1_1, arg0_1, arg2_1, buf1, xnumel, rnumel)
-    return (reinterpret_tensor(buf1, (2, S), (S, 1), 0),)
+    return reinterpret_tensor(buf1, (2, S), (S, 1), 0)


### PR DESCRIPTION
- keep only one baseline=True for the Triton kernel
- fix the return type for result comparison

Thanks so much for suggested fix by @yf225 