### PR TITLE
Forward fix of forward only ops

### DIFF
--- a/tritonbench/operators/decoding_attention/operator.py
+++ b/tritonbench/operators/decoding_attention/operator.py
@@ -277,6 +277,7 @@ class Operator(BenchmarkOperator):
     DEFAULT_PRECISION = "bf16"
 
     DEFAULT_METRICS = ["latency", "speedup"]
+    FWD_ONLY = True
 
     def __init__(
         self, tb_args: argparse.Namespace, extra_args: Optional[List[str]] = None


### PR DESCRIPTION
Summary:
In D84065929 we require all ops to declare if they are forward only.

Add `FWD_ONLY = True` to internal ops.

Differential Revision: D84155460


