### PR TITLE
Migrate bmm, addmm, and other operators

### DIFF
--- a/tritonbench/data/loader.py
+++ b/tritonbench/data/loader.py
@@ -5,7 +5,14 @@ from typing import Any
 
 from tritonbench.utils.env_utils import is_fbcode
 
-SUPPORTED_INPUT_OPS = ["highway_self_gating", "grouped_gemm"]
+SUPPORTED_INPUT_OPS = [
+    "highway_self_gating",
+    "grouped_gemm",
+    "addmm",
+    "bmm",
+    "gemm",
+    "jagged_dense_dense_sum",
+]
 
 INPUT_CONFIG_DIR = Path(__file__).parent.joinpath("input_configs")
 INTERNAL_INPUT_CONFIG_DIR = (

--- a/tritonbench/operator_loader/aten/input_loader.py
+++ b/tritonbench/operator_loader/aten/input_loader.py
@@ -172,6 +172,8 @@ class OperatorInputLoader:
             obj = json.load(f)
 
         for operator in obj:
+            if operator == "metadata":
+                continue
             op_inps = Counter()
             for inputs in obj[operator]:
                 cnt = inputs["count"]

--- a/tritonbench/operators/addmm/__init__.py
+++ b/tritonbench/operators/addmm/__init__.py
@@ -1,1 +1,2 @@
+from .input_loader import InputLoader
 from .operator import Operator

--- a/tritonbench/operators/addmm/input_loader.py
+++ b/tritonbench/operators/addmm/input_loader.py
@@ -1,0 +1,70 @@
+"""
+Get input generator for TritonBench addmm type inputs.
+"""
+
+from typing import Callable
+
+import torch
+
+from tritonbench.operator_loader.aten.input_loader import OperatorInputLoader
+from tritonbench.utils.triton_op import PRECISION_DTYPE_MAPPING
+
+
+class InputLoader(OperatorInputLoader):
+    def __init__(self, tritonbench_op: str, op_name: str, json_file_path: str):
+        super().__init__(op_name, json_file_path)
+        self.op = tritonbench_op
+
+    def get_input_iter(
+        self,
+    ) -> Callable:
+        shapes = [eval(inp)[1] for inp, _cnt in self.operator_db[self.op_name].items()]
+        inputs = []
+        for entry in shapes:
+            M = int(entry["M"])
+            N = int(entry["N"])
+            K = int(entry["K"])
+            strides = eval(entry["strides"])
+            dtype = entry["dtype"]
+            assert (
+                len(strides) == 3
+            ), f"Can only have 3 strides from input, get: {strides}"
+            assert (
+                len(strides[0]) == 2 and len(strides[1]) == 2 and len(strides[2]) == 2
+            ), f"Can only deal with 2D strides, get: {strides}"
+            inputs.append(
+                {
+                    "shapes": (M, K, N),
+                    "dtype": dtype,
+                    "strides": strides,
+                }
+            )
+
+        def _inner():
+            requires_grad = self.op.requires_grad
+            device = self.op.device
+            for obj in inputs:
+                shapes = obj["shapes"]
+                dtype = PRECISION_DTYPE_MAPPING[obj["dtype"]]
+                strides = obj["strides"]
+                m, k, n = shapes
+                original_m = max(m, strides[1][1])
+                original_k = max(k, strides[1][0], strides[2][1])
+                original_n = max(n, strides[2][0])
+                a = torch.randn((m, n), device=device, dtype=dtype).requires_grad_(
+                    requires_grad
+                )
+                mat1 = torch.randn(
+                    (original_m, original_k), device=device, dtype=dtype
+                ).requires_grad_(requires_grad)
+                mat2 = torch.randn(
+                    (original_k, original_n), device=device, dtype=dtype
+                ).requires_grad_(requires_grad)
+                a = a.as_strided((m, n), strides[0])
+                mat1 = mat1.as_strided((m, k), strides[1])
+                mat2 = mat2.as_strided((k, n), strides[2])
+                if self.op.col_major:
+                    mat2 = mat2.T.contiguous().T
+                yield a, mat1, mat2
+
+        return _inner

--- a/tritonbench/operators/fp8_gemm/__init__.py
+++ b/tritonbench/operators/fp8_gemm/__init__.py
@@ -1,1 +1,2 @@
 from .fp8_gemm import Operator
+from .input_loader import InputLoader

--- a/tritonbench/operators/fp8_gemm/input_loader.py
+++ b/tritonbench/operators/fp8_gemm/input_loader.py
@@ -1,0 +1,39 @@
+"""
+Load input shapes from JSON data for FP8 GEMM operator.
+
+Expected op_inputs format:
+
+{
+    "fp8_gemm": [
+        {
+            "count": 1,
+            "duration_ms": 0.0106,
+            "inputs": "((), {'M': '192', 'N': '512', 'K': '512'})"
+        },
+        ...
+    ]
+}
+"""
+
+from typing import Callable
+
+from tritonbench.operator_loader.aten.input_loader import OperatorInputLoader
+
+
+class InputLoader(OperatorInputLoader):
+    def __init__(self, tritonbench_op: str, op_name: str, json_file_path: str):
+        super().__init__(op_name, json_file_path)
+        self.op = tritonbench_op
+
+    def get_input_iter(
+        self,
+    ) -> Callable:
+        shapes = [eval(inp)[1] for inp, _cnt in self.operator_db[self.op_name].items()]
+        all_shapes = []
+        for entry in shapes:
+            M = int(entry["M"])
+            N = int(entry["N"])
+            K = int(entry["K"])
+            all_shapes.append((M, N, K))
+        self.op.external_shapes = all_shapes
+        return self.op.get_input_iter

--- a/tritonbench/operators/gemm/__init__.py
+++ b/tritonbench/operators/gemm/__init__.py
@@ -1,1 +1,2 @@
+from .input_loader import InputLoader
 from .operator import Operator

--- a/tritonbench/operators/gemm/input_loader.py
+++ b/tritonbench/operators/gemm/input_loader.py
@@ -1,0 +1,68 @@
+"""
+Get input generator for TritonBench gemm type inputs.
+"""
+
+from typing import Callable
+
+from tritonbench.operator_loader.aten.input_loader import OperatorInputLoader
+from tritonbench.utils.triton_op import PRECISION_DTYPE_MAPPING
+
+
+class InputLoader(OperatorInputLoader):
+    def __init__(self, tritonbench_op: str, op_name: str, json_file_path: str):
+        super().__init__(op_name, json_file_path)
+        self.op = tritonbench_op
+
+    def get_input_iter(
+        self,
+    ) -> Callable:
+        shapes = [eval(inp)[1] for inp, _cnt in self.operator_db[self.op_name].items()]
+        inputs = []
+        for entry in shapes:
+            M = int(entry["M"])
+            N = int(entry["N"])
+            K = int(entry["K"])
+            strides = eval(entry["strides"])
+            dtype = entry["dtype"]
+            assert (
+                len(strides) == 2
+            ), f"Can only have 2 strides from input, get: {strides}"
+            assert (
+                len(strides[0]) == 2 and len(strides[1]) == 2
+            ), f"Can only deal with 2D strides, get: {strides}"
+            inputs.append(
+                {
+                    "shapes": (M, K, N),
+                    "dtype": dtype,
+                    "strides": strides,
+                }
+            )
+
+        def _inner():
+            requires_grad = self.op.requires_grad
+            device = self.op.device
+            for obj in inputs:
+                shapes = obj["shapes"]
+                dtype = PRECISION_DTYPE_MAPPING[obj["dtype"]]
+                strides = obj["strides"]
+                m, k, n = shapes
+                # The shape might from a tensor view, which is different from the original shape
+                # Try to infer the original shape from both shape and strides
+                actual_m = max(m, strides[0][1])
+                actual_k = max(k, strides[0][0], strides[1][1])
+                actual_n = max(n, strides[1][0])
+                a = self.op._scaled_randn(
+                    (actual_m, actual_k), scale=k, device=device, dtype=dtype
+                ).requires_grad_(requires_grad)
+                w = self.op._scaled_randn(
+                    (actual_k, actual_n), scale=k, device=device, dtype=dtype
+                ).requires_grad_(requires_grad)
+                a = a.as_strided(size=[m, k], stride=strides[0]).requires_grad_(
+                    requires_grad
+                )
+                w = w.as_strided(size=[k, n], stride=strides[1]).requires_grad_(
+                    requires_grad
+                )
+                yield a, w, None
+
+        return _inner

--- a/tritonbench/operators/gemm/operator.py
+++ b/tritonbench/operators/gemm/operator.py
@@ -556,6 +556,7 @@ class Operator(BenchmarkOperator):
         return (torch.randn(*args, **kwargs) + 1) / scale
 
     def get_input_iter(self) -> Generator:
+        requires_grad = self.requires_grad
         for shape_id, shape in enumerate(self.shapes):
             if len(shape) == 4:
                 m, n, k, bias = shape
@@ -564,47 +565,17 @@ class Operator(BenchmarkOperator):
                 bias = None
             else:
                 raise ValueError(f"Invalid shape {shape}")
-            if hasattr(self, "dtypes") and self.dtypes:
-                self.tb_args.precision = "bypass"
-                self.dtype = PRECISION_DTYPE_MAPPING[self.dtypes[shape_id]]
-            requires_grad = self.mode in (Mode.BWD, Mode.FWD_BWD)
-            if hasattr(self, "strides"):
-                strides = self.strides[shape_id]
-                assert (
-                    len(strides) == 2
-                ), f"Can only have 2 strides from input, get: {strides}"
-                assert (
-                    len(strides[0]) == 2 and len(strides[1]) == 2
-                ), f"Can only deal with 2D strides, get: {strides}"
-                # The shape might from a tensor view, which is different from the original shape
-                # Try to infer the original shape from both shape and strides
-                actual_m = max(m, strides[0][1])
-                actual_k = max(k, strides[0][0], strides[1][1])
-                actual_n = max(n, strides[1][0])
-                a = self._scaled_randn(
-                    (actual_m, actual_k), scale=k, device=self.device, dtype=self.dtype
-                ).requires_grad_(requires_grad)
-                w = self._scaled_randn(
-                    (actual_k, actual_n), scale=k, device=self.device, dtype=self.dtype
-                ).requires_grad_(requires_grad)
-                a = a.as_strided(size=[m, k], stride=strides[0]).requires_grad_(
-                    requires_grad
-                )
-                w = w.as_strided(size=[k, n], stride=strides[1]).requires_grad_(
-                    requires_grad
-                )
-            else:
-                a = self._scaled_randn(
-                    (m, k), scale=k, device=self.device, dtype=self.dtype
-                ).requires_grad_(requires_grad)
-                w = self._scaled_randn(
-                    (k, n), scale=k, device=self.device, dtype=self.dtype
-                ).requires_grad_(requires_grad)
-                # Convert inputs to column-major if layout is "n" (non-transposed)
-                if self.layout[0] == "n":
-                    a = a.T.contiguous().T.requires_grad_(requires_grad)
-                if self.layout[1] == "n":
-                    w = w.T.contiguous().T.requires_grad_(requires_grad)
+            a = self._scaled_randn(
+                (m, k), scale=k, device=self.device, dtype=self.dtype
+            ).requires_grad_(requires_grad)
+            w = self._scaled_randn(
+                (k, n), scale=k, device=self.device, dtype=self.dtype
+            ).requires_grad_(requires_grad)
+            # Convert inputs to column-major if layout is "n" (non-transposed)
+            if self.layout[0] == "n":
+                a = a.T.contiguous().T.requires_grad_(requires_grad)
+            if self.layout[1] == "n":
+                w = w.T.contiguous().T.requires_grad_(requires_grad)
             if not bias == None:
                 bias = torch.randn(
                     (bias), device=self.device, dtype=self.dtype

--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -106,6 +106,7 @@ PRECISION_DTYPE_MAPPING = {
     "tf32": torch.float32,
     "fp16": torch.float16,
     "bf16": torch.bfloat16,
+    "float": torch.float32,
 }
 _RANGE_NAME = "tritonbench_range"
 


### PR DESCRIPTION
Summary:
Migrate input config files to the new format. Now it supports multiple ops in the same file. The interface is also simplified.

Supported ops:

* gemm
* bmm
* addmm
* fp8_gemm
* group_gemm
* jagged_dense_dense_sum

Differential Revision: D84190515
