### PR TITLE
[ab test] fix triton repo location

### DIFF
--- a/tritonbench/utils/scuba_utils.py
+++ b/tritonbench/utils/scuba_utils.py
@@ -136,7 +136,7 @@ def decorate_benchmark_data(
 
     repo_locs = {
         "tritonbench": REPO_PATH,
-        "triton": os.environ.get("TRITONBENCH_TRITON_REPO", "unknown"),
+        "triton": os.environ.get("TRITONBENCH_TRITON_INSTALL_DIR", "unknown"),
         "pytorch": os.environ.get("TRITONBENCH_PYTORCH_REPO_PATH", "unknown"),
     }
     aggregated_obj = {


### PR DESCRIPTION
This was previously using TRITONBENCH_TRITON_REPO, which is the name of the repo (e.g. triton-lang/triton) instead of the install dir (e.g. /workspace/triton-main)

Test: https://github.com/meta-pytorch/tritonbench/actions/runs/17844515179