### PR TITLE
Update flex_attention sliding window size default to 4096

### DIFF
--- a/tritonbench/operators/flex_attention/operator.py
+++ b/tritonbench/operators/flex_attention/operator.py
@@ -108,7 +108,7 @@ def parse_op_args(args: List[str]):
         "--max-autotune", action="store_true", help="Whether to enable max autotune"
     )
     parser.add_argument(
-        "--sliding-window-size", type=int, default=128, help="sliding window size"
+        "--sliding-window-size", type=int, default=4096, help="sliding window size"
     )
     parser.add_argument("--prefix-length", type=int, default=128, help="prefix length")
     parser.add_argument(


### PR DESCRIPTION
Summary: Changed the default sliding window size from 128 to 4096 in the flex_attention operator. The larger default provides better performance characteristics for typical attention workloads and aligns with common use cases.

Differential Revision: D84878577


