### PR TITLE
fix paths

### DIFF
--- a/tritonbench/utils/run_utils.py
+++ b/tritonbench/utils/run_utils.py
@@ -204,7 +204,7 @@ def _run(args: argparse.Namespace, extra_args: List[str]) -> BenchmarkOperatorRe
     finally:
         metrics = opbench.output
         if is_fbcode() and args.log_scuba:
-            from tritonbench.fb.utils import log_benchmark  # @manual
+            from .fb.utils import log_benchmark  # @manual
 
             kwargs = {
                 "metrics": metrics,


### PR DESCRIPTION
Summary: when we moved run calls to run_utils we didnt fix the paths for the fb.utils files

Differential Revision: D85867763
