### PR TITLE
Support FAv4 backwards in TritonBench

### DIFF
--- a/tritonbench/operators/blackwell_attentions/operator.py
+++ b/tritonbench/operators/blackwell_attentions/operator.py
@@ -405,9 +405,7 @@ class Operator(BenchmarkOperator):
             q, k, v, is_causal=self.causal, scale=self.sm_scale
         )
 
-    @register_benchmark(
-        enabled=(IS_BLACKWELL and HAS_FLASH_CUTE), label="FAv4", fwd_only=True
-    )
+    @register_benchmark(enabled=(IS_BLACKWELL and HAS_FLASH_CUTE), label="FAv4")
     def cutedsl_blackwell(
         self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor
     ) -> Callable:


### PR DESCRIPTION
Summary:
Enables backwards for FAv4 which should now be available in fbcode.

Note: FAv4 seems to only work with H-DIM=128 not H-DIM=64 at this time.

Differential Revision: D88273056


