### PR TITLE
Allow specifiying the use of persistent kernel

### DIFF
--- a/tritonbench/operators/fp8_gemm_rowwise/operator.py
+++ b/tritonbench/operators/fp8_gemm_rowwise/operator.py
@@ -49,6 +49,14 @@ def parse_args(args: List[str]) -> argparse.Namespace:
         action="store_true",
     )
     parser.add_argument("--warp_specialization", action="store_true")
+
+    # Validate that both --use_persistent and --no_use_persistent are not specified together
+    if "--use_persistent" in args and "--no_use_persistent" in args:
+        parser.error(
+            "Cannot specify both '--use_persistent' and '--no_use_persistent' at the same time. "
+            "These options are mutually exclusive. Please use only one."
+        )
+
     parsed_args = parser.parse_args(args)
     if parsed_args.use_tma is None:
         # Default to True for CUDA, False for ROCm


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/FBGEMM/pull/5129

X-link: https://github.com/facebookresearch/FBGEMM/pull/2130

Added environment argument "use_persistent" (default is False) to explicitly turn off non-persistent kernel and use persistent kernel.
Throws error when both "use_persistent" and "no_use_persistent" are specified in the arguments.
Example usage:
Persistent kernel--
buck2 run mode/{dev-nosan,amd-gpu} -c xlog.level=WARNING -m ovr_config//triton:trunk -m rocm7 -c fbcode.nvcc_arch=mi350 -c fbcode.enable_gpu_sections=true pytorch/tritonbench:run -- --op fp8_gemm_rowwise --no_use_tma --use_persistent
Non-persistent kernel--
buck2 run mode/{dev-nosan,amd-gpu} -c xlog.level=WARNING -m ovr_config//triton:trunk -m rocm7 -c fbcode.nvcc_arch=mi350 -c fbcode.enable_gpu_sections=true pytorch/tritonbench:run -- --op fp8_gemm_rowwise --no_use_tma --no_use_persistent

When both specified in the arguments:
buck2 run mode/{dev-nosan,amd-gpu} -c xlog.level=WARNING -m ovr_config//triton:trunk -m rocm7 -c fbcode.nvcc_arch=mi350 -c fbcode.enable_gpu_sections=true pytorch/tritonbench:run -- --op fp8_gemm_rowwise --no_use_tma --use_persistent --no_use_persistent
IT WILL THROW ERROR: Cannot specify both '--use_persistent' and '--no_use_persistent' at the same time. These options are mutually exclusive. Please use only one.

Reviewed By: adamomainz, jwfromm

Differential Revision: D86579911


