### PR TITLE
Add `--exit-on-exception` to exit process on any exception

### DIFF
--- a/tritonbench/utils/parser.py
+++ b/tritonbench/utils/parser.py
@@ -155,6 +155,12 @@ def get_parser(args=None):
         action="store_true",
     )
     parser.add_argument(
+        "--exit-on-exception",
+        action="store_true",
+        default=False,
+        help="Immediately terminate the process if any operator run raises an exception.",
+    )
+    parser.add_argument(
         "--input-id",
         type=int,
         default=0,

--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -994,6 +994,8 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
                 "Caught exception, terminating early with partial results",
                 exc_info=True,
             )
+            if self.tb_args.exit_on_exception:
+                os._exit(1)
             raise
         finally:
             self.output = BenchmarkOperatorResult(


### PR DESCRIPTION
Currently if an operator run throws an exception, it will print something like:
```
  0%|          | 0/6 [02:11<?, ?it/s]
Caught exception, terminating early with partial results
Traceback (most recent call last):
...

 17%|█▋        | 1/6 [00:14<01:11, 14.21s/it]
```
i.e. it prints the exception trace and then moves on to the next input shape.

(Example job: https://github.com/pytorch/helion/actions/runs/17875899712/job/50837215746 "Run Benchmark" section)

However, during development, we want to have a "debug mode" that, upon exception, immediately terminates the process and returns non-zero exit code, so that the exception can actually cause the benchmark CI job to fail with red and developer can take proper notice. This PR tries to add this mode with `--exit-on-exception` flag.

If desired, I can also prepend this with `debug` (like `--debug-exit-on-exception`) to make its purpose more clear.