### PR TITLE
[rocm] Add docker build to cron

### DIFF
--- a/.github/workflows/docker-rocm.yaml
+++ b/.github/workflows/docker-rocm.yaml
@@ -1,5 +1,8 @@
 name: TritonBench Nightly ROCM Docker Build
 on:
+  schedule:
+    # Push the nightly docker daily at 3 PM UTC
+    - cron: '0 15 * * *'
   pull_request:
     paths:
       - .github/workflows/docker-rocm.yaml


### PR DESCRIPTION
We are running nightly workflows everyday, so it needs to build the rocm docker