### PR TITLE
Enable printing latency metric with simple mode on

### DIFF
--- a/tritonbench/components/do_bench/run.py
+++ b/tritonbench/components/do_bench/run.py
@@ -124,6 +124,9 @@ class Latency:
         else:
             raise ValueError(f"Unsupported latency output mode: {mode}")
 
+    def to_float(self) -> float:
+        return float(self.to_str())
+
 
 def _summarize_statistics(times, quantiles, return_mode):
     if quantiles is not None:

--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -401,11 +401,15 @@ class BenchmarkOperatorResult:
 
         if self.simple_mode:
             # do not print header if in simple output mode
-            avg_row = [
-                str(x / len(self.result)) if isinstance(x, Number) else None
-                for x in avg_row
-            ]
-            avg_row = [",".join(avg_row)]
+            new_avg_row = []
+            for x in avg_row:
+                if isinstance(x, Number):
+                    new_avg_row.append(str(x / len(self.result)))
+                elif isinstance(x, Latency):
+                    new_avg_row.append(str(x.to_float() / len(self.result)))
+                else:
+                    new_avg_row.append(None)
+            avg_row = [",".join(new_avg_row)]
         else:
             avg_row = ["average"] + [
                 x / len(self.result) if isinstance(x, Number) else None for x in avg_row


### PR DESCRIPTION
Summary: Enable `latency` metric with `--simple-output`.

Reviewed By: xuzhao9

Differential Revision: D87828563


