### PR TITLE
[backends] add mojo matmul

### DIFF
--- a/benchmarks/mojo_matmul/requirements.txt
+++ b/benchmarks/mojo_matmul/requirements.txt
@@ -1,1 +1,0 @@
-modular

--- a/benchmarks/mojo_matmul/requirements.txt
+++ b/benchmarks/mojo_matmul/requirements.txt
@@ -1,0 +1,1 @@
+modular

--- a/benchmarks/mojo_matmul/run.py
+++ b/benchmarks/mojo_matmul/run.py
@@ -1,0 +1,120 @@
+import argparse
+import json
+import logging
+import os
+import sys
+
+from os.path import abspath, exists
+from typing import Dict, List
+
+
+def setup_tritonbench_cwd():
+    original_dir = abspath(os.getcwd())
+
+    for tritonbench_dir in (
+        ".",
+        "../../../tritonbench",
+    ):
+        if exists(tritonbench_dir):
+            break
+
+    if exists(tritonbench_dir):
+        tritonbench_dir = abspath(tritonbench_dir)
+        os.chdir(tritonbench_dir)
+        sys.path.append(tritonbench_dir)
+    return original_dir
+
+setup_tritonbench_cwd()
+
+import torch
+import max.graph as mg
+
+from max import engine
+from max.graph import TensorValue, ops, DType, DeviceRef, TensorType, Graph
+from max.graph.type import Shape, ShapeLike
+from max.driver import CPU, Tensor, Accelerator
+
+
+def matmul_graph(
+    name: str,
+    shapes: tuple[ShapeLike, ShapeLike],
+    dtype: DType = DType.float32,
+) -> Graph:
+    """Creates a graph op containing a matmul."""
+
+    def tensor_type(dims: ShapeLike) -> TensorType:
+        return TensorType(dtype, Shape(dims), device=DeviceRef.CPU())
+
+    return Graph(
+        name,
+        lambda a, b: ops.matmul(a, b),
+        (tensor_type(shapes[0]), tensor_type(shapes[1])),
+    )
+
+
+
+def promote_mojo_tensor_to_fp32(mojo_tensor, dtype, device):
+    input_type = TensorType(dtype=dtype, shape=mojo_tensor.shape, device=device)
+    with mg.Graph("mojo_to_fp32", input_types=(input_type, )) as g:
+        (inp, ) = g.inputs
+        out = ops.cast(inp, dtype=DType.float32)
+        g.output(out)
+    session = engine.InferenceSession(devices=[CPU()])
+    model = session.load(g)
+    output = model.execute(mojo_tensor)
+    return output
+
+def demote_numpy_to_mojo_tensor_bf16(numpy_array, dtype):
+    with mg.Graph("mojo_to_bf16") as g:
+        inp = ops.constant(numpy_array, dtype=DType.float32, device=DeviceRef.GPU())
+        out = ops.cast(inp, dtype=DType.bfloat16)
+        g.output(out)
+    session = engine.InferenceSession(devices=[GPU()])
+    model = session.load(g)
+    output = model.execute()
+    return output[0]
+
+MOJO_DTYPE_MAPPING = {
+    "bf16": DType.bfloat16,
+    "fp32": DType.float32,
+    "fp16": DType.float16,
+}
+MOJO_DEVICE_MAPPING = {
+    "cuda": DeviceRef.GPU,
+    "cpu": DeviceRef.CPU,
+}
+
+def mojo_matmul(precision, device, a, b):
+    mojo_dtype = MOJO_DTYPE_MAPPING[precision]
+    mojo_device = MOJO_DEVICE_MAPPING[device]
+    a_numpy = a.cpu().float().numpy()
+    b_numpy = b.cpu().float().numpy()
+    a_mojo_cuda = Tensor.from_numpy(a_numpy, device=mojo_device)
+    b_mojo_cuda = Tensor.from_numpy(a_numpy, device=mojo_device)
+    a_mojo_bf16 = demote_numpy_to_mojo_tensor_bf16(a_numpy, mojo_dtype)
+    b_mojo_bf16 = demote_numpy_to_mojo_tensor_bf16(b_numpy, mojo_dtype)
+    input_types = (
+        TensorType(dtype=mojo_dtype, shape=a_numpy.shape, device=mojo_device()),
+        TensorType(dtype=mojo_dtype, shape=a_numpy.shape, device=mojo_device()),
+    )
+    with mg.Graph("mojo_matmul", input_types=input_types) as g:
+        a_val, b_val = g.inputs
+        c_val = ops.matmul(a_val, b_val)
+        g.output(c_val)
+    session = engine.InferenceSession(devices=[Accelerator()])
+    model = session.load(g)
+    outputs = model.execute(a_mojo_bf16, b_mojo_bf16)
+    return outputs
+
+if __name__ == "__main__":
+    precision = "bf16"
+    a = torch.randn([1024, 1024], dtype=torch.bfloat16).cuda()
+    b = torch.randn([1024, 1024], dtype=torch.bfloat16).cuda()
+    mojo_matmul("bf16", "cuda", a, b)
+    # gemm_opbench = load_opbench_by_name("gemm")
+    # register_benchmark(mojo_matmul)
+    # gemm_opbench.run()
+    # promoting the output to fp32 for numerics check
+    # convert back to pytorch
+    y_torch = torch.from_numpy(promote_mojo_tensor_to_fp32(outputs[0], dtype=DType.bfloat16, device=DeviceRef.CPU())[0].to_numpy())
+    print("success!")

