### PR TITLE
fix --export flag parsing options

### DIFF
--- a/tritonbench/utils/parser.py
+++ b/tritonbench/utils/parser.py
@@ -237,7 +237,7 @@ def get_parser(args=None):
     parser.add_argument(
         "--export",
         default=None,
-        choices=["in", "out", "both"],
+        choices=["input", "output", "both"],
         help="Export input or output. Must be used together with --export-dir.",
     )
     parser.add_argument(


### PR DESCRIPTION
Summary: The parser was only accepting "in" and "out" as options but the [export_data function](https://github.com/meta-pytorch/tritonbench/blob/c32f869958ac504fe4c5aca5e8b1b183546a8c90/tritonbench/components/export/export.py#L19) matches against "input" or "output" strings. This was causing nothing to be generated when in or out options were specified.

Reviewed By: xuzhao9

Differential Revision: D83291025


