### PR TITLE
enable tma for output in gdpa kernel

### DIFF
--- a/tritonbench/operators/gdpa/gdpa.py
+++ b/tritonbench/operators/gdpa/gdpa.py
@@ -20,10 +20,8 @@ from typing import Tuple
 
 import torch
 import torch.nn.functional as F
-
 import triton  # @manual=//triton:triton
 import triton.language as tl  # @manual=//triton:triton
-
 from torch._library.triton import capture_triton
 from triton.tools.tensor_descriptor import TensorDescriptor
 
@@ -468,7 +466,8 @@ def _gdpa_fwd_compute(
                 [
                     (begin_q + start_m * BLOCK_M).to(tl.int32),
                     (o_offset).to(tl.int32),
-                ], acc.to(Out.type.element_ty),
+                ],
+                acc.to(Out.type.element_ty),
             )
         else:
             o_mask = (offs_m[:, None] < qlen) & (offs_d[None, :] < HEAD_DIM)


### PR DESCRIPTION
I was wondering why the GDPA kernel does not use TMA for storing the output.

This PR adds support for enabling TMA output storage in the GDPA kernel. 

Tested the performance and accuracy on H100 with 
```
bash denoise.sh python run.py --op gdpa --metrics speedup,accuracy --batch 1024 --max_seq_len 1024 --dim 512 --head 4 --sparsity 0.5 --only gdpa,gdpa_opt,gdpa_opt_sorted,eager_gdpa  --baseline eager_gdpa --simple-output --rep 3000
```
The original:
| gdpa-speedup  |  gdpa-accuracy   | gdpa_opt-speedup  |  gdpa_opt-accuracy  |  gdpa_opt_sorted-speedup    | gdpa_opt_sorted-accuracy |
|---|---|---|---|---|---|
| 73.3927 | 1 | 61.67 | 1 | 69.4485 | 1 |

After this PR:
| gdpa-speedup  |  gdpa-accuracy   | gdpa_opt-speedup  |  gdpa_opt-accuracy  |  gdpa_opt_sorted-speedup    | gdpa_opt_sorted-accuracy |
|---|---|---|---|---|---|
| 73.9545 | 1 | 60.1875 | 1 | 69.4483 | 1 |
