### PR TITLE
[amd] Disable _cutlass_or_ck tests in OSS

### DIFF
--- a/install.py
+++ b/install.py
@@ -5,10 +5,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-from tools.cuda_utils import (
-    DEFAULT_TOOLKIT_VERSION,
-    TOOLKIT_MAPPING,
-)
+from tools.cuda_utils import DEFAULT_TOOLKIT_VERSION, TOOLKIT_MAPPING
 from tools.git_utils import checkout_submodules
 from tools.python_utils import (
     generate_build_constraints,
@@ -24,6 +21,7 @@ logger = logging.getLogger(__name__)
 # if torch does not exist
 if not has_pkg("torch"):
     from tools.torch_utils import install_pytorch_nightly
+
     env = os.environ
     toolkit_version = TOOLKIT_MAPPING[DEFAULT_TOOLKIT_VERSION]["pytorch_url"]
     install_pytorch_nightly(toolkit_version, env)

--- a/tools/cuda_utils.py
+++ b/tools/cuda_utils.py
@@ -26,10 +26,13 @@ HIP_VERSION_MAP = {
     }
 }
 
-IS_CUDA = bool(shutil.which("nvidia-smi") is not None) or bool(os.environ.get("CUDA_HOME", None))
+IS_CUDA = bool(shutil.which("nvidia-smi") is not None) or bool(
+    os.environ.get("CUDA_HOME", None)
+)
 
 DEFAULT_TOOLKIT_VERSION = DEFAULT_CUDA_VERSION if IS_CUDA else DEFAULT_HIP_VERSION
 TOOLKIT_MAPPING = CUDA_VERSION_MAP if IS_CUDA else HIP_VERSION_MAP
+
 
 def detect_cuda_version_with_nvcc(env):
     test_nvcc = ["nvcc", "--version"]

--- a/tritonbench/operators/fp8_gemm_rowwise/operator.py
+++ b/tritonbench/operators/fp8_gemm_rowwise/operator.py
@@ -6,7 +6,7 @@ import triton
 
 from tritonbench.utils.data_utils import get_production_shapes
 
-from tritonbench.utils.env_utils import get_nvidia_gpu_model, is_cuda, is_hip, is_fbcode
+from tritonbench.utils.env_utils import get_nvidia_gpu_model, is_cuda, is_fbcode, is_hip
 
 from tritonbench.utils.triton_op import (
     BenchmarkOperator,

--- a/tritonbench/operators/fp8_gemm_rowwise_grouped/operator.py
+++ b/tritonbench/operators/fp8_gemm_rowwise_grouped/operator.py
@@ -53,9 +53,9 @@ from typing import Any, Callable, Generator, List, Optional, Tuple
 
 import torch
 import triton
+from tritonbench.utils.data_utils import get_production_shapes
 
 from tritonbench.utils.env_utils import is_fbcode
-from tritonbench.utils.data_utils import get_production_shapes
 
 from tritonbench.utils.triton_op import (
     BenchmarkOperator,


### PR DESCRIPTION
We need to disable OSS _cutlass_or_ck tests because it will sefgfault on MI350.

Failure log: https://github.com/meta-pytorch/tritonbench/actions/runs/19905259316/job/57059697420