### PR TITLE
[tilelang] Add gemm and rms_norm kernels

### DIFF
--- a/tritonbench/operators/gemm/operator.py
+++ b/tritonbench/operators/gemm/operator.py
@@ -25,7 +25,9 @@ else:
     def _tlx_matmul(*args, **kwargs):
         raise RuntimeError("TLX not available in this Triton version")
 
+
 from tritonbench.utils.python_utils import try_import
+
 with try_import("HAS_TILELANG"):
     from .tilelang import tilelang_matmul_func
 
@@ -33,10 +35,10 @@ with try_import("HAS_TILELANG"):
 from tritonbench.utils.data_utils import get_production_shapes
 from tritonbench.utils.env_utils import (
     get_nvidia_gpu_model,
+    is_cu130,
     is_cuda,
     is_fbcode,
     supports_tma,
-    is_cu130,
 )
 
 from tritonbench.utils.path_utils import REPO_PATH

--- a/tritonbench/operators/gemm/operator.py
+++ b/tritonbench/operators/gemm/operator.py
@@ -25,6 +25,10 @@ else:
     def _tlx_matmul(*args, **kwargs):
         raise RuntimeError("TLX not available in this Triton version")
 
+from tritonbench.utils.python_utils import try_import
+with try_import("HAS_TILELANG"):
+    from .tilelang import tilelang_matmul_func
+
 
 from tritonbench.utils.data_utils import get_production_shapes
 from tritonbench.utils.env_utils import (
@@ -32,6 +36,7 @@ from tritonbench.utils.env_utils import (
     is_cuda,
     is_fbcode,
     supports_tma,
+    is_cu130,
 )
 
 from tritonbench.utils.path_utils import REPO_PATH
@@ -471,6 +476,12 @@ class Operator(BenchmarkOperator):
                 return lambda: _tlx_matmul(a, b) + bias
             else:
                 return lambda: _tlx_matmul(a, b)
+
+        @register_benchmark(enabled=HAS_TILELANG and is_cu130())
+        def tilelang_blackwell_matmul(self, a, b, bias) -> Callable:
+            assert bias is None, "Tilelang does not support bias"
+            assert a.dtype == torch.bfloat16, "Tilelang only supports bf16"
+            return tilelang_matmul_func(a, b)
 
     @register_x_val(label="(M, N, K)")
     def get_x_val(self, example_inputs) -> Tuple[int, int, int]:

--- a/tritonbench/operators/gemm/tilelang.py
+++ b/tritonbench/operators/gemm/tilelang.py
@@ -1,7 +1,7 @@
 # Original source: https://github.com/tile-ai/tilelang/blob/main/examples/gemm_sm100/gemm_tcgen5mma.py
-import torch
 import tilelang
 import tilelang.language as T
+import torch
 
 tilelang.disable_cache()
 
@@ -28,11 +28,13 @@ def matmul(
 
     @T.prim_func
     def main(
-            A: T.Tensor(A_shape, in_dtype),
-            B: T.Tensor(B_shape, in_dtype),
-            C: T.Tensor((M, N), out_dtype),
+        A: T.Tensor(A_shape, in_dtype),
+        B: T.Tensor(B_shape, in_dtype),
+        C: T.Tensor((M, N), out_dtype),
     ):
-        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=threads) as (bx, by):
+        with T.Kernel(
+            T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=threads
+        ) as (bx, by):
             A_shared = T.alloc_shared(A_shared_shape, in_dtype)
             B_shared = T.alloc_shared(B_shared_shape, in_dtype)
             C_tmem = T.alloc_tmem([block_M, block_N], accum_dtype)
@@ -51,7 +53,8 @@ def matmul(
                     trans_B,
                     mbar=mbar,
                     wg_wait=-1,
-                    clear_accum=k == 0)
+                    clear_accum=k == 0,
+                )
                 T.mbarrier_wait_parity(mbar, k % 2)
 
             T.copy(C_tmem, C_local)
