### PR TITLE
Refactor input loaders

### DIFF
--- a/tritonbench/data/__init__.py
+++ b/tritonbench/data/__init__.py
@@ -1,6 +1,1 @@
-from .loader import (
-    get_input_loader,
-    INPUT_CONFIG_DIR,
-    INTERNAL_INPUT_CONFIG_DIR,
-    SUPPORTED_INPUT_OPS,
-)
+from .loader import get_input_loader

--- a/tritonbench/data/loader.py
+++ b/tritonbench/data/loader.py
@@ -1,7 +1,8 @@
 import importlib
+import json
 import os
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 
 from tritonbench.utils.env_utils import is_fbcode
 
@@ -22,20 +23,69 @@ INTERNAL_INPUT_CONFIG_DIR = (
 )
 
 
-def get_input_loader(tritonbench_op: Any, op: str, input: str):
-    assert (
-        hasattr(tritonbench_op, "aten_op_name") or op in SUPPORTED_INPUT_OPS
-    ), f"Unsupported op: {op}. "
+def get_input_config_path(input_config_short_path: str):
+    if os.path.exists(input_config_short_path):
+        input_file_path = Path(input_config_short_path)
+    elif INPUT_CONFIG_DIR.joinpath(input_config_short_path).exists():
+        input_file_path = INPUT_CONFIG_DIR.joinpath(input_config_short_path)
+    elif INTERNAL_INPUT_CONFIG_DIR.joinpath(input_config_short_path).exists():
+        input_file_path = INTERNAL_INPUT_CONFIG_DIR.joinpath(input_config_short_path)
+    else:
+        raise RuntimeError(f"Input file {input_config_short_path} does not exist.")
+    return input_file_path
+
+
+def get_input_loader(
+    tritonbench_op: Any, input: Optional[str] = None, loader="builtin"
+):
+    """Dispatch input loader based on op name and loader type."""
+    op_name = (
+        tritonbench_op.aten_op_name
+        if hasattr(tritonbench_op, "aten_op_name")
+        else tritonbench_op.name
+    )
+
+    if hasattr(tritonbench_op, "aten_op_name"):
+        loader = "aten"
+    if loader == "jagged":
+        # default config for all jagged inputs
+        input = "durin_20250402/jagged_dense_dense_sum.json" if not input else input
+    input_file_path = get_input_config_path(input)
+
+    with open(input_file_path, "r") as f:
+        input_config = json.load(f)
+
+    # Sanity checks
+    if "metadata" in input_config and "tritonbench_loader" in input_config["metadata"]:
+        loader = input_config["metadata"]["tritonbench_loader"]
+    if loader == "builtin":
+        assert (
+            hasattr(tritonbench_op, "aten_op_name") or op_name in SUPPORTED_INPUT_OPS
+        ), f"Unsupported op by builtin loader: {op_name}. "
+
+    # Load jagged inputs
+    if loader == "jagged" and is_fbcode():
+        from .input_loaders.fb.jagged import InputLoader
+
+        return InputLoader(tritonbench_op, input_config).get_input_iter()
+    # Load operator warehouse inputs
+    elif loader == "operator_warehouse" and is_fbcode():
+        from .input_loaders.fb.operator_warehouse import (
+            get_input_iter as get_input_iter_ow,
+        )
+
+        return get_input_iter_ow(tritonbench_op, [input_config])
+
     op_module = ".".join(tritonbench_op.__module__.split(".")[:-1])
     generator_module = importlib.import_module(op_module)
     input_loader_cls = generator_module.InputLoader
-    if os.path.exists(input):
-        input_file_path = Path(input)
-    elif INPUT_CONFIG_DIR.joinpath(input).exists():
-        input_file_path = INPUT_CONFIG_DIR.joinpath(input)
-    elif INTERNAL_INPUT_CONFIG_DIR.joinpath(input).exists():
-        input_file_path = INTERNAL_INPUT_CONFIG_DIR.joinpath(input)
+    # Load aten inputs
+    if loader == "aten":
+        operator_inputs_loader = input_loader_cls(op_name, input_config)
+        return operator_inputs_loader.get_input_iter()
+    # Load builtin inputs
+    elif loader == "builtin":
+        input_loader = input_loader_cls(tritonbench_op, input_config)
+        return input_loader.get_input_iter()
     else:
