### PR TITLE
Print input ID's corresponding input shape after each run

### DIFF
--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -1135,6 +1135,9 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
                     _reduce_benchmarks, benchmarks, {}
                 )
                 metrics.append((x_val, y_vals))
+                logger.warning(
+                    f"Completed input ID {input_id}:\n{table}",
+                )
                 self._cur_backend_name = None
                 del self.example_inputs  # save some memory
                 if "proton" in self.required_metrics:


### PR DESCRIPTION
Sometimes the run for a specific shape will generated lots of log, and it's hard to figure out which input shape we are running at end of that run. This PR helps us surface it.