### PR TITLE
Contribute fp8_gemm Blackwell-specific per-row scaling config

### DIFF
--- a/benchmarks/run_config/fp8_gemm_blackwell_rowwise_config_1.yaml
+++ b/benchmarks/run_config/fp8_gemm_blackwell_rowwise_config_1.yaml
@@ -1,0 +1,4 @@
+fp8_gemm_blackwell_rowwise_config_1:
+    op: fp8_gemm
+    args: --op fp8_gemm --only blackwell_pt2_fp8_gemm --metrics tflops --m 1024 --n 256 --k 9216 --scaling_rowwise --simple-output
+    envs: TORCHINDUCTOR_AUTOTUNE_IN_SUBPROC=1 TRITON_ALWAYS_COMPILE=1 TORCHINDUCTOR_FORCE_DISABLE_CACHES=1 ENABLE_PERSISTENT_TMA_MATMUL=1 TORCHINDUCTOR_MAX_AUTOTUNE_GEMM=1


### PR DESCRIPTION
Summary: Contribute Blackwell-specific FP8 GEMM config for per-row scaling to TritonBench's EVO tuning config suite.

Reviewed By: xuzhao9

Differential Revision: D83192979

On Meta's blackwell devgpu:

```
CUDA_VISIBLE_DEVICES=1 TRITONBENCH_RUN_CONFIG=/home/xzhao9/tritonbench/benchmarks/run_config/fp8_gemm_blackwell_rowwise_config_1.yaml python run.py
             x_val    blackwell_pt2_fp8_gemm-tflops
------------------  -------------------------------
 (1024, 256, 9216)                          61.8072
61.807181947795755
```

