### PR TITLE
Support BLOCK_N=128 for FA fwd

### DIFF
--- a/tritonbench/kernels/tlx_attention_ws_pipelined.py
+++ b/tritonbench/kernels/tlx_attention_ws_pipelined.py
@@ -62,7 +62,7 @@ configs_persistent = [
     triton.Config(
         {
             "BLOCK_M": 256,
-            "BLOCK_N": 64,
+            "BLOCK_N": 128,
             "NUM_BUFFERS_Q": 1,
             "NUM_BUFFERS_KV": 6,
             "NUM_BUFFERS_QK": 1,
@@ -78,8 +78,9 @@ configs_persistent = [
 
 def prune_pipelined_configs_by_hdim(configs, named_args, **kwargs):
     HEAD_DIM = kwargs["HEAD_DIM"]
+    target_kv_buffers = 6 if HEAD_DIM == 64 else 3
     # Only match HEAD_DIM for BLOCK_N
-    return [conf for conf in configs if conf.kwargs.get("BLOCK_N", 0) == HEAD_DIM]
+    return [conf for conf in configs if conf.kwargs.get("NUM_BUFFERS_KV", 0) == target_kv_buffers]
 
 
 @triton.jit
@@ -177,7 +178,7 @@ def _mask_scalar(qk, col_limit_right, s, i):
 
 
 @triton.jit
-def _apply_causal_mask(qk, col_limit_right, HEAD_DIM: tl.constexpr):
+def _apply_causal_mask(qk, col_limit_right, BLOCK_N: tl.constexpr):
     # Apply causal mask via a bitmask calculated for each block of 16 elements.
     # This allows the efficient R2P (register to predicate) instruction to be used at the SASS level.
     # Credit to Tri Dao,
@@ -185,7 +186,7 @@ def _apply_causal_mask(qk, col_limit_right, HEAD_DIM: tl.constexpr):
     #
     # NOTE: We use map_elementiwse here in order to generate an interleaved sequence of instructions
     # that processes one element of qk at a time. This improves ptxas's resulting SASS.
-    offs_n = tl.arange(0, HEAD_DIM)[None, :]
+    offs_n = tl.arange(0, BLOCK_N)[None, :]
     s = offs_n & ~0xF
     i = offs_n & 0xF
     return tl.map_elementwise(_mask_scalar, qk, col_limit_right, s, i)
@@ -227,7 +228,7 @@ def _softmax_inner_loop(
 
         if STAGE == 2:
             col_limit_right = (offs_m - start_n + 1)[:, None]
-            qk = _apply_causal_mask(qk, col_limit_right, HEAD_DIM)
+            qk = _apply_causal_mask(qk, col_limit_right, BLOCK_N)
 
         # compute m_i, p in registers
         m_ij = tl.maximum(m_i, tl.max(qk, 1) * qk_scale)
@@ -755,7 +756,7 @@ def _pipelined_softmax_inner_loop(
 
         if STAGE == 2:
             col_limit_right = (offs_m - start_n + 1)[:, None]
-            qk = _apply_causal_mask(qk, col_limit_right, HEAD_DIM)
+            qk = _apply_causal_mask(qk, col_limit_right, BLOCK_N)
 
         # compute m_i, p in registers
         m_ij = tl.maximum(m_i, tl.max(qk, 1) * qk_scale)
@@ -763,8 +764,8 @@ def _pipelined_softmax_inner_loop(
         # -- compute correction factor
         alpha = tl.math.exp2(m_i - m_ij)
         tlx.barrier_wait(tlx.local_view(alpha_empties, cid), qk_phase ^ 1)
-        # Use alpha[0] for cid=0, and alpha[HEAD_DIM] for cid=1
-        tlx.local_store(tlx.local_view(alpha_tiles, cid * HEAD_DIM), alpha[:, None])
+        # Use alpha[0] for cid=0, and alpha[BLOCK_N] for cid=1
+        tlx.local_store(tlx.local_view(alpha_tiles, cid * BLOCK_N), alpha[:, None])
         tlx.barrier_arrive(tlx.local_view(alpha_fulls, cid))
 
         qk = _fma_f32x2(qk, qk_scale, -m_ij[:, None])
@@ -816,7 +817,6 @@ def _attn_fwd_ws_persistent(
     NUM_MMA_GROUPS: tl.constexpr,  #
     NUM_MMA_SLICES: tl.constexpr,  #
 ):
-    tl.static_assert(BLOCK_N <= HEAD_DIM)
     tl.static_assert(NUM_MMA_GROUPS == 2)
     tl.static_assert(NUM_BUFFERS_QK == 1)
     tl.static_assert(NUM_BUFFERS_Q == 1)
@@ -928,8 +928,8 @@ def _attn_fwd_ws_persistent(
                     for cid in tl.static_range(0, NUM_MMA_GROUPS):
                         # -- update output accumulator --
                         tlx.barrier_wait(alpha_fulls[cid], phase)
-                        # Use alpha[0] for cid=0, and alpha[HEAD_DIM] for cid=1
-                        alpha_1 = tlx.local_load(alpha_tiles[cid * HEAD_DIM])
+                        # Use alpha[0] for cid=0, and alpha[BLOCK_N] for cid=1
+                        alpha_1 = tlx.local_load(alpha_tiles[cid * BLOCK_N])
                         tlx.barrier_arrive(alpha_empties[cid])
                         for slice_id in tl.static_range(0, NUM_MMA_SLICES):
                             subslice = tlx.subslice(
@@ -948,11 +948,11 @@ def _attn_fwd_ws_persistent(
                 for cid in tl.static_range(0, NUM_MMA_GROUPS):
                     # epilogue
                     tlx.barrier_wait(l_fulls[cid], phase)
-                    # Use l[1]/l[1+HEAD_DIM] and m[2][2 + HEAD_DIM]
-                    # to disambigulate from alpha[0]/alpha[HEAD_DIM]
-                    l = tlx.local_load(l_tiles[cid * HEAD_DIM + 1])
+                    # Use l[1]/l[1+BLOCK_N] and m[2][2 + BLOCK_N]
+                    # to disambigulate from alpha[0]/alpha[BLOCK_N]
+                    l = tlx.local_load(l_tiles[cid * BLOCK_N + 1])
                     tlx.barrier_arrive(qk_empties[cid])
-                    m = tlx.local_load(m_tiles[cid * HEAD_DIM + 2])
+                    m = tlx.local_load(m_tiles[cid * BLOCK_N + 2])
                     m += tl.math.log2(l)
                     offs_m = (
                         start_m * BLOCK_M
@@ -1059,10 +1059,10 @@ def _attn_fwd_ws_persistent(
                     )
 
                 # prepare l_i for the epilog
-                # Use l[1]/l[1+HEAD_DIM] and m[2][2 + HEAD_DIM]
-                # to disambigulate from alpha[0]/alpha[HEAD_DIM]
-                tlx.local_store(l_tiles[cid * HEAD_DIM + 1], l_i[:, None])
-                tlx.local_store(m_tiles[cid * HEAD_DIM + 2], m_i[:, None])
+                # Use l[1]/l[1+BLOCK_N] and m[2][2 + BLOCK_N]
+                # to disambigulate from alpha[0]/alpha[BLOCK_N]
+                tlx.local_store(l_tiles[cid * BLOCK_N + 1], l_i[:, None])
+                tlx.local_store(m_tiles[cid * BLOCK_N + 2], m_i[:, None])
                 tlx.barrier_arrive(l_fulls[cid])
                 tile_idx += num_progs
 


### PR DESCRIPTION
Summary: Updates the kernel to allow using `BLOCK_N=128` to improve performance with H-DIM=64. See this PR for correctness: https://github.com/facebookexperimental/triton/pull/700.

Reviewed By: htyu

Differential Revision: D87967562


