### PR TITLE
Add backward operator support for vector_exp

### DIFF
--- a/tritonbench/operators/vector_exp/kernels.py
+++ b/tritonbench/operators/vector_exp/kernels.py
@@ -1,3 +1,4 @@
+import torch
 import triton
 import triton.language as tl
 
@@ -36,3 +37,90 @@ def triton_exp_kernel(
     if profile_mem is not None:
         end = time()
         tl.store(profile_mem + pid, end - start)
+
+
+@triton.jit
+def triton_exp_backward_kernel(
+    grad_output_ptr,  # *Pointer* to grad_output vector.
+    output_ptr,  # *Pointer* to forward pass output vector (exp(x)).
+    grad_input_ptr,  # *Pointer* to grad_input vector.
+    n_elements,  # Size of the vector.
+    BLOCK_SIZE: tl.constexpr,  # Number of elements each program should process.
+    profile_mem=None,  # *Pointer* to profile_mem.
+):
+    if profile_mem is not None:
+        start = time()
+
+    # There are multiple 'programs' processing different data. We identify which program
+    # we are here:
+    pid = tl.program_id(axis=0)  # We use a 1D launch grid so axis is 0.
+
+    # This program will process inputs that are offset from the initial data.
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    # Create a mask to guard memory operations against out-of-bounds accesses.
+    mask = offsets < n_elements
+
+    # Load grad_output and output from DRAM
+    grad_output = tl.load(grad_output_ptr + offsets, mask=mask)
+    output = tl.load(output_ptr + offsets, mask=mask)
+
+    # Compute grad_input = grad_output * output (since d/dx(exp(x)) = exp(x))
+    grad_input = grad_output * output
+
+    # Write grad_input back to DRAM.
+    tl.store(grad_input_ptr + offsets, grad_input, mask=mask)
+
+    if profile_mem is not None:
+        end = time()
+        tl.store(profile_mem + pid, end - start)
+
+
+class TritonExpFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx, x: torch.Tensor, block_size: int = 1024, profile_mem: torch.Tensor = None
+    ):
+        # Allocate output tensor
+        output = torch.empty_like(x)
+        n_elements = output.numel()
+
+        # Launch grid - number of blocks needed
+        grid = lambda meta: (triton.cdiv(n_elements, block_size),)
+
+        # Launch forward kernel
+        triton_exp_kernel[grid](
+            x, output, n_elements, BLOCK_SIZE=block_size, profile_mem=profile_mem
+        )
+
+        # Save output for backward pass
+        ctx.save_for_backward(output)
+        ctx.block_size = block_size
+        ctx.profile_mem = profile_mem
+
+        return output
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):
+        # Retrieve saved tensors
+        (output,) = ctx.saved_tensors
+
+        # Allocate grad_input tensor
+        grad_input = torch.empty_like(grad_output)
+        n_elements = grad_output.numel()
+
+        # Launch grid - number of blocks needed
+        grid = lambda meta: (triton.cdiv(n_elements, ctx.block_size),)
+
+        # Launch backward kernel
+        triton_exp_backward_kernel[grid](
+            grad_output,
+            output,
+            grad_input,
+            n_elements,
+            BLOCK_SIZE=ctx.block_size,
+            profile_mem=ctx.profile_mem,
+        )
+
+        # Return gradients (None for block_size and profile_mem as they don't need gradients)
+        return grad_input, None, None


### PR DESCRIPTION
- Add Triton kernel for backward.

Testing:
Forward:
```
$ python run.py --op vector_exp --metrics accuracy
First-k mode: Selected 16 sequential inputs starting from index 0 (total available: 16)
Input IDs to run: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 16/16 [00:02<00:00,  6.34it/s]
    x_val    triton_exp-accuracy    torch_compile_exp-accuracy
---------  ---------------------  ----------------------------
     4096                      1                             1
     8192                      1                             1
    16384                      1                             1
    32768                      1                             1
    65536                      1                             1
   131072                      1                             1
   262144                      1                             1
   524288                      1                             1
  1048576                      1                             1
  2097152                      1                             1
  4194304                      1                             1
  8388608                      1                             1
 16777216                      1                             1
 33554432                      1                             1
 67108864                      1                             1
134217728                      1                             1
  average                      1                             1
  ```

Backward:
```
$ python run.py --op vector_exp --metrics accuracy --bwd
First-k mode: Selected 16 sequential inputs starting from index 0 (total available: 16)
Input IDs to run: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 16/16 [00:02<00:00,  5.49it/s]
    x_val    triton_exp-accuracy    torch_compile_exp-accuracy
---------  ---------------------  ----------------------------
     4096                      1                             1
     8192                      1                             1
    16384                      1                             1
    32768                      1                             1
    65536                      1                             1
   131072                      1                             1
   262144                      1                             1
   524288                      1                             1
  1048576                      1                             1
  2097152                      1                             1
  4194304                      1                             1
  8388608                      1                             1
 16777216                      1                             1
 33554432                      1                             1
 67108864                      1                             1
134217728                      1                             1
  average                      1                             1
  ```