### PR TITLE
Improve failing input error message

### DIFF
--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -1142,7 +1142,7 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
             )
             if getattr(self, "_cur_input_id", None) is not None:
                 logger.warning(
-                    "Failing input: --input-id %s --num-inputs 1",
+                    "Failing input: --input-id %s --num-inputs 1 --input-sample-mode first-k",
                     self._cur_input_id,
                 )
             if self.tb_args.exit_on_exception:


### PR DESCRIPTION
The repro input id flags only works in `--input-sample-mode first-k` mode.