@@ -60,6 +63,7 @@ def matmul(
             T.copy(C_shared, C[by * block_M, bx * block_N])
 
     return main
+
 
 TILELANG_DTYPE_MAP = {
     torch.bfloat16: "bfloat16",
@@ -79,8 +83,21 @@ def tilelang_matmul_func(a, b):
     accum_dtype = "float"
     num_stages = 2
     threads = 256
-    func = matmul(M, N, K, block_M, block_N, block_K, trans_A, trans_B, in_dtype, out_dtype,
-              accum_dtype, num_stages, threads)
+    func = matmul(
+        M,
+        N,
+        K,
+        block_M,
+        block_N,
+        block_K,
+        trans_A,
+        trans_B,
+        in_dtype,
+        out_dtype,
+        accum_dtype,
+        num_stages,
+        threads,
+    )
     jit_kernel = tilelang.compile(
         func,
         out_idx=[2],
@@ -88,5 +105,6 @@ def tilelang_matmul_func(a, b):
         pass_configs={
             tilelang.PassConfigKey.TL_DISABLE_TMA_LOWER: True,
             tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
-    })
+        },
+    )
     return lambda: jit_kernel(a, b_T)

--- a/tritonbench/operators/gemm/tilelang.py
+++ b/tritonbench/operators/gemm/tilelang.py
@@ -1,0 +1,91 @@
+import torch
+import tilelang
+import tilelang.language as T
+
+tilelang.disable_cache()
+
+
+def matmul(
+    M,
+    N,
+    K,
+    block_M,
+    block_N,
+    block_K,
+    trans_A,
+    trans_B,
+    in_dtype,
+    out_dtype,
+    accum_dtype,
+    num_stages,
+    threads,
+):
+    A_shape = (K, M) if trans_A else (M, K)
+    B_shape = (N, K) if trans_B else (K, N)
+    A_shared_shape = (block_K, block_M) if trans_A else (block_M, block_K)
+    B_shared_shape = (block_N, block_K) if trans_B else (block_K, block_N)
+
+    @T.prim_func
+    def main(
+            A: T.Tensor(A_shape, in_dtype),
+            B: T.Tensor(B_shape, in_dtype),
+            C: T.Tensor((M, N), out_dtype),
+    ):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=threads) as (bx, by):
+            A_shared = T.alloc_shared(A_shared_shape, in_dtype)
+            B_shared = T.alloc_shared(B_shared_shape, in_dtype)
+            C_tmem = T.alloc_tmem([block_M, block_N], accum_dtype)
+            mbar = T.alloc_barrier(1)
+            C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
+            C_shared = T.alloc_shared((block_M, block_N), out_dtype)
+
+            for k in T.Pipelined(T.ceildiv(K, block_K), num_stages=num_stages):
+                T.copy(A[by * block_M, k * block_K], A_shared)
+                T.copy(B[bx * block_N, k * block_K], B_shared)
+                T.gemm(
+                    A_shared,
+                    B_shared,
+                    C_tmem,
+                    trans_A,
+                    trans_B,
+                    mbar=mbar,
+                    wg_wait=-1,
+                    clear_accum=k == 0)
+                T.mbarrier_wait_parity(mbar, k % 2)
+
+            T.copy(C_tmem, C_local)
+            T.copy(C_local, C_shared)
+
+            T.copy(C_shared, C[by * block_M, bx * block_N])
+
+    return main
+
+TILELANG_DTYPE_MAP = {
+    torch.bfloat16: "bfloat16",
+    torch.float16: "float16",
+    torch.float32: "float",
+}
+
+
+def tilelang_matmul_func(a, b):
+    M, K = a.size()
+    K, N = b.size()
+    b_T = b.T.contiguous()
+    block_M, block_N, block_K = 128, 256, 128
+    trans_A, trans_B = False, True
+    in_dtype = TILELANG_DTYPE_MAP[a.dtype]
+    out_dtype = TILELANG_DTYPE_MAP[a.dtype]
+    accum_dtype = "float"
+    num_stages = 2
+    threads = 256
+    func = matmul(M, N, K, block_M, block_N, block_K, trans_A, trans_B, in_dtype, out_dtype,
+              accum_dtype, num_stages, threads)
+    jit_kernel = tilelang.compile(
+        func,
+        out_idx=[2],
+        target="cuda",
+        pass_configs={
+            tilelang.PassConfigKey.TL_DISABLE_TMA_LOWER: True,
+            tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
+    })
+    return lambda: jit_kernel(a, b_T)

