### PR TITLE
Skip benchmarks that are not enabled in --only mode

### DIFF
--- a/tritonbench/utils/parser.py
+++ b/tritonbench/utils/parser.py
@@ -137,6 +137,12 @@ def get_parser(args=None):
         help="Specify one or multiple kernel implementations to skip.",
     )
     parser.add_argument(
+        "--force",
+        action="store_true",
+        default=False,
+        help="Force all --only benchmarks to run, despite possibly not being enabled.",
+    )
+    parser.add_argument(
         "--only-match-mode",
         default="exact",
         choices=["exact", "prefix-with-baseline"],


### PR DESCRIPTION
Summary: Skip benchmarks that are not `enabled` in TritonBench when in `--only` mode unless `--force` is enabled.

Reviewed By: xuzhao9

Differential Revision: D83290749
