### PR TITLE
softmax: change baseline to directly use F.softmax

### DIFF
--- a/tritonbench/operators/softmax/operator.py
+++ b/tritonbench/operators/softmax/operator.py
@@ -118,24 +118,10 @@ class Operator(BenchmarkOperator):
 
     @register_benchmark(baseline=True)
     def naive_softmax(self, x):
-        """Compute row-wise softmax of X using native pytorch
-        We subtract the maximum element in order to avoid overflows. Softmax is invariant to
-        this shift.
-        """
+        """Compute row-wise softmax of X using native pytorch."""
 
         def _inner():
-            # read  MN elements ; write M  elements
-            x_max = x.max(dim=1)[0]
-            # read MN + M elements ; write MN elements
-            z = x - x_max[:, None]
-            # read  MN elements ; write MN elements
-            numerator = torch.exp(z)
-            # read  MN elements ; write M  elements
-            denominator = numerator.sum(dim=1)
-            # read MN + M elements ; write MN elements
-            ret = numerator / denominator[:, None]
-            # in total: read 5MN + 2M elements ; wrote 3MN + 2M elements
-            return ret
+            return torch.nn.functional.softmax(x, dim=1)
 
         return _inner
 


### PR DESCRIPTION
The current baseline fails accuracy check for the first input shape:
```
$ python run.py --op softmax --num-inputs 1 --input-id 0 --metrics accuracy
First-k mode: Selected 1 sequential inputs starting from index 0 (total available: 98)
Input IDs to run: [0]
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:01<00:00,  1.84s/it]
     (M, N)    triton_softmax-accuracy    quack-accuracy    torch_compile_softmax-accuracy
-----------  -------------------------  ----------------  --------------------------------
(4096, 256)                          0                 0                                 0
    average                          0                 0                                 0
```
We could improve the existing baseline implementation. But since `F.softmax` is the most easily accessible eager impl, and it already handles the numerics correctly, I think we should just use `F.softmax` as baseline.