--- a/tritonbench/operators/gemm/tilelang.py
+++ b/tritonbench/operators/gemm/tilelang.py
@@ -1,3 +1,4 @@
+# Original source: https://github.com/tile-ai/tilelang/blob/main/examples/gemm_sm100/gemm_tcgen5mma.py
 import torch
 import tilelang
 import tilelang.language as T

--- a/tritonbench/operators/rms_norm/operator.py
+++ b/tritonbench/operators/rms_norm/operator.py
@@ -4,6 +4,7 @@ from typing import Callable, Generator, List, Optional, Tuple
 import torch
 
 from tritonbench.utils.env_utils import is_hip
+from tritonbench.utils.python_utils import try_import
 
 from tritonbench.utils.triton_op import (
     BenchmarkOperator,
@@ -30,6 +31,9 @@ try:
     from .quack import QuackRMSNorm
 except ModuleNotFoundError:
     QuackRMSNorm = None
+
+with try_import("HAS_TILELANG"):
+    from .tilelang import rms_norm as tilelang_rms_norm
 
 
 def parse_op_args(args: List[str]):
@@ -151,6 +155,13 @@ class Operator(BenchmarkOperator):
         module = AITerRMSNorm(hidden_size=H, eps=self.eps).to(self.device)
         module.weight = weight
         self.aiter_rms_op = module
+        return lambda: module(input)
+
+    @register_benchmark(enabled=HAS_TILELANG)
+    def tilelang(self, H, input, weight) -> Callable:
+        module = TilelangRMSNorm(hidden_size=H, eps=self.eps).to(self.device)
+        module.weight = weight
+        self.tilelang_rms_op = module
         return lambda: module(input)
 
     @register_x_val(label="(M, H)")

--- a/tritonbench/operators/rms_norm/operator.py
+++ b/tritonbench/operators/rms_norm/operator.py
@@ -33,7 +33,7 @@ except ModuleNotFoundError:
     QuackRMSNorm = None
 
 with try_import("HAS_TILELANG"):
-    from .tilelang import rms_norm as tilelang_rms_norm
+    from .tilelang import TileLangRMSNorm
 
 
 def parse_op_args(args: List[str]):
@@ -159,9 +159,8 @@ class Operator(BenchmarkOperator):
 
     @register_benchmark(enabled=HAS_TILELANG)
     def tilelang(self, H, input, weight) -> Callable:
-        module = TilelangRMSNorm(hidden_size=H, eps=self.eps).to(self.device)
+        module = TileLangRMSNorm(hidden_size=H, eps=self.eps).to(self.device)
         module.weight = weight
-        self.tilelang_rms_op = module
         return lambda: module(input)
 
     @register_x_val(label="(M, H)")

--- a/tritonbench/operators/rms_norm/operator.py
+++ b/tritonbench/operators/rms_norm/operator.py
@@ -161,7 +161,7 @@ class Operator(BenchmarkOperator):
     def tilelang(self, H, input, weight) -> Callable:
         module = TileLangRMSNorm(hidden_size=H, eps=self.eps).to(self.device)
         module.weight = weight
-        return lambda: module(input)
+        return module(input)
 
     @register_x_val(label="(M, H)")
     def get_x_val(self, example_inputs) -> Tuple[int, int]:

--- a/tritonbench/operators/rms_norm/tilelang.py
+++ b/tritonbench/operators/rms_norm/tilelang.py
@@ -4,6 +4,8 @@ import torch
 import tilelang
 import tilelang.language as T
 
+tilelang.disable_cache()
+
 
 def rms_norm_splitk(M, N, blk_m, blk_k):
     dtype = "float"

--- a/tritonbench/operators/rms_norm/tilelang.py
+++ b/tritonbench/operators/rms_norm/tilelang.py
@@ -4,8 +4,6 @@ import torch
 import tilelang
 import tilelang.language as T
 
-tilelang.disable_cache()
-
 
 def rms_norm_splitk(M, N, blk_m, blk_k):
     dtype = "float"

--- a/tritonbench/operators/rms_norm/tilelang.py
+++ b/tritonbench/operators/rms_norm/tilelang.py
@@ -1,0 +1,71 @@
+import torch
+import tilelang
+import tilelang.language as T
+
+
+def rms_norm_splitk(M, N, blk_m, blk_k):
+    dtype = "float"
+
+    @T.prim_func
+    def main(A: T.Tensor((M, N), dtype), B: T.Tensor((M, N), dtype)):
+        with T.Kernel(T.ceildiv(M, blk_m), threads=128) as bx:
+            A_shared = T.alloc_shared((blk_m, blk_k), dtype)
+            A_local = T.alloc_fragment((blk_m, blk_k), dtype)
+            A_powsum = T.alloc_fragment((blk_m,), dtype)
+
+            num_k_step = T.ceildiv(N, blk_k)
+            T.clear(A_local)
+            for k in range(num_k_step):
+                T.copy(A[bx * blk_m, k * blk_k], A_shared)
+                for i, j in T.Parallel(blk_m, blk_k):
+                    A_local[i, j] += A_shared[i, j] * A_shared[i, j]
+            T.reduce_sum(A_local, A_powsum, dim=1)
+            for i in T.Parallel(blk_m):
+                A_powsum[i] = T.rsqrt(A_powsum[i] / N) + 1e-12
+
+            for k in range(num_k_step):
+                # reverse, better cache hit rate
+                T.copy(A[bx * blk_m, (num_k_step - 1 - k) * blk_k], A_shared)
+                for i, j in T.Parallel(blk_m, blk_k):
+                    A_shared[i, j] *= A_powsum[i]
+                T.copy(A_shared, B[bx * blk_m, (num_k_step - 1 - k) * blk_k])
+
+    return main
+
+@tilelang.jit(out_idx=[-1], pass_configs={"tl.disable_tma_lower": True})
+def rms_norm(M, N, blk_m, variance_epsilon=1e-12):
+    dtype = "float"
+
+    @T.prim_func
+    def main(A: T.Tensor((M, N), dtype), B: T.Tensor((M, N), dtype)):
+        with T.Kernel(T.ceildiv(M, blk_m), threads=128) as bx:
+            A_shared = T.alloc_shared((blk_m, N), dtype)
+            A_pow_local = T.alloc_fragment((blk_m, N), dtype)
+            A_local = T.alloc_fragment((blk_m, N), dtype)
+            A_powsum = T.alloc_fragment((blk_m,), dtype)
+
+            T.copy(A[bx * blk_m:(bx + 1) * blk_m, :], A_shared)
+            T.copy(A_shared, A_local)
+            for i, j in T.Parallel(blk_m, N):
+                A_pow_local[i, j] = A_local[i, j] * A_local[i, j]
+            T.reduce_sum(A_pow_local, A_powsum, dim=1)
+            for i in T.Parallel(blk_m):
+                A_powsum[i] = T.rsqrt(A_powsum[i] / N) + variance_epsilon
+            for i, j in T.Parallel(blk_m, N):
+                A_local[i, j] *= A_powsum[i]
+            T.copy(A_local, B[bx * blk_m:(bx + 1) * blk_m, :])
+
+    return main
+
+class TileLangRMSNorm(torch.nn.Module):
+    def __init__(self, hidden_size, eps=1e-6):
+        """
+        TileLangRMSNorm
+        """
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.ones(hidden_size))
+        self.variance_epsilon = eps
+
+    def forward(self, hidden_states):
+        M, N = hidden_states.size()
+        kernel = rms_norm(M, N, 1, self.variance_epsilon)

