### PR TITLE
Support alternative pip installers (uv) via get_pip_cmd

### DIFF
--- a/tools/python_utils.py
+++ b/tools/python_utils.py
@@ -40,8 +40,6 @@ def get_pkg_versions(packages: List[str]) -> Dict[str, str]:
 def get_pip_cmd():
     if env := os.getenv("PIP_MODULE"):
         return env.split()
-    if shutil.which("uv"):
-        return ["uv", "pip"]
     else:
         return [sys.executable, "-m", "pip"]
 


### PR DESCRIPTION
Currently, installation scripts always invoke pip via `sys.executable -m pip` in subprocesses.  
This PR introduces `get_pip_cmd()` (same as [PR#2659 for torchbench](https://github.com/pytorch/benchmark/pull/2659)), which:

- Uses the `PIP_MODULE` environment variable to override the installer if set.
    
    ```bash
    PIP_MODULE="uv pip" python install.py
    ```

- Defaults to `sys.executable -m pip` otherwise.