### PR TITLE
Enable roofline for mx4 <-> fp32

### DIFF
--- a/tritonbench/operators/mx4_to_fp32/operator.py
+++ b/tritonbench/operators/mx4_to_fp32/operator.py
@@ -2,13 +2,16 @@ import argparse
 from typing import Callable, Generator, List, Optional, Tuple
 
 import torch
+from tritonbench.utils.jagged_utils import GIGABYTES_PER_BYTE
 
 # We are benchmarking the kernel used inside quantize_comm. Insofar, we are using the fp32_to_mx4 fbgemm API rather than the quantize_mx API.
 
 from tritonbench.utils.python_utils import try_import
 from tritonbench.utils.triton_op import (
     BenchmarkOperator,
+    BenchmarkOperatorMetrics,
     register_benchmark,
+    register_metric,
     register_x_val,
 )
 
@@ -17,6 +20,8 @@ with try_import("HAS_FBGEMM"):
 
 
 class Operator(BenchmarkOperator):
+    is_compute_bound: bool = False
+
     def __init__(
         self, tb_args: argparse.Namespace, extra_args: Optional[List[str]] = None
     ):
@@ -53,3 +58,24 @@ class Operator(BenchmarkOperator):
     def get_x_val(self, example_inputs) -> Tuple[int, int, int, int]:
         input_tensor, group_size, ebits, mbits = example_inputs
         return (input_tensor.numel(), group_size, ebits, mbits)
+
+    @register_metric()
+    def gbps(
+        self,
+        fn,
+        example_inputs: Tuple[torch.Tensor, int, int, int],
+        metrics: BenchmarkOperatorMetrics,
+    ) -> float:
+        # mx4_to_fp32: a[M / 2 + M / group_size] (int 8) -> out[M]
+        packed_group_size = example_inputs[1] // 2 + 1
+        num_groups = example_inputs[0].numel() // packed_group_size
+        out_size = num_groups * example_inputs[1]
+        return (
+            (
+                example_inputs[0].element_size() * example_inputs[0].numel()
+                + out_size * 4
+            )
+            / metrics.latency
+            * 1e3
+            * GIGABYTES_PER_BYTE
+        )


### PR DESCRIPTION
Summary:
Adding gbps metric and setting kernels as memory bound for `mx4_to_fp32` and `fp32_to_mx4`. On H100, we see

```
<tritonbench run>  --op mx4_to_fp32 --device cuda --metrics gbps,hw_roofline,latency
```
prints
```
  (Size, Group Size, ebits, mbits)    hw_roofline    fbgemm_mx4_to_fp32-gbps    fbgemm_mx4_to_fp32-latency
----------------------------------  -------------  -------------------------  ----------------------------
                  (6392, 32, 2, 1)           2000                     8.6048             0.006336 (±7.07%)
                (278528, 32, 2, 1)           2000                   335.928              0.007072 (±8.14%)
              (17825792, 32, 2, 1)           2000                  1874.3                0.081120 (±1.70%)
              (17825809, 32, 2, 1)           2000                  1879.5                0.080896 (±1.90%)
```

```
<tritonbench run>  --op fp32_to_mx4 --device cuda --metrics gbps,hw_roofline,latency
```
prints
```
  (Size, Group Size, ebits, mbits, rounding_mode, stochastic_casting)    hw_roofline    fbgemm_fp32_to_mx4-gbps    fbgemm_fp32_to_mx4-latency
---------------------------------------------------------------------  -------------  -------------------------  ----------------------------
                     (24048, 32, 2, 1, <RoundingMode.even: 2>, False)           2000                    15.6924             0.006944 (±6.91%)
                   (1048576, 32, 2, 1, <RoundingMode.even: 2>, False)           2000                   412.444              0.011520 (±5.00%)
                  (67108864, 32, 2, 1, <RoundingMode.even: 2>, False)           2000                  1734.07               0.175360 (±0.53%)
                  (67108880, 32, 2, 1, <RoundingMode.even: 2>, False)           2000                  1733.76               0.175392 (±0.64%)
```

Differential Revision: D85782147


