### PR TITLE
More accurate kernel impl name prefix, for easier matching

### DIFF
--- a/tritonbench/operators/gather_gemv/operator.py
+++ b/tritonbench/operators/gather_gemv/operator.py
@@ -39,11 +39,11 @@ class Operator(BenchmarkOperator):
         super().__init__(tb_args, extra_args)
 
     @register_benchmark()
-    def test_0(self, p1, p2, p3) -> Callable:
+    def triton_gather_gemv(self, p1, p2, p3) -> Callable:
         return lambda: triton_test_0(p1, p2, p3)
 
     @register_benchmark(baseline=True)
-    def test_eager(self, w, idx, x):
+    def eager_gather_gemv(self, w, idx, x):
         s = x.size(0)
 
         if s <= 8192:
@@ -61,7 +61,7 @@ class Operator(BenchmarkOperator):
         return eager_impl
 
     @register_benchmark()
-    def test_inductor(self, w, idx, x):
+    def torch_compile_gather_gemv(self, w, idx, x):
         @torch.compile(mode="max-autotune-no-cudagraphs")
         def gather_gemv(w, idx, x):
             return w[idx].to(x.dtype) @ x

--- a/tritonbench/operators/grouped_gemm/operator.py
+++ b/tritonbench/operators/grouped_gemm/operator.py
@@ -88,7 +88,7 @@ class Operator(BenchmarkOperator):
         return _inner
 
     @register_benchmark()
-    def pt2_triton_grouped_mm(self, group_A, group_B):
+    def torch_compile_grouped_gemm(self, group_A, group_B):
         def _inner():
             torch._dynamo.reset()
 
@@ -121,7 +121,7 @@ class Operator(BenchmarkOperator):
         return _inner
 
     @register_benchmark()
-    def triton(self, group_A, group_B):
+    def triton_grouped_gemm(self, group_A, group_B):
         def _inner():
             (d_a_ptrs, d_b_ptrs, d_c_ptrs, d_g_sizes, d_g_lds, group_C) = (
                 self.list_input_to_triton_input(group_A, group_B)

--- a/tritonbench/operators/welford/operator.py
+++ b/tritonbench/operators/welford/operator.py
@@ -46,7 +46,7 @@ class Operator(BenchmarkOperator):
         self.shapes = BUILDIN_SHAPES
 
     @register_benchmark()
-    def test_welford(self, p1, p2, p3) -> Callable:
+    def triton_welford(self, p1, p2, p3) -> Callable:
         return lambda: triton_welford(p1, p2, p3)
 
     @register_benchmark()


### PR DESCRIPTION
To make it easier for users to select only specific kernels to run.