### PR TITLE
[amd] Update rocm to 7.0

### DIFF
--- a/tools/rocm_utils.py
+++ b/tools/rocm_utils.py
@@ -3,10 +3,13 @@ import os
 import subprocess
 
 # defines the default ROCM version to compile against
-DEFAULT_ROCM_VERSION = "6.4"
+DEFAULT_ROCM_VERSION = "7.0"
 ROCM_VERSION_MAP = {
     "6.4": {
         "pytorch_url": "rocm6.4",
+    },
+    "7.0": {
+        "pytorch_url": "rocm7.0",
     },
 }
 


### PR DESCRIPTION
MI350 requires ROCM 7.0

Test plan:

https://github.com/meta-pytorch/tritonbench/actions/runs/18139879529