### PR TITLE
Disable triton_mm benchmark by default

### DIFF
--- a/tritonbench/operators/fp8_gemm_rowwise/operator.py
+++ b/tritonbench/operators/fp8_gemm_rowwise/operator.py
@@ -201,7 +201,8 @@ class Operator(BenchmarkOperator):
             use_warp_specialization=self.warp_specialization,
         )
 
-    @register_benchmark(enabled=HAS_TRITON)
+    # disabled by default due to shape incompatibility with the other kernels
+    @register_benchmark(enabled=False)
     def _aoti_fp8_triton_mm(self, xq, wq, x_scale, w_scale, bias) -> Callable:
         return lambda: aoti_fp8_triton_mm(
             xq,


### PR DESCRIPTION
Summary: Disable testing on the op by default, due to incompatibility of some [shapes](https://github.com/meta-pytorch/tritonbench/issues/509).

Reviewed By: jananisriram

Differential Revision: D84527186