-        raise RuntimeError(f"Input file {input} does not exist.")
-    input_loader = input_loader_cls(tritonbench_op, op, input_file_path)
-    return input_loader.get_input_iter()
+        raise ValueError(f"Unsupported input loader name: {loader}")

--- a/tritonbench/operator_loader/aten/__init__.py
+++ b/tritonbench/operator_loader/aten/__init__.py
@@ -1,1 +1,2 @@
+from .input_loader import OperatorInputLoader as InputLoader
 from .op_loader import get_aten_loader_cls_by_name, list_aten_ops

--- a/tritonbench/operators/addmm/input_loader.py
+++ b/tritonbench/operators/addmm/input_loader.py
@@ -2,7 +2,7 @@
 Get input generator for TritonBench addmm type inputs.
 """
 
-from typing import Callable
+from typing import Any, Callable
 
 import torch
 
@@ -11,8 +11,8 @@ from tritonbench.utils.triton_op import PRECISION_DTYPE_MAPPING
 
 
 class InputLoader(OperatorInputLoader):
-    def __init__(self, tritonbench_op: str, op_name: str, json_file_path: str):
-        super().__init__(op_name, json_file_path)
+    def __init__(self, tritonbench_op: str, input_config: Any):
+        super().__init__(tritonbench_op.name, input_config)
         self.op = tritonbench_op
 
     def get_input_iter(

--- a/tritonbench/operators/fp8_gemm/input_loader.py
+++ b/tritonbench/operators/fp8_gemm/input_loader.py
@@ -15,14 +15,14 @@ Expected op_inputs format:
 }
 """
 
-from typing import Callable
+from typing import Any, Callable
 
 from tritonbench.operator_loader.aten.input_loader import OperatorInputLoader
 
 
 class InputLoader(OperatorInputLoader):
