### PR TITLE
Add run configs for fp8_gemm BlockWise scaling variants

### DIFF
--- a/benchmarks/run_config/fp8_gemm_h100_blockwise1x128_blockwise128x128_large_K.yaml
+++ b/benchmarks/run_config/fp8_gemm_h100_blockwise1x128_blockwise128x128_large_K.yaml
@@ -1,0 +1,4 @@
+fp8_gemm_h100_blockwise1x128_blockwise128x128_large_K:
+  op: fp8_gemm
+  args: --op fp8_gemm --only pt2_fp8_gemm --metrics tflops --scaling-pair=BlockWise1x128,BlockWise128x128 --m 2048 --n 4096 --k 12800 --simple-output
+  envs: TORCHINDUCTOR_AUTOTUNE_IN_SUBPROC=1 TRITON_PRINT_AUTOTUNING=1 TRITON_ALWAYS_COMPILE=1 ENABLE_PERSISTENT_TMA_MATMUL=1 TORCHINDUCTOR_MAX_AUTOTUNE_GEMM=1 TORCH_LOGS=+inductor TORCHINDUCTOR_FORCE_DISABLE_CACHES=1

--- a/benchmarks/run_config/fp8_gemm_h100_blockwise1x128_blockwise128x128_medium_K.yaml
+++ b/benchmarks/run_config/fp8_gemm_h100_blockwise1x128_blockwise128x128_medium_K.yaml
@@ -1,0 +1,4 @@
+fp8_gemm_h100_blockwise1x128_blockwise128x128_medium_K:
+  op: fp8_gemm
+  args: --op fp8_gemm --only pt2_fp8_gemm --metrics tflops --scaling-pair=BlockWise1x128,BlockWise128x128 --m 2048 --n 4096 --k 2560 --simple-output
+  envs: TORCHINDUCTOR_AUTOTUNE_IN_SUBPROC=1 TRITON_PRINT_AUTOTUNING=1 TRITON_ALWAYS_COMPILE=1 ENABLE_PERSISTENT_TMA_MATMUL=1 TORCHINDUCTOR_MAX_AUTOTUNE_GEMM=1 TORCH_LOGS=+inductor TORCHINDUCTOR_FORCE_DISABLE_CACHES=1

--- a/benchmarks/run_config/fp8_gemm_h100_blockwise1x128_blockwise1x128_large_K.yaml
+++ b/benchmarks/run_config/fp8_gemm_h100_blockwise1x128_blockwise1x128_large_K.yaml
@@ -1,0 +1,4 @@
+fp8_gemm_h100_blockwise1x128_blockwise1x128_large_K:
+  op: fp8_gemm
+  args: --op fp8_gemm --only pt2_fp8_gemm --metrics tflops --scaling-pair=BlockWise1x128,BlockWise1x128 --m 2048 --n 4096 --k 12800 --simple-output
+  envs: TORCHINDUCTOR_AUTOTUNE_IN_SUBPROC=1 TRITON_PRINT_AUTOTUNING=1 TRITON_ALWAYS_COMPILE=1 ENABLE_PERSISTENT_TMA_MATMUL=1 TORCHINDUCTOR_MAX_AUTOTUNE_GEMM=1 TORCH_LOGS=+inductor TORCHINDUCTOR_FORCE_DISABLE_CACHES=1

--- a/benchmarks/run_config/fp8_gemm_h100_blockwise1x128_blockwise1x128_medium_K.yaml
+++ b/benchmarks/run_config/fp8_gemm_h100_blockwise1x128_blockwise1x128_medium_K.yaml
@@ -1,0 +1,4 @@
+fp8_gemm_h100_blockwise1x128_blockwise1x128_medium_K:
+  op: fp8_gemm
+  args: --op fp8_gemm --only pt2_fp8_gemm --metrics tflops --scaling-pair=BlockWise1x128,BlockWise1x128 --m 2048 --n 4096 --k 2560 --simple-output
+  envs: TORCHINDUCTOR_AUTOTUNE_IN_SUBPROC=1 TRITON_PRINT_AUTOTUNING=1 TRITON_ALWAYS_COMPILE=1 ENABLE_PERSISTENT_TMA_MATMUL=1 TORCHINDUCTOR_MAX_AUTOTUNE_GEMM=1 TORCH_LOGS=+inductor TORCHINDUCTOR_FORCE_DISABLE_CACHES=1


### PR DESCRIPTION
Summary:
Add run configs for `fp8_gemm` to tune the following scaling variants:
- `BlockWise1x128` x `BlockWise128x128` (Deepseek-style)
- `BlockWise1x128` x `BlockWise1x128`

Differential Revision: D87597866


