### PR TITLE
Fix TritonParse Output Path Format

### DIFF
--- a/tritonbench/utils/tritonparse_utils.py
+++ b/tritonbench/utils/tritonparse_utils.py
@@ -68,7 +68,7 @@ def tritonparse_parse(tritonparse_log_path):
             if is_fbcode():
                 out = None
             else:
-                out = (f"{tritonparse_log_path}/parsed_logs",)
+                out = f"{tritonparse_log_path}/parsed_logs"
             unified_parse(
                 f"{tritonparse_log_path}/raw_logs",
                 out=out,


### PR DESCRIPTION

## Overview
Fixed incorrect tuple wrapping of the output path parameter in `tritonparse_parse()` function.

## Changes
- **File**: `tritonbench/utils/tritonparse_utils.py`
- **Change**: Changed `out = (f"{tritonparse_log_path}/parsed_logs",)` to `out = f"{tritonparse_log_path}/parsed_logs"`
- **Impact**: The output path is now correctly passed as a string instead of a single-element tuple

## Problem
The `unified_parse()` function expects a string path for the `out` parameter, but a tuple was being passed instead. This caused incorrect behavior when parsing tritonparse logs in non-fbcode environments.

## Solution
Removed the unnecessary parentheses and comma that were creating a tuple wrapper around the output path string.

## Testing
Verified that tritonparse integration works correctly by running:
```bash
python run.py --op embedding --num-inputs 1 --tritonparse /tmp/yhao/tp_traces/pta/
```

Successfully generated parsed logs with the correct output:
- Generated 3 files in `/tmp/yhao/tp_traces/pta/parsed_logs/`
- Parsing completed successfully
