### PR TITLE
Enable hw_roofline for MTIA

### DIFF
--- a/tritonbench/operators/vector_add/operator.py
+++ b/tritonbench/operators/vector_add/operator.py
@@ -16,6 +16,7 @@ from .kernels import triton_add_kernel
 class Operator(BenchmarkOperator):
     DEFAULT_METRICS = ["latency", "gbps"]
     FWD_ONLY = True
+    is_compute_bound = False
 
     @register_metric()
     def gbps(self, fn, example_inputs, metrics: BenchmarkOperatorMetrics):

--- a/tritonbench/utils/env_utils.py
+++ b/tritonbench/utils/env_utils.py
@@ -87,6 +87,10 @@ def is_tile_enabled():
     return os.getenv("ENABLE_TILE", "0") == "1"
 
 
+def is_mtia():
+    return triton.runtime.driver.active.get_current_target().backend == "mtia"
+
+
 def set_env():
     # set cutlass dir
     # by default we use the cutlass version built with pytorch

--- a/tritonbench/utils/gpu_utils.py
+++ b/tritonbench/utils/gpu_utils.py
@@ -4,6 +4,15 @@ import subprocess
 from contextlib import contextmanager
 from typing import Dict, List, Optional
 
+from tritonbench.utils.env_utils import is_mtia
+
+if is_mtia():
+    from tritonbench.utils.fb.mtia_utils import MTIA_COMPUTE_SPECS, MTIA_MEMORY_SPECS
+else:
+    MTIA_COMPUTE_SPECS = {}
+    MTIA_MEMORY_SPECS = {}
+
+
 # NVIDIA A100 GPU Spec:
 # https://www.nvidia.com/content/dam/en-zz/Solutions/Data-Center/a100/pdf/nvidia-a100-datasheet-us-nvidia-1758950-r4-web.pdf
 NV_A100 = {
@@ -55,6 +64,7 @@ HW_ROOFLINE_SPECS: Dict[
         "NVIDIA H100": NV_H100,
         "AMD MI300X": AMD_MI300X,
         "NVIDIA B200": NV_B200,
+        **MTIA_COMPUTE_SPECS,
     },
     False: {
         # https://www.nvidia.com/en-gb/data-center/h100
@@ -62,6 +72,7 @@ HW_ROOFLINE_SPECS: Dict[
         "NVIDIA H100": 2000,
         # https://www.amd.com/content/dam/amd/en/documents/instinct-tech-docs/data-sheets/amd-instinct-mi300x-platform-data-sheet.pdf
         "AMD MI300X": 5300,
+        **MTIA_MEMORY_SPECS,
     },
 }
 

--- a/tritonbench/utils/operator_utils.py
+++ b/tritonbench/utils/operator_utils.py
@@ -3,7 +3,7 @@ Utilities for getting operator details.
 """
 
 import sys
-from typing import Dict, List, Optional, OrderedDict, Union
+from typing import List, OrderedDict
 
 from tritonbench.operators import load_opbench_by_name
 

--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -45,6 +45,7 @@ from tritonbench.utils.env_utils import (
     apply_precision,
     is_fbcode,
     is_hip,
+    is_mtia,
     set_env,
     set_random_seed,
 )
@@ -2195,8 +2196,17 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
 
         rooflines = HW_ROOFLINE_SPECS[self.is_compute_bound]
 
+        def _get_mtia_device_name():
+            from tritonbench.utils.fb.mtia_utils import get_mtia_device_name
+
+            return get_mtia_device_name()
+
         device_name = (
-            torch.cuda.get_device_name() if not torch.version.hip else "AMD MI300X"
+            "AMD MI300X"
+            if torch.version.hip
+            else _get_mtia_device_name()
+            if is_mtia()
+            else torch.cuda.get_device_name()
         )
         assert (
             device_name in rooflines


### PR DESCRIPTION
Summary:
Adding roofline entry points for MTIA. We are currently expanding dicts, which are only defined if running on meta's code stack.

The internal diff has testing which demonstrates that cuda's rooflines continue to work.

Reviewed By: xuzhao9

Differential Revision: D84939499


