### PR TITLE
flash_attention: remove input shape that causes OOM across various backends

### DIFF
--- a/tritonbench/operators/flash_attention/operator.py
+++ b/tritonbench/operators/flash_attention/operator.py
@@ -566,7 +566,7 @@ class Operator(BenchmarkOperator):
                         yield (BATCH, self.H, SEQ_LEN, SEQ_LEN_KV, self.D_HEAD)
                         SEQ_LEN *= 2
                 return
-            for i in range(SEQ_LEN_LOG2, 15):
+            for i in range(SEQ_LEN_LOG2, 14):
                 N_CTX = 2**i
                 # BATCH = 16384 // N_CTX
                 # H = 2048 // D_HEAD


### PR DESCRIPTION
```
2025-10-11T12:55:09.4051935Z   (Batch, Heads, SeqLen, SeqLen_KV, Dhead)    flex_attention-speedup    flex_attention-accuracy    helion_attention-speedup    helion_attention-accuracy
2025-10-11T12:55:09.4052457Z ------------------------------------------  ------------------------  -------------------------  --------------------------  ---------------------------
2025-10-11T12:55:09.4052811Z                     (4, 48, 128, 128, 128)         1.536953561519681                        1.0                     3.06383                          1.0
2025-10-11T12:55:09.4053132Z                     (4, 48, 256, 256, 128)        2.1935440831897135                        1.0                     3.41165                          0.0
2025-10-11T12:55:09.4053444Z                   (4, 48, 1024, 1024, 128)         5.014317589040697                        1.0                     2.66505                          1.0
2025-10-11T12:55:09.4053752Z                   (4, 48, 2048, 2048, 128)         6.458828405732327                        1.0                     7.02111                          1.0
2025-10-11T12:55:09.4054070Z                   (4, 48, 8192, 8192, 128)         9.470944017684172                        1.0                     9.4448                           1.0
2025-10-11T12:55:09.4054394Z                 (4, 48, 16384, 16384, 128)                  CUDA OOM                   CUDA OOM                                                 CUDA OOM
2025-10-11T12:55:09.4054736Z                                    average         4.112431276194432         0.8333333333333334                     4.26774           0.6666666666666666
```