### PR TITLE
Fix Matmul config issues

### DIFF
--- a/tritonbench/operators/gemm/triton_matmul_configs.py
+++ b/tritonbench/operators/gemm/triton_matmul_configs.py
@@ -320,22 +320,25 @@ def get_tileir_configs():
     block_mnk_range = [16, 32, 64, 128, 256]
     occ_range = [1, 2]
     num_ctas_range = [1, 2]
+    num_stages_range = [1, 2, 3, 4, 5]
     configs = []
     for block_m in block_mnk_range:
         for block_n in block_mnk_range:
             for block_k in block_mnk_range:
                 for occ in occ_range:
                     for num_ctas in num_ctas_range:
-                        configs.append(
-                            triton.Config(
-                                {
-                                    "BLOCK_M": block_m,
-                                    "BLOCK_N": block_n,
-                                    "BLOCK_K": block_k,
-                                    "GROUP_M": 8,
-                                    "occupancy": occ,
-                                },
-                                num_ctas=num_ctas,
+                        for num_stages in num_stages_range:
+                            configs.append(
+                                triton.Config(
+                                    {
+                                        "BLOCK_M": block_m,
+                                        "BLOCK_N": block_n,
+                                        "BLOCK_K": block_k,
+                                        "GROUP_M": 8,
+                                        "occupancy": occ,
+                                    },
+                                    num_ctas=num_ctas,
+                                    num_stages=num_stages,
+                                )
                             )
-                        )
     return configs

--- a/tritonbench/operators/gemm/warp_spec_persistent_matmul.py
+++ b/tritonbench/operators/gemm/warp_spec_persistent_matmul.py
@@ -85,6 +85,9 @@ def matmul_get_configs(pre_hook=None):
                 triton.Config(
                     new_kwargs,
                     pre_hook=pre_hook,
+                    num_stages=config.num_stages,
+                    num_ctas=config.num_ctas,
+                    num_warps=config.num_warps,
                 )
             )
         return configs
@@ -283,6 +286,9 @@ def matmul_tma_persistent_get_configs(pre_hook=None):
                             **new_kwargs,
                         },
                         pre_hook=pre_hook,
+                        num_stages=config.num_stages,
+                        num_ctas=config.num_ctas,
+                        num_warps=config.num_warps,
                     )
                 )
         return configs


### PR DESCRIPTION
Summary:
Fixes 2 issues noted by our partners at Nvidia:

1. num_stages should be set as it controls the latency cost model parameter right now (I was wrong). It should be a value between 1-5.
2. The warp spec templates didn't propagate the num_ctas information.

Differential Revision: D87289927