--- a/tritonbench/operators/rms_norm/tilelang.py
+++ b/tritonbench/operators/rms_norm/tilelang.py
@@ -1,6 +1,10 @@
+# Original source: 
+# https://github.com/tile-ai/tilelang/blob/main/examples/norm/test_rms_norm.py
 import torch
 import tilelang
 import tilelang.language as T
+
+tilelang.disable_cache()
 
 
 def rms_norm_splitk(M, N, blk_m, blk_k):
@@ -32,9 +36,8 @@ def rms_norm_splitk(M, N, blk_m, blk_k):
 
     return main
 
-@tilelang.jit(out_idx=[-1], pass_configs={"tl.disable_tma_lower": True})
-def rms_norm(M, N, blk_m, variance_epsilon=1e-12):
-    dtype = "float"
+
+def rms_norm(M, N, blk_m, dtype, variance_epsilon=1e-12):
 
     @T.prim_func
     def main(A: T.Tensor((M, N), dtype), B: T.Tensor((M, N), dtype)):
@@ -57,6 +60,13 @@ def rms_norm(M, N, blk_m, variance_epsilon=1e-12):
 
     return main
 
+TILELANG_DTYPE_MAP = {
+    torch.bfloat16: "bfloat16",
+    torch.float16: "float16",
+    torch.float32: "float",
+}
+
+
 class TileLangRMSNorm(torch.nn.Module):
     def __init__(self, hidden_size, eps=1e-6):
         """
@@ -68,4 +78,18 @@ class TileLangRMSNorm(torch.nn.Module):
 
     def forward(self, hidden_states):
         M, N = hidden_states.size()
-        kernel = rms_norm(M, N, 1, self.variance_epsilon)
+        dtype = TILELANG_DTYPE_MAP[hidden_states.dtype]
+        blk_m = 1
+        blk_k = 512
+
+        kernel = rms_norm(M, N, blk_m, dtype, self.variance_epsilon)
+        jit_kernel = tilelang.compile(
+            kernel,
+            out_idx=[-1],
+            target="cuda",
+            pass_configs={
+                tilelang.PassConfigKey.TL_DISABLE_TMA_LOWER: True,
+            }
+        )
+        return lambda: jit_kernel(hidden_states)
+

--- a/tritonbench/operators/rms_norm/tilelang.py
+++ b/tritonbench/operators/rms_norm/tilelang.py
@@ -1,8 +1,8 @@
-# Original source: 
+# Original source:
 # https://github.com/tile-ai/tilelang/blob/main/examples/norm/test_rms_norm.py
-import torch
 import tilelang
 import tilelang.language as T
+import torch
 
 tilelang.disable_cache()
 
@@ -38,7 +38,6 @@ def rms_norm_splitk(M, N, blk_m, blk_k):
 
 
 def rms_norm(M, N, blk_m, dtype, variance_epsilon=1e-12):
-
     @T.prim_func
     def main(A: T.Tensor((M, N), dtype), B: T.Tensor((M, N), dtype)):
         with T.Kernel(T.ceildiv(M, blk_m), threads=128) as bx:
@@ -47,7 +46,7 @@ def rms_norm(M, N, blk_m, dtype, variance_epsilon=1e-12):
             A_local = T.alloc_fragment((blk_m, N), dtype)
             A_powsum = T.alloc_fragment((blk_m,), dtype)
 
-            T.copy(A[bx * blk_m:(bx + 1) * blk_m, :], A_shared)
+            T.copy(A[bx * blk_m : (bx + 1) * blk_m, :], A_shared)
             T.copy(A_shared, A_local)
             for i, j in T.Parallel(blk_m, N):
                 A_pow_local[i, j] = A_local[i, j] * A_local[i, j]
@@ -56,9 +55,10 @@ def rms_norm(M, N, blk_m, dtype, variance_epsilon=1e-12):
                 A_powsum[i] = T.rsqrt(A_powsum[i] / N) + variance_epsilon
             for i, j in T.Parallel(blk_m, N):
                 A_local[i, j] *= A_powsum[i]
-            T.copy(A_local, B[bx * blk_m:(bx + 1) * blk_m, :])
+            T.copy(A_local, B[bx * blk_m : (bx + 1) * blk_m, :])
 
     return main
+
 
 TILELANG_DTYPE_MAP = {
     torch.bfloat16: "bfloat16",
@@ -89,7 +89,6 @@ class TileLangRMSNorm(torch.nn.Module):
             target="cuda",
             pass_configs={
                 tilelang.PassConfigKey.TL_DISABLE_TMA_LOWER: True,
-            }
+            },
         )
         return lambda: jit_kernel(hidden_states)
-

--- a/tritonbench/utils/env_utils.py
+++ b/tritonbench/utils/env_utils.py
@@ -74,8 +74,10 @@ def is_hip_mi300():
 def supports_tma():
     return is_cuda() and torch.cuda.get_device_capability()[0] >= 9
 
+
 def is_cu130():
     return is_cuda() and torch.version.cuda == "13.0"
+
 
 def set_env():
     # set cutlass dir

--- a/tritonbench/utils/env_utils.py
+++ b/tritonbench/utils/env_utils.py
@@ -74,6 +74,8 @@ def is_hip_mi300():
 def supports_tma():
     return is_cuda() and torch.cuda.get_device_capability()[0] >= 9
 
+def is_cu130():
+    return is_cuda() and torch.version.cuda == "13.0"
 
 def set_env():
     # set cutlass dir


### PR DESCRIPTION
Adding gemm and rms_norm tilelang kernels to compare with Triton and other operators.

TileLang requires minimum CUDA 12.9. The results are obtained on 13.0.

Test Plan:

====================== GEMM ====================
On B200:

TileLang example:
```
$ python gemm_tcgen5mma.py
Latency: 0.34409600496292114 ms
Flops: 798.8407391524935 TFLOPS
```

Tritonbench:
```
$ python run.py --op gemm --only aten_matmul,tilelang_blackwell_matmul,triton_blackwell_warpspec_persistent_matmul --m 4096 --n 4096 --k 8192 --precision bf16 --force --latency-measure-mode=profiler --cudagraph
         (M, N, K)    aten_matmul-latency    aten_matmul-tflops    tilelang_blackwell_matmul-latency    tilelang_blackwell_matmul-speedup    tilelang_blackwell_matmul-tflops    triton_blackwell_warpspec_persistent_matmul-latency    triton_blackwell_warpspec_persistent_matmul-speedup    triton_blackwell_warpspec_persistent_matmul-tflops
------------------  ---------------------  --------------------  -----------------------------------  -----------------------------------  ----------------------------------  -----------------------------------------------------  -----------------------------------------------------  ----------------------------------------------------
(4096, 4096, 8192)      0.226171 (±3.46%)               1215.35                    0.362883 (±5.09%)                             0.623262                             757.484                                      0.276269 (±4.20%)                                               0.818661                                               994.964
           average                                      1215.35                                                                  0.623262                             757.484                                                                                                      0.818661                                               994.964
```

The tflops number matches.


====================== RMS_NORM ====================

Tilelang Example:

```
$ python run.py --op rms_norm --only llama_rms,torch_compile_rms,tilelang,triton_fused_rmsnorm --metrics=latency,accuracy
       (M, H)    llama_rms-latency    torch_compile_rms-latency    torch_compile_rms-accuracy    tilelang-latency    tilelang-accuracy    triton_fused_rmsnorm-latency    triton_fused_rmsnorm-accuracy
-------------  -------------------  ---------------------------  ----------------------------  ------------------  -------------------  ------------------------------  -------------------------------
 (2048, 1024)    0.039936 (±1.04%)           0.009184 (±24.39%)                             1  0.010208 (±20.38%)                    1               0.048224 (±2.12%)                                1
 (2048, 2048)    0.050240 (±4.59%)           0.010944 (±12.57%)                             1  0.011072 (±10.98%)                    1               0.057312 (±6.76%)                                1
 (2048, 4096)    0.082976 (±1.04%)           0.017440 (±13.76%)                             1   0.017248 (±8.35%)                    1               0.087136 (±2.64%)                                1
 (2048, 8192)    0.148544 (±1.49%)            0.027712 (±8.43%)                             1   0.029728 (±7.64%)                    1               0.150624 (±1.49%)                                1
(2048, 16384)    0.275456 (±1.20%)            0.048160 (±4.98%)                             1   0.059392 (±3.66%)                    1               0.283840 (±1.48%)                                1
(2048, 32768)    0.514144 (±0.84%)            0.095200 (±4.50%)                             1   0.125088 (±1.66%)                    1               0.522208 (±0.73%)                                1
      average                                                                               1                                        1                                                                1
```

