### PR TITLE
Move aten input loader to the new loader style

### DIFF
--- a/tritonbench/data/loader.py
+++ b/tritonbench/data/loader.py
@@ -6,7 +6,7 @@ from tritonbench.utils.env_utils import is_fbcode
 
 SUPPORTED_INPUT_OPS = ["highway_self_gating"]
 
-INPUT_CONFIG_DIR = Path(__file__).parent.parent.joinpath("input_configs")
+INPUT_CONFIG_DIR = Path(__file__).parent.joinpath("input_configs")
 INTERNAL_INPUT_CONFIG_DIR = (
     importlib.resources.files("tritonbench.data.input_configs.fb")
     if is_fbcode()
@@ -15,15 +15,11 @@ INTERNAL_INPUT_CONFIG_DIR = (
 
 
 def get_input_loader(tritonbench_op: Any, op: str, input: str):
-    if hasattr(tritonbench_op, "aten_op_name"):
-        generator_module = importlib.import_module(
-            ".input_loaders.aten", package=__package__
-        )
-    elif op in SUPPORTED_INPUT_OPS:
-        op_module = ".".join(tritonbench_op.__module__.split(".")[:-1])
-        generator_module = importlib.import_module(f"{op_module}.input_loader")
-    else:
-        raise RuntimeError(f"Unsupported op: {op}")
+    assert (
+        hasattr(tritonbench_op, "aten_op_name") or op in SUPPORTED_INPUT_OPS
+    ), f"Unsupported op: {op}. "
+    op_module = ".".join(tritonbench_op.__module__.split(".")[:-1])
+    generator_module = importlib.import_module(f"{op_module}.input_loader")
     input_iter_getter = generator_module.get_input_iter
     input_iter = input_iter_getter(tritonbench_op, op, input)
     return input_iter

--- a/tritonbench/operator_loader/aten/__init__.py
+++ b/tritonbench/operator_loader/aten/__init__.py
@@ -1,1 +1,1 @@
-from .loader import get_aten_loader_cls_by_name, list_aten_ops
+from .op_loader import get_aten_loader_cls_by_name, list_aten_ops

--- a/tritonbench/operator_loader/aten/input_loader.py
+++ b/tritonbench/operator_loader/aten/input_loader.py
@@ -39,7 +39,7 @@ dtype_abbrs = {
 
 dtype_abbrs_parsing = {value: key for key, value in dtype_abbrs.items()}
 
-INPUT_CONFIG_DIR = Path(__file__).parent.parent.joinpath("input_configs")
+from tritonbench.data import INPUT_CONFIG_DIR
 
 
 def truncate_inp(arg):

--- a/tritonbench/operator_loader/aten/op_loader.py
+++ b/tritonbench/operator_loader/aten/op_loader.py
@@ -51,7 +51,7 @@ def get_aten_loader_cls_by_name(aten_op_name: str, aten_op_input: Optional[str] 
     If input is not provided, use the default input from the config file.
     """
     op_cls_name = aten_op_name.replace(".", "_")
-    module_name = f"tritonbench.operator_loader.loaders.{op_cls_name}"
+    module_name = f"tritonbench.operator_loader.aten.{op_cls_name}"
     op_name_module = types.ModuleType(module_name)
     op_class = AtenOperator
     op_class.__module__ = module_name


### PR DESCRIPTION
Summary:
We are refactoring the input loader component.

Now, each operator must implement its input loader script in the `input-loader.py` under its directory. This file must provide a function, `get_input_loader(tritonbench_op: Any, op: str, input: str)`, which will be plugged in as the new input generator.

The same interface holds for operator loaders like aten.

Reviewed By: FindHao

Differential Revision: D83754693
