### PR TITLE
[autows] set subtile_p to be false by default

### DIFF
--- a/tritonbench/kernels/blackwell_triton_fused_attention_dp.py
+++ b/tritonbench/kernels/blackwell_triton_fused_attention_dp.py
@@ -305,7 +305,7 @@ if is_tile_enabled():
         for BN in [64, 128]
         for occ in [1, 2]
         for subtile in [True]
-        for subtile_p in [True]
+        for subtile_p in [False]
         for vectmul in [0]
         for add2reduce in [False]
     ]
@@ -347,7 +347,7 @@ else:
         for s in NUM_STAGES_OPTIONS
         for w in [4]
         for subtile in [True]
-        for subtile_p in [True]
+        for subtile_p in [False]
         for vectmul in [1]
         for add2reduce in [False]
         for maxreg in [152, 192]


### PR DESCRIPTION
Fix for automatic regression detected for benchmark_tritonbench_bf16_gemm_mi300x

Stacked PRs:
 * __->__#656


--- --- ---

### [autows] set subtile_p to be false by default

