### PR TITLE
Print exception message when accuracy check fails

### DIFF
--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -1481,7 +1481,7 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
                 )
             return True
         except Exception as e:
-            print(f"Exception during accuracy check: {e}", file=sys.stderr)
+            logger.warning(f"Exception during accuracy check: {e}")
             return False
 
     def _do_bench(


### PR DESCRIPTION
This helps surface the root cause of the accuracy check error (e.g. numerical mismatch or # outputs mismatch etc.)