### PR TITLE
Skip blackwell attentions in the CI

### DIFF
--- a/test/test_gpu/skip_tests_h100_pytorch.yaml
+++ b/test/test_gpu/skip_tests_h100_pytorch.yaml
@@ -12,8 +12,8 @@ flash_attention:
   - triton_tutorial_flash_v2_ws
   - triton_tutorial_flash_v2_tma_ws
   - triton_tutorial_flash_v2_tma_ws_persistent
+# skip all blackwell kernels
 blackwell_attentions:
-  - gluon_blackwell_fwd
 # the two requires full fbgemm instead of genai flavor
 fp8_gemm_rowwise:
 fp8_gemm_rowwise_grouped:

--- a/test/test_gpu/skip_tests_h100_triton_main.yaml
+++ b/test/test_gpu/skip_tests_h100_triton_main.yaml
@@ -12,8 +12,8 @@ flash_attention:
   - triton_tutorial_flash_v2_ws
   - triton_tutorial_flash_v2_tma_ws
   - triton_tutorial_flash_v2_tma_ws_persistent
+# skip all blackwell kernels
 blackwell_attentions:
-  - gluon_blackwell_fwd
 # the two requires full fbgemm instead of genai flavor
 fp8_gemm_rowwise:
 fp8_gemm_rowwise_grouped:


### PR DESCRIPTION
Summary: More blackwell_attention kernels now rely on B200-only features, and it does not make sense to test them on H100.

Differential Revision: D84625519