--- a/benchmarks/mojo_matmul/run.py
+++ b/benchmarks/mojo_matmul/run.py
@@ -88,7 +88,7 @@ def mojo_matmul(operator, a, b, bias) -> Callable:
     b_mojo_bf16 = demote_numpy_to_mojo_tensor_dtype(b_numpy, mojo_dtype)
     input_types = (
         TensorType(dtype=mojo_dtype, shape=a_numpy.shape, device=mojo_device()),
-        TensorType(dtype=mojo_dtype, shape=a_numpy.shape, device=mojo_device()),
+        TensorType(dtype=mojo_dtype, shape=b_numpy.shape, device=mojo_device()),
     )
     with mg.Graph("mojo_matmul", input_types=input_types) as g:
         a_val, b_val = g.inputs
@@ -101,7 +101,7 @@ def mojo_matmul(operator, a, b, bias) -> Callable:
     return output_func
 
 if __name__ == "__main__":
-    args = ["--op", "gemm", "--only", "aten_matmul,mojo_matmul", "--num-inputs", "1"]
+    args = ["--op", "gemm", "--only", "aten_matmul,mojo_matmul", "--precision", "bf16", "--m", "512", "--n", "8192", "--k", "5376"]
     gemm_opbench_cls = load_opbench_by_name("gemm")
     parser = get_parser(args)
     tb_args, extra_args = parser.parse_known_args(args)

--- a/benchmarks/mojo_matmul/run.py
+++ b/benchmarks/mojo_matmul/run.py
@@ -81,7 +81,7 @@ def mojo_matmul(operator, a, b, bias) -> Callable:
     mojo_device = MOJO_DEVICE_MAPPING[device]
     mojo_driver_device = MOJO_DRIVER_DEVICE_MAPPING[device]
     a_numpy = a.cpu().float().numpy()
-    b_numpy = b.cpu().float().numpy()
+    b_numpy = b.T.cpu().float().numpy()
     a_mojo_cuda = driver.Tensor.from_numpy(a_numpy).to(mojo_driver_device())
     b_mojo_cuda = driver.Tensor.from_numpy(b_numpy).to(mojo_driver_device())
     a_mojo_bf16 = demote_numpy_to_mojo_tensor_dtype(a_numpy, mojo_dtype)
@@ -92,7 +92,7 @@ def mojo_matmul(operator, a, b, bias) -> Callable:
     )
     with mg.Graph("mojo_matmul", input_types=input_types) as g:
         a_val, b_val = g.inputs
-        c_val = ops.matmul(a_val, b_val)
+        c_val = ops.matmul(a_val, b_val.T)
         g.output(c_val)
     session = engine.InferenceSession(devices=[driver.Accelerator()])
     model = session.load(g)

--- a/benchmarks/mojo_matmul/run.py
+++ b/benchmarks/mojo_matmul/run.py
@@ -1,3 +1,9 @@
+"""
+Benchmark mojo_matmul with modular nightly.
+To install modular nightly:
+pip install --pre modular --index-url https://dl.modular.com/public/nightly/python/simple/
+"""
+
 import argparse
 import json
 import logging

