### PR TITLE
Print actual inputs IDs used at warn level

### DIFF
--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -877,7 +877,7 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
                 f"(total available: {self._available_num_inputs})",
             )
 
-        logger.info(
+        logger.warning(
             f"Input IDs to run: {self._input_ids}",
         )
 


### PR DESCRIPTION
... to ensure that it's always printed to typical CI logs.