### PR TITLE
Generate GPU L2 size inputs in flash_attention Triton Bench

### DIFF
--- a/tritonbench/components/do_bench/run.py
+++ b/tritonbench/components/do_bench/run.py
@@ -127,6 +127,10 @@ class Latency:
     def to_float(self) -> float:
         return float(self.to_str())
 
+    def scale(self, scale):
+        for i in range(len(self.times)):
+            self.times[i] /= scale
+
 
 def _summarize_statistics(times, quantiles, return_mode):
     if quantiles is not None:

--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -1730,6 +1730,7 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
                         self.tb_args, "entropy_max_samples", 10000
                     ),
                 )
+                metrics.latency.scale(self.get_latency_scale(self.example_inputs))
             if {
                 "gpu_peak_mem",
                 "gpu_mem_footprint_compression_ratio",
@@ -2433,3 +2434,6 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
     def has_baseline(cls) -> Optional[str]:
         operator_name = cls.name
         return BASELINE_BENCHMARKS.get(operator_name, None)
+
+    def get_latency_scale(self, example_inputs):
+        return 1


### PR DESCRIPTION
Summary:
Add an option to generate inputs as large as the GPU L2 cache size to
avoid an explicit cache clearing in every iteration

Differential Revision: D85318459


