### PR TITLE
Use active driver benchmarker for do_bench measurements

### DIFF
--- a/tritonbench/components/do_bench/run.py
+++ b/tritonbench/components/do_bench/run.py
@@ -481,7 +481,7 @@ def do_bench_wrapper(
                 if latency_measure_mode == "profiler"
                 else _do_bench_inductor
                 if latency_measure_mode == "inductor_benchmarker"
-                else triton.testing.do_bench
+                else triton.runtime.driver.active.get_benchmarker()
             )
 
             return Latency(


### PR DESCRIPTION
Summary: Sometimes the triton backend may set a profiler to be different from the standard `do_bench` implmentation. For cuda this has no functional change, i.e. `triton.runtime.driver.active.get_benchmarker()` still points at `do_bench`.

Reviewed By: xuzhao9

Differential Revision: D84215437


