### PR TITLE
Fix cudagraph support for rms_norm bwd and layer_norm bwd

### DIFF
--- a/tritonbench/operators/layer_norm/operator.py
+++ b/tritonbench/operators/layer_norm/operator.py
@@ -100,12 +100,6 @@ class Operator(BenchmarkOperator):
     def get_bwd_fn(self, fwd_fn: Callable) -> Callable:
         from torch.utils._pytree import tree_map
 
-        # Run forward once to get output
-        output = fwd_fn()
-        y = output[0] if isinstance(output, tuple) else output
-        torch.manual_seed(0)
-        dy = 0.1 * torch.randn_like(y)
-
         # Extract tensors that require gradients from example_inputs
         grad_tensors = []
 
@@ -118,14 +112,23 @@ class Operator(BenchmarkOperator):
         # example_inputs is set by the benchmark framework and contains the current input
         tree_map(extract_if_requires_grad, self.example_inputs)
 
+        state = {"y": None, "dy": None}
+
         def bwd_fn():
             # Clear existing gradients
             for t in grad_tensors:
                 if t.grad is not None:
                     t.grad = None
 
+            # Initialize on first call
+            if state["y"] is None:
+                output = fwd_fn()
+                state["y"] = output[0] if isinstance(output, tuple) else output
+                torch.manual_seed(0)
+                state["dy"] = 0.1 * torch.randn_like(state["y"])
+
             # Run backward
-            y.backward(dy, retain_graph=True)
+            state["y"].backward(state["dy"], retain_graph=True)
 
             # Return the tensors (not gradients) for accuracy checking
             return grad_tensors


### PR DESCRIPTION
Originally they fail with:
```
$ CUDA_LAUNCH_BLOCKING=1 python run.py --op rms_norm --bwd --num-inputs 1 --metrics speedup,accuracy --only torch_compile --only-match-mode prefix-with-baseline --latency-measure-mode triton_do_bench --cudagraph
Using input-sample-mode=equally-spaced-k for rms_norm
Running rms_norm benchmark with Helion implementation...

Equally-spaced-k mode: Selected 1 equally spaced inputs (total available: 6)
Input IDs to run: [0]
  0%|                                                                                                                                                           | 0/1 [00:00<?, ?it/s]
Caught exception, terminating early with partial results
Traceback (most recent call last):
  File "/home/willfeng/local/pytorch-nightly/triton/testing.py", line 111, in do_bench_cudagraph
    fn()
  File "/home/willfeng/local/helion/benchmarks/tritonbench/tritonbench/operators/rms_norm/operator.py", line 178, in bwd_fn
    y.backward(dy, retain_graph=True)
  File "/home/willfeng/local/pytorch-nightly/torch/_tensor.py", line 625, in backward
    torch.autograd.backward(
  File "/home/willfeng/local/pytorch-nightly/torch/autograd/__init__.py", line 354, in backward
    _engine_run_backward(
  File "/home/willfeng/local/pytorch-nightly/torch/autograd/graph.py", line 841, in _engine_run_backward
    return Variable._execution_engine.run_backward(  # Calls into the C++ engine to run the backward pass
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
torch.AcceleratorError: CUDA error: operation would make the legacy stream depend on a capturing blocking stream
Search for `cudaErrorStreamCaptureImplicit' in https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TYPES.html for more information.
Compile with `TORCH_USE_CUDA_DSA` to enable device-side assertions.


During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/willfeng/local/helion/benchmarks/tritonbench/tritonbench/utils/triton_op.py", line 1083, in run
    y_vals: Dict[str, BenchmarkOperatorMetrics] = functools.reduce(
                                                  ^^^^^^^^^^^^^^^^^
  File "/home/willfeng/local/helion/benchmarks/tritonbench/tritonbench/utils/triton_op.py", line 1068, in _reduce_benchmarks
    acc[bm_name] = self._do_bench(
                   ^^^^^^^^^^^^^^^
  File "/home/willfeng/local/helion/benchmarks/tritonbench/tritonbench/utils/triton_op.py", line 1507, in _do_bench
    metrics.latency = do_bench_wrapper(
                      ^^^^^^^^^^^^^^^^^
  File "/home/willfeng/local/helion/benchmarks/tritonbench/tritonbench/components/do_bench/run.py", line 416, in do_bench_wrapper
    raise e
  File "/home/willfeng/local/helion/benchmarks/tritonbench/tritonbench/components/do_bench/run.py", line 389, in do_bench_wrapper
    times=bench_fn(
          ^^^^^^^^^
  File "/home/willfeng/local/pytorch-nightly/triton/testing.py", line 106, in do_bench_cudagraph
    with torch.cuda.graph(g):
         ^^^^^^^^^^^^^^^^^^^
  File "/home/willfeng/local/pytorch-nightly/torch/cuda/graphs.py", line 265, in __exit__
    self.cuda_graph.capture_end()
  File "/home/willfeng/local/pytorch-nightly/torch/cuda/graphs.py", line 128, in capture_end
    super().capture_end()
torch.AcceleratorError: CUDA error: operation failed due to a previous error during capture
Search for `cudaErrorStreamCaptureInvalidated' in https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TYPES.html for more information.
Compile with `TORCH_USE_CUDA_DSA` to enable device-side assertions.
```