-    def __init__(self, tritonbench_op: str, op_name: str, json_file_path: str):
-        super().__init__(op_name, json_file_path)
+    def __init__(self, tritonbench_op: str, input_config: Any):
+        super().__init__(tritonbench_op.name, input_config)
         self.op = tritonbench_op
 
     def get_input_iter(

--- a/tritonbench/operators/gemm/input_loader.py
+++ b/tritonbench/operators/gemm/input_loader.py
@@ -2,15 +2,15 @@
 Get input generator for TritonBench gemm type inputs.
 """
 
-from typing import Callable
+from typing import Any, Callable
 
 from tritonbench.operator_loader.aten.input_loader import OperatorInputLoader
 from tritonbench.utils.triton_op import PRECISION_DTYPE_MAPPING
 
 
 class InputLoader(OperatorInputLoader):
-    def __init__(self, tritonbench_op: str, op_name: str, json_file_path: str):
-        super().__init__(op_name, json_file_path)
+    def __init__(self, tritonbench_op: str, input_config: Any):
+        super().__init__(tritonbench_op.name, input_config)
         self.op = tritonbench_op
 
     def get_input_iter(

--- a/tritonbench/operators/grouped_gemm/input_loader.py
+++ b/tritonbench/operators/grouped_gemm/input_loader.py
@@ -2,14 +2,14 @@
 Input loader for Grouped GEMM operator.
 """
 
-from typing import Callable
+from typing import Any, Callable
 
 from tritonbench.operator_loader.aten.input_loader import OperatorInputLoader
 
 
 class InputLoader(OperatorInputLoader):
-    def __init__(self, tritonbench_op: str, op_name: str, json_file_path: str):
-        super().__init__(op_name, json_file_path)
+    def __init__(self, tritonbench_op: str, input_config: Any):
+        super().__init__(tritonbench_op.name, input_config)
         self.op = tritonbench_op
 
     def get_input_iter(

--- a/tritonbench/operators/jagged_softmax/operator.py
+++ b/tritonbench/operators/jagged_softmax/operator.py
@@ -8,6 +8,8 @@ from typing import Callable, Generator, List, Optional, Tuple
 import torch
 import triton
 
+from tritonbench.data import get_input_loader
+
 from tritonbench.utils.jagged_utils import (
     ABSOLUTE_TOLERANCE,
     generate_input_vals,
@@ -204,9 +206,7 @@ class Operator(BenchmarkOperator):
             ):
                 yield (nt, B, M, max_seqlen, sparsity)
         else:
-            from tritonbench.data.fb.input_loader import get_input_loader_jagged
-
-            loader = get_input_loader_jagged(self)
+            loader = get_input_loader(self, loader="jagged")
             for jagged_values, jagged_offsets, dense_0, _ in loader():
                 nested_tensor = jagged_to_nested_tensor(jagged_values, jagged_offsets)
                 # Yueming: in the future, if we integrate more input shapes for other jagged operators,

--- a/tritonbench/operators/jagged_sum/operator.py
+++ b/tritonbench/operators/jagged_sum/operator.py
@@ -5,6 +5,8 @@ from typing import Any, Callable, Generator, List, Optional, Tuple
 import torch
 import triton
 
+from tritonbench.data import get_input_loader
+
 from tritonbench.utils.jagged_utils import (
     ABSOLUTE_TOLERANCE,
     generate_input_vals,
@@ -208,9 +210,7 @@ class Operator(BenchmarkOperator):
                 RANDOM_CHOICE_MARGIN=RANDOM_CHOICE_MARGIN,
             )
         else:
-            from tritonbench.data.fb.input_loader import get_input_loader_jagged
-
-            loader = get_input_loader_jagged(self)
+            loader = get_input_loader(self, loader="jagged")
             for jagged_values, jagged_offsets, dense_0, _ in loader():
                 nested_tensor = jagged_to_nested_tensor(jagged_values, jagged_offsets)
                 # Yueming: in the future, if we integrate more input shapes for other jagged operators,

--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -34,7 +34,7 @@ from tritonbench.components.do_bench import do_bench_wrapper, Latency
 from tritonbench.components.export import export_data
 
 from tritonbench.components.power import PowerManagerTask
-from tritonbench.data import SUPPORTED_INPUT_OPS
+from tritonbench.data import get_input_loader
 from tritonbench.utils.constants import (
     DEFAULT_POWER_REPCNT,
     DEFAULT_QUANTILES,
@@ -808,22 +808,7 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
     # Run the post initialization
     def __post__init__(self):
         if self.tb_args.input_loader:
-            if (
-                is_fbcode()
-                and not hasattr(self, "aten_op_name")
-                and self.name not in SUPPORTED_INPUT_OPS
-            ):
-                from tritonbench.data.fb.input_loader import get_input_loader
-
-                self.get_input_iter = get_input_loader(
-                    self, self.name, self.tb_args.input_loader
-                )
-            else:
-                from tritonbench.data import get_input_loader
-
-                self.get_input_iter = get_input_loader(
-                    self, self.name, self.tb_args.input_loader
-                )
+            self.get_input_iter = get_input_loader(self, self.tb_args.input_loader)
         # Count total available inputs directly
         self._available_num_inputs = sum(1 for _ in self.get_input_iter())
 


### PR DESCRIPTION
Summary:
Refactor input loader so that it takes a unified entrypoint at `tritonbench.data.get_input_loader()`.

Tested on operators:

* jagged_dense_dense_sum: default inputs, --input-loader (jagged)
* jagged_sum: --prod-shapes (jagged)
* jagged_dense_bmm: --input-loader (operator warehouse)
* concat_2d_jagged: --input-loader (operator warehouse)
* jagged_flash_attention_v2: --input-loader (operator warehouse)
* addmm: --input-loader (builtin)

Differential Revision: D85770734