--- a/benchmarks/mojo_matmul/run.py
+++ b/benchmarks/mojo_matmul/run.py
@@ -101,7 +101,7 @@ def mojo_matmul(operator, a, b, bias) -> Callable:
     return output_func
 
 if __name__ == "__main__":
-    args = ["--op", "gemm", "--only", "aten_matmul,mojo_matmul", "--precision", "bf16", "--m", "512", "--n", "8192", "--k", "5376"]
+    args = ["--op", "gemm", "--only", "aten_matmul,mojo_matmul", "--precision", "bf16", "--m", "512", "--n", "8192", "--k", "5376"] + sys.argv[1:]
     gemm_opbench_cls = load_opbench_by_name("gemm")
     parser = get_parser(args)
     tb_args, extra_args = parser.parse_known_args(args)

--- a/benchmarks/mojo_matmul/run.py
+++ b/benchmarks/mojo_matmul/run.py
@@ -29,37 +29,19 @@ setup_tritonbench_cwd()
 import torch
 import max.graph as mg
 
-from max import engine
-from max.graph import TensorValue, ops, DType, DeviceRef, TensorType, Graph
-from max.graph.type import Shape, ShapeLike
-from max.driver import CPU, Tensor, Accelerator
+from max import engine, driver
+from max.graph import TensorValue, ops, DeviceRef, TensorType, Graph
+from max.graph.type import Shape, ShapeLike, DType
 
+from tritonbench.operators import load_opbench_by_name
 
-def matmul_graph(
-    name: str,
-    shapes: tuple[ShapeLike, ShapeLike],
-    dtype: DType = DType.float32,
-) -> Graph:
-    """Creates a graph op containing a matmul."""
-
-    def tensor_type(dims: ShapeLike) -> TensorType:
-        return TensorType(dtype, Shape(dims), device=DeviceRef.CPU())
-
-    return Graph(
-        name,
-        lambda a, b: ops.matmul(a, b),
-        (tensor_type(shapes[0]), tensor_type(shapes[1])),
-    )
-
-
-
-def promote_mojo_tensor_to_fp32(mojo_tensor, dtype, device):
-    input_type = TensorType(dtype=dtype, shape=mojo_tensor.shape, device=device)
+def promote_mojo_tensor_to_fp32(mojo_tensor, dtype):
+    input_type = TensorType(dtype=dtype, shape=mojo_tensor.shape, device=DeviceRef.GPU())
     with mg.Graph("mojo_to_fp32", input_types=(input_type, )) as g:
         (inp, ) = g.inputs
         out = ops.cast(inp, dtype=DType.float32)
         g.output(out)
-    session = engine.InferenceSession(devices=[CPU()])
+    session = engine.InferenceSession(devices=[driver.Accelerator()])
     model = session.load(g)
     output = model.execute(mojo_tensor)
     return output
@@ -69,7 +51,7 @@ def demote_numpy_to_mojo_tensor_bf16(numpy_array, dtype):
         inp = ops.constant(numpy_array, dtype=DType.float32, device=DeviceRef.GPU())
         out = ops.cast(inp, dtype=DType.bfloat16)
         g.output(out)
-    session = engine.InferenceSession(devices=[GPU()])
+    session = engine.InferenceSession(devices=[driver.Accelerator()])
     model = session.load(g)
     output = model.execute()
     return output[0]
@@ -83,14 +65,19 @@ MOJO_DEVICE_MAPPING = {
     "cuda": DeviceRef.GPU,
     "cpu": DeviceRef.CPU,
 }
+MOJO_DRIVER_DEVICE_MAPPING = {
+    "cuda": driver.Accelerator,
+    "cpu": driver.CPU,
+}
 
 def mojo_matmul(precision, device, a, b):
     mojo_dtype = MOJO_DTYPE_MAPPING[precision]
     mojo_device = MOJO_DEVICE_MAPPING[device]
+    mojo_driver_device = MOJO_DRIVER_DEVICE_MAPPING[device]
     a_numpy = a.cpu().float().numpy()
     b_numpy = b.cpu().float().numpy()
-    a_mojo_cuda = Tensor.from_numpy(a_numpy, device=mojo_device)
-    b_mojo_cuda = Tensor.from_numpy(a_numpy, device=mojo_device)
+    a_mojo_cuda = driver.Tensor.from_numpy(a_numpy).to(mojo_driver_device())
+    b_mojo_cuda = driver.Tensor.from_numpy(b_numpy).to(mojo_driver_device())
     a_mojo_bf16 = demote_numpy_to_mojo_tensor_bf16(a_numpy, mojo_dtype)
     b_mojo_bf16 = demote_numpy_to_mojo_tensor_bf16(b_numpy, mojo_dtype)
     input_types = (
@@ -101,7 +88,7 @@ def mojo_matmul(precision, device, a, b):
         a_val, b_val = g.inputs
         c_val = ops.matmul(a_val, b_val)
         g.output(c_val)
-    session = engine.InferenceSession(devices=[Accelerator()])
+    session = engine.InferenceSession(devices=[driver.Accelerator()])
     model = session.load(g)
     outputs = model.execute(a_mojo_bf16, b_mojo_bf16)
     return outputs
@@ -110,11 +97,11 @@ if __name__ == "__main__":
     precision = "bf16"
     a = torch.randn([1024, 1024], dtype=torch.bfloat16).cuda()
     b = torch.randn([1024, 1024], dtype=torch.bfloat16).cuda()
-    mojo_matmul("bf16", "cuda", a, b)
-    # gemm_opbench = load_opbench_by_name("gemm")
+    outputs = mojo_matmul("bf16", "cuda", a, b)
+    gemm_opbench = load_opbench_by_name("gemm")
     # register_benchmark(mojo_matmul)
     # gemm_opbench.run()
     # promoting the output to fp32 for numerics check
     # convert back to pytorch
-    y_torch = torch.from_numpy(promote_mojo_tensor_to_fp32(outputs[0], dtype=DType.bfloat16, device=DeviceRef.CPU())[0].to_numpy())
+    y_torch = torch.from_numpy(promote_mojo_tensor_to_fp32(outputs[0], dtype=DType.bfloat16)[0].to_numpy())
     print("success!")

--- a/benchmarks/mojo_matmul/run.py
+++ b/benchmarks/mojo_matmul/run.py
@@ -37,6 +37,8 @@ from tritonbench.operators import load_opbench_by_name
 from tritonbench.utils.triton_op import register_benchmark
 from tritonbench.utils.parser import get_parser
 
+from typing import Callable
+
 def promote_mojo_tensor_to_fp32(mojo_tensor, dtype):
     input_type = TensorType(dtype=dtype, shape=mojo_tensor.shape, device=DeviceRef.GPU())
     with mg.Graph("mojo_to_fp32", input_types=(input_type, )) as g:
@@ -48,10 +50,10 @@ def promote_mojo_tensor_to_fp32(mojo_tensor, dtype):
     output = model.execute(mojo_tensor)
     return output
 
-def demote_numpy_to_mojo_tensor_bf16(numpy_array, dtype):
-    with mg.Graph("mojo_to_bf16") as g:
+def demote_numpy_to_mojo_tensor_dtype(numpy_array, dtype):
+    with mg.Graph("mojo_to_dtype") as g:
         inp = ops.constant(numpy_array, dtype=DType.float32, device=DeviceRef.GPU())
-        out = ops.cast(inp, dtype=DType.bfloat16)
+        out = ops.cast(inp, dtype=dtype)
         g.output(out)
     session = engine.InferenceSession(devices=[driver.Accelerator()])
     model = session.load(g)
@@ -72,7 +74,9 @@ MOJO_DRIVER_DEVICE_MAPPING = {
     "cpu": driver.CPU,
 }
 
-def mojo_matmul(precision, device, a, b):
+def mojo_matmul(operator, a, b, bias) -> Callable:
+    precision = operator.precision
+    device = operator.device
     mojo_dtype = MOJO_DTYPE_MAPPING[precision]
     mojo_device = MOJO_DEVICE_MAPPING[device]
     mojo_driver_device = MOJO_DRIVER_DEVICE_MAPPING[device]
@@ -80,8 +84,8 @@ def mojo_matmul(precision, device, a, b):
     b_numpy = b.cpu().float().numpy()
     a_mojo_cuda = driver.Tensor.from_numpy(a_numpy).to(mojo_driver_device())
     b_mojo_cuda = driver.Tensor.from_numpy(b_numpy).to(mojo_driver_device())
-    a_mojo_bf16 = demote_numpy_to_mojo_tensor_bf16(a_numpy, mojo_dtype)
-    b_mojo_bf16 = demote_numpy_to_mojo_tensor_bf16(b_numpy, mojo_dtype)
+    a_mojo_bf16 = demote_numpy_to_mojo_tensor_dtype(a_numpy, mojo_dtype)
+    b_mojo_bf16 = demote_numpy_to_mojo_tensor_dtype(b_numpy, mojo_dtype)
     input_types = (
         TensorType(dtype=mojo_dtype, shape=a_numpy.shape, device=mojo_device()),
         TensorType(dtype=mojo_dtype, shape=a_numpy.shape, device=mojo_device()),
@@ -93,21 +97,18 @@ def mojo_matmul(precision, device, a, b):
     session = engine.InferenceSession(devices=[driver.Accelerator()])
     model = session.load(g)
     outputs = model.execute(a_mojo_bf16, b_mojo_bf16)
-    return outputs
+    output_func = lambda: model.execute(a_mojo_bf16, b_mojo_bf16)
+    return output_func
 
 if __name__ == "__main__":
-    precision = "bf16"
-    a = torch.randn([1024, 1024], dtype=torch.bfloat16).cuda()
-    b = torch.randn([1024, 1024], dtype=torch.bfloat16).cuda()
-    outputs = mojo_matmul("bf16", "cuda", a, b)
     args = ["--op", "gemm", "--only", "aten_matmul,mojo_matmul", "--num-inputs", "1"]
     gemm_opbench_cls = load_opbench_by_name("gemm")
     parser = get_parser(args)
     tb_args, extra_args = parser.parse_known_args(args)
     gemm_opbench = gemm_opbench_cls(tb_args, extra_args)
-    decorator = register_benchmark(operator_name="gemm", func_name="mojo_matmul")
-    decorator(mojo_matmul)
+    gemm_opbench.add_benchmark(bm_func_name="mojo_matmul", bm_callable=mojo_matmul)
     gemm_opbench.run()
+    metrics = gemm_opbench.output
+    print(metrics)
     # TODO: promote the output to fp32 for numerics check
     # y_torch = torch.from_numpy(promote_mojo_tensor_to_fp32(outputs[0], dtype=DType.bfloat16)[0].to_numpy())
-    print("success!")

--- a/benchmarks/mojo_matmul/run.py
+++ b/benchmarks/mojo_matmul/run.py
@@ -34,6 +34,8 @@ from max.graph import TensorValue, ops, DeviceRef, TensorType, Graph
 from max.graph.type import Shape, ShapeLike, DType
 
 from tritonbench.operators import load_opbench_by_name
+from tritonbench.utils.triton_op import register_benchmark
+from tritonbench.utils.parser import get_parser
 
 def promote_mojo_tensor_to_fp32(mojo_tensor, dtype):
     input_type = TensorType(dtype=dtype, shape=mojo_tensor.shape, device=DeviceRef.GPU())
@@ -98,10 +100,14 @@ if __name__ == "__main__":
     a = torch.randn([1024, 1024], dtype=torch.bfloat16).cuda()
     b = torch.randn([1024, 1024], dtype=torch.bfloat16).cuda()
     outputs = mojo_matmul("bf16", "cuda", a, b)
-    gemm_opbench = load_opbench_by_name("gemm")
-    # register_benchmark(mojo_matmul)
-    # gemm_opbench.run()
-    # promoting the output to fp32 for numerics check
-    # convert back to pytorch
-    y_torch = torch.from_numpy(promote_mojo_tensor_to_fp32(outputs[0], dtype=DType.bfloat16)[0].to_numpy())
+    args = ["--op", "gemm", "--only", "aten_matmul,mojo_matmul", "--num-inputs", "1"]
+    gemm_opbench_cls = load_opbench_by_name("gemm")
+    parser = get_parser(args)
+    tb_args, extra_args = parser.parse_known_args(args)
+    gemm_opbench = gemm_opbench_cls(tb_args, extra_args)
+    decorator = register_benchmark(operator_name="gemm", func_name="mojo_matmul")
+    decorator(mojo_matmul)
+    gemm_opbench.run()
+    # TODO: promote the output to fp32 for numerics check
+    # y_torch = torch.from_numpy(promote_mojo_tensor_to_fp32(outputs[0], dtype=DType.bfloat16)[0].to_numpy())
     print("success!")


### PR DESCRIPTION
Add mojo matmul as an example benchmark following the read on https://www.modular.com/blog/matrix-multiplication-on-blackwell-part-4---breaking-sota

~~It was fun experience, however mojo's `ops.matmul` operator in Python is always falling-back to cublas calls.
Need further investigation on how to reroute to the Mojo kernel itself.~~

Mojo SM100 kernel requires to transpose the input on matrix B, so the matrix B has to be in shape [N,K] then transposed.

Some numbers on blackwell:

```
$ CUDA_VISIBLE_DEVICES=6 bash ~/fbsource/fbcode/ads_mkl/benchmarks/denoise.sh python benchmarks/mojo_matmul/run.py --only aten_matmul,mojo_matmul,triton_blackwell_warpspec_persistent_matmul --latency-measure-mode=profiler

        (M, N, K)    aten_matmul-latency    aten_matmul-tflops    mojo_matmul-latency    mojo_matmul-speedup    mojo_matmul-tflops    triton_blackwell_warpspec_persistent_matmul-latency    triton_blackwell_warpspec_persistent_matmul-speedup    triton_blackwell_warpspec_persistent_matmul-tflops
-----------------  ---------------------  --------------------  ---------------------  ---------------------  --------------------  -----------------------------------------------------  -----------------------------------------------------  ----------------------------------------------------
(512, 8192, 5376)      0.041502 (±3.55%)               1086.62      0.043078 (±3.83%)               0.963412               1046.87                                      0.051077 (±2.98%)                                               0.812535                                               882.921
          average                                      1086.62                                      0.963412               1046.87                                                                                                      0.812535                                               882.921
```


Collecting ncu traces:

```

100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:18<00:00, 18.99s/it]
        (M, N, K)    aten_matmul-latency    aten_matmul-tflops    mojo_matmul-latency    mojo_matmul-speedup    mojo_matmul-tflops    triton_blackwell_warpspec_persistent_matmul-latency    triton_blackwell_warpspec_persistent_matmul-spee
-----------------  ---------------------  --------------------  ---------------------  ---------------------  --------------------  -----------------------------------------------------  --------------------------------------------------
(512, 8192, 5376)      0.041502 (±3.55%)               1086.62      0.043078 (±3.83%)               0.963412               1046.87                                      0.051077 (±2.98%)                                               0.812
          average                                      1086.62                                      0.963412               1046.87                                                                                                      0.812
(py312) [xzhao9@devgpu023.atn1 ~/tritonbench (xz9/add-mojo)]$ CUDA_VISIBLE_DEVICES=6 bash ~/fbsource/fbcode/ads_mkl/benchmarks/denoise.sh python benchmarks/mojo_matmul/run.py --only aten_matmul,mojo_matmul,triton_blackwell_warpspec_persi
Processing GPU 6...
→ Locking power cap to 750 W and SM clock to 1830 MHz on GPU 6
/home/xzhao9/.conda/envs/py312/lib/python3.12/site-packages/torch/cuda/__init__.py:63: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml directly, please report this to th
  import pynvml  # type: ignore[import]
  0%|                                                                                                                                                                                                                  | 0/1 [00:00<?, ?it/s]
Failed to configure DCGM profiling, it may be DCGM is not supported or failed/home/xzhao9/.conda/envs/py312/lib/python3.12/site-packages/torch/cuda/__init__.py:63: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml
  import pynvml  # type: ignore[import]
==PROF== Connected to process 2189016 (/home/xzhao9/.conda/envs/py312/bin/python3.12)
  0%|                                                                                                                                                                                                                  | 0/1 [00:00<?, ?it/s]


==PROF== Profiling "nvjet_tst_224x128_64x7_1x2_2c..." - 0: 0%....50%....100% - 40 passes
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:07<00:00,  7.42s/it]
        (M, N, K)    aten_matmul-_ncu_trace_in_task
-----------------  --------------------------------
(512, 8192, 5376)                           success
          average
==PROF== Disconnected from process 2189016
==WARNING== No source files were imported. Check that the target application was compiled with -lineinfo.
==PROF== Report: /tmp/tritonbench_xzhao9/bf16_gemm_fwd/aten_matmul_0/ncu_rep.ncu-rep
I0921 14:06:13.349408 2199682 DynoCmdLine.cpp:1397] Target Host: localhost (port 1777)
Failed to configure DCGM profiling, it may be DCGM is not supported or failed/home/xzhao9/.conda/envs/py312/lib/python3.12/site-packages/torch/cuda/__init__.py:63: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml directly, please report this to the maintainers of the package that installed pynvml for you.
  import pynvml  # type: ignore[import]
==PROF== Connected to process 2200427 (/home/xzhao9/.conda/envs/py312/bin/python3.12)
  0%|                                                                                                                                                                                                                  | 0/1 [00:00<?, ?it/s]==WARNING== Unable to access the following 6 metrics: ctc__rx_bytes_data_user.sum, ctc__rx_bytes_data_user.sum.pct_of_peak_sustained_elapsed, ctc__rx_bytes_data_user.sum.per_second, ctc__tx_bytes_data_user.sum, ctc__tx_bytes_data_user.sum.pct_of_peak_sustained_elapsed, ctc__tx_bytes_data_user.sum.per_second.


==PROF== Profiling "linalg_matmul_sm100_blackwell..." - 0: 0%....50%....100% - 40 passes
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:09<00:00,  9.80s/it]
        (M, N, K)    mojo_matmul-_ncu_trace_in_task
-----------------  --------------------------------
(512, 8192, 5376)                           success
          average
==PROF== Disconnected from process 2200427
==WARNING== No source files were imported. Check that the target application was compiled with -lineinfo.
==PROF== Report: /tmp/tritonbench_xzhao9/bf16_gemm_fwd/mojo_matmul_0/ncu_rep.ncu-rep
I0921 14:06:29.449487 2214630 DynoCmdLine.cpp:1397] Target Host: localhost (port 1777)
Failed to configure DCGM profiling, it may be DCGM is not supported or failed/home/xzhao9/.conda/envs/py312/lib/python3.12/site-packages/torch/cuda/__init__.py:63: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml directly, please report this to the maintainers of the package that installed pynvml for you.
  import pynvml  # type: ignore[import]
==PROF== Connected to process 2216766 (/home/xzhao9/.conda/envs/py312/bin/python3.12)
  0%|                                                                                                                                                                                                                  | 0/1 [00:00<?, ?it/s]==WARNING== Unable to access the following 6 metrics: ctc__rx_bytes_data_user.sum, ctc__rx_bytes_data_user.sum.pct_of_peak_sustained_elapsed, ctc__rx_bytes_data_user.sum.per_second, ctc__tx_bytes_data_user.sum, ctc__tx_bytes_data_user.sum.pct_of_peak_sustained_elapsed, ctc__tx_bytes_data_user.sum.per_second.


==PROF== Profiling "matmul_kernel_tma_persistent" - 0: 0%....50%....100% - 40 passes
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:12<00:00, 12.43s/it]
        (M, N, K)    triton_blackwell_warpspec_persistent_matmul-_ncu_trace_in_task
-----------------  ----------------------------------------------------------------
(512, 8192, 5376)                                                           success
          average
==PROF== Disconnected from process 2216766
==PROF== Report: /tmp/tritonbench_xzhao9/bf16_gemm_fwd/triton_blackwell_warpspec_persistent_matmul_0/ncu_rep.ncu-rep
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:50<00:00, 50.06s/it]
        (M, N, K)                                                  aten_matmul-ncu_rep                                                  mojo_matmul-ncu_rep                                                  triton_blackwell_warpspec_persistent_matmul-ncu_rep
-----------------  -------------------------------------------------------------------  -------------------------------------------------------------------  ---------------------------------------------------------------------------------------------------
(512, 8192, 5376)  /tmp/tritonbench_xzhao9/bf16_gemm_fwd/aten_matmul_0/ncu_rep.ncu-rep  /tmp/tritonbench_xzhao9/bf16_gemm_fwd/mojo_matmul_0/ncu_rep.ncu-rep  /tmp/tritonbench_xzhao9/bf16_gemm_fwd/triton_blackwell_warpspec_persistent_matmul_0/ncu_rep.ncu-rep
          average
```