### PR TITLE
[flex_attention][AMD] Fix flex_attention by not using tanh_approx

### DIFF
--- a/install.py
+++ b/install.py
@@ -5,10 +5,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-from tools.cuda_utils import (
-    DEFAULT_TOOLKIT_VERSION,
-    TOOLKIT_MAPPING,
-)
+from tools.cuda_utils import DEFAULT_TOOLKIT_VERSION, TOOLKIT_MAPPING
 from tools.git_utils import checkout_submodules
 from tools.python_utils import (
     generate_build_constraints,
@@ -24,6 +21,7 @@ logger = logging.getLogger(__name__)
 # if torch does not exist
 if not has_pkg("torch"):
     from tools.torch_utils import install_pytorch_nightly
+
     env = os.environ
     toolkit_version = TOOLKIT_MAPPING[DEFAULT_TOOLKIT_VERSION]["pytorch_url"]
     install_pytorch_nightly(toolkit_version, env)

--- a/tools/cuda_utils.py
+++ b/tools/cuda_utils.py
@@ -26,10 +26,13 @@ HIP_VERSION_MAP = {
     }
 }
 
-IS_CUDA = bool(shutil.which("nvidia-smi") is not None) or bool(os.environ.get("CUDA_HOME", None))
+IS_CUDA = bool(shutil.which("nvidia-smi") is not None) or bool(
+    os.environ.get("CUDA_HOME", None)
+)
 
 DEFAULT_TOOLKIT_VERSION = DEFAULT_CUDA_VERSION if IS_CUDA else DEFAULT_HIP_VERSION
 TOOLKIT_MAPPING = CUDA_VERSION_MAP if IS_CUDA else HIP_VERSION_MAP
+
 
 def detect_cuda_version_with_nvcc(env):
     test_nvcc = ["nvcc", "--version"]

--- a/tritonbench/operators/flex_attention/operator.py
+++ b/tritonbench/operators/flex_attention/operator.py
@@ -26,8 +26,8 @@ try:
 except ImportError:
     pass
 
-from tritonbench.utils.input import input_filter
 from tritonbench.utils.env_utils import is_hip
+from tritonbench.utils.input import input_filter
 from tritonbench.utils.triton_op import (
     BenchmarkOperator,
     BenchmarkOperatorMetrics,


### PR DESCRIPTION
tanh_approx only works on NVIDIA. To get flex_attention benchmark work on AMD, ideally we want to use the AMD version of fast_tanh: https://github.com/triton-lang/triton/blob/28e7587c5f67d8a744a50a0890fe4cd8431f5516/third_party/amd/language/hip/libdevice.py#L77

However I am not sure how to embed HIP assembly yet, so we have to disable fast_tanh_approx on AMD for now.

There are still pretty big perf gaps, in both fwd and bwd.

Test plan:

fwd, MI350X:

```
                 (B, Hq, M, Hkv, N, D) | Mask Type     compiled-latency    compiled-tflops    compiled-tbps
--------------------------------------------------  -------------------  -----------------  ---------------
      (8, 16, 128, 16, 128, 128) |            noop   0.052000 (±14.23%)            20.7295        0.322639
      (8, 16, 128, 16, 128, 128) |          causal   0.018560 (±32.76%)            58.0785        0.903945
      (8, 16, 128, 16, 128, 128) |             rel   0.051961 (±16.40%)            20.7451        0.322881
      (8, 16, 128, 16, 128, 128) |       head_bias   0.051960 (±14.32%)            20.7455        0.322887
      (8, 16, 128, 16, 128, 128) |           alibi    0.018600 (±6.46%)            57.9536        0.902001
      (8, 16, 128, 16, 128, 128) |  sliding_window   0.018600 (±37.42%)            57.9536        0.902001
    (1, 16, 1024, 16, 1024, 128) |   document_mask    0.112921 (±2.05%)            16.7054        0.148575
      (8, 16, 128, 16, 128, 128) |       prefix_lm   0.019120 (±30.75%)            56.3774        0.877469
      (8, 16, 128, 16, 128, 128) |         softcap    0.019800 (±3.04%)            54.4412        0.847334
      (8, 16, 256, 16, 256, 128) |            noop   0.051401 (±13.85%)            83.8844        0.652797
      (8, 16, 256, 16, 256, 128) |          causal    0.024760 (±1.94%)           130.606         1.35519
      (8, 16, 256, 16, 256, 128) |             rel   0.051160 (±14.62%)            84.2796        0.655872
      (8, 16, 256, 16, 256, 128) |       head_bias   0.049320 (±15.00%)            87.4239        0.680341
      (8, 16, 256, 16, 256, 128) |           alibi    0.028040 (±2.71%)           115.328         1.19666
      (8, 16, 256, 16, 256, 128) |  sliding_window    0.025041 (±2.55%)           129.141         1.33998
    (1, 16, 2048, 16, 2048, 128) |   document_mask    0.251923 (±1.29%)            20.8593        0.133193
      (8, 16, 256, 16, 256, 128) |       prefix_lm    0.025080 (±3.03%)           128.94          1.3379
      (8, 16, 256, 16, 256, 128) |         softcap    0.031880 (±2.51%)           101.437         1.05252
      (8, 16, 512, 16, 512, 128) |            noop    0.082641 (±1.98%)           208.698         0.812053
      (8, 16, 512, 16, 512, 128) |          causal    0.074001 (±1.68%)           145.665         0.906864
      (8, 16, 512, 16, 512, 128) |             rel    0.081641 (±1.71%)           211.254         0.821999
      (8, 16, 512, 16, 512, 128) |       head_bias    0.084681 (±2.03%)           203.67          0.79249
      (8, 16, 512, 16, 512, 128) |           alibi    0.084041 (±1.76%)           128.263         0.798525
      (8, 16, 512, 16, 512, 128) |  sliding_window    0.073921 (±2.06%)           145.823         0.907846
    (1, 16, 4096, 16, 4096, 128) |   document_mask    0.634767 (±1.37%)            23.3497        0.105722
      (8, 16, 512, 16, 512, 128) |       prefix_lm    0.073881 (±1.89%)           145.902         0.908337
      (8, 16, 512, 16, 512, 128) |         softcap    0.099401 (±1.89%)           108.443         0.675133
    (8, 16, 1024, 16, 1024, 128) |            noop    0.272163 (±1.84%)           253.48          0.493152
    (8, 16, 1024, 16, 1024, 128) |          causal    0.258083 (±2.57%)           150.361         0.520056
    (8, 16, 1024, 16, 1024, 128) |             rel    0.271163 (±1.79%)           254.415         0.494971
    (8, 16, 1024, 16, 1024, 128) |       head_bias    0.279884 (±1.50%)           246.488         0.479548
    (8, 16, 1024, 16, 1024, 128) |           alibi    0.290444 (±1.54%)           133.608         0.462112
    (8, 16, 1024, 16, 1024, 128) |  sliding_window    0.258683 (±1.52%)           150.013         0.51885
    (1, 16, 8192, 16, 8192, 128) |   document_mask    1.983983 (±4.42%)            23.4306        0.0676506
    (8, 16, 1024, 16, 1024, 128) |       prefix_lm    0.258603 (±1.45%)           150.059         0.519011
    (8, 16, 1024, 16, 1024, 128) |         softcap    0.357124 (±1.40%)           108.662         0.375829
    (8, 16, 2048, 16, 2048, 128) |            noop    0.972331 (±0.71%)           283.804         0.276074
    (8, 16, 2048, 16, 2048, 128) |          causal    0.955011 (±1.30%)           153.505         0.281081
    (8, 16, 2048, 16, 2048, 128) |             rel    0.967131 (±0.70%)           285.33          0.277559
    (8, 16, 2048, 16, 2048, 128) |       head_bias    0.999131 (±0.58%)           276.192         0.268669
    (8, 16, 2048, 16, 2048, 128) |           alibi    1.071573 (±1.23%)           136.808         0.250506
    (8, 16, 2048, 16, 2048, 128) |  sliding_window    0.955771 (±1.36%)           153.383         0.280857
  (1, 16, 16384, 16, 16384, 128) |   document_mask    6.886521 (±2.28%)            23.4793        0.0389798
    (8, 16, 2048, 16, 2048, 128) |       prefix_lm    0.957371 (±1.30%)           153.127         0.280388
    (8, 16, 2048, 16, 2048, 128) |         softcap    1.344856 (±1.52%)           109.007         0.199602
    (8, 16, 4096, 16, 4096, 128) |            noop    3.715604 (±0.28%)           297.073         0.144491
    (8, 16, 4096, 16, 4096, 128) |          causal    3.711684 (±0.69%)           153.34          0.144643
    (8, 16, 4096, 16, 4096, 128) |             rel    3.670443 (±0.22%)           300.728         0.146269
    (8, 16, 4096, 16, 4096, 128) |       head_bias    3.821124 (±0.32%)           288.87          0.140501
    (8, 16, 4096, 16, 4096, 128) |           alibi    4.149728 (±0.52%)           137.154         0.129375
    (8, 16, 4096, 16, 4096, 128) |  sliding_window    3.704043 (±0.63%)           153.657         0.144942
  (1, 16, 32768, 16, 32768, 128) |   document_mask   15.328780 (±1.26%)            39.1249        0.0350237
    (8, 16, 4096, 16, 4096, 128) |       prefix_lm    3.715443 (±0.67%)           153.185         0.144497
    (8, 16, 4096, 16, 4096, 128) |         softcap    5.252981 (±0.76%)           108.348         0.102203
    (8, 16, 8192, 16, 8192, 128) |            noop   14.390929 (±0.13%)           306.806         0.0746124
    (8, 16, 8192, 16, 8192, 128) |          causal   11.243492 (±0.30%)           199.414         0.095499
    (8, 16, 8192, 16, 8192, 128) |             rel   14.295968 (±0.09%)           308.844         0.075108
    (8, 16, 8192, 16, 8192, 128) |       head_bias   15.201138 (±0.08%)           290.454         0.0706356
    (8, 16, 8192, 16, 8192, 128) |           alibi   12.536387 (±0.41%)           178.848         0.08565
    (8, 16, 8192, 16, 8192, 128) |  sliding_window    7.625769 (±0.19%)           223.905         0.140804
  (1, 16, 65536, 16, 65536, 128) |   document_mask   38.581772 (±0.35%)            59.6917        0.0278303
    (8, 16, 8192, 16, 8192, 128) |       prefix_lm   11.230172 (±0.40%)           199.65          0.0956122
    (8, 16, 8192, 16, 8192, 128) |         softcap   15.971388 (±0.25%)           140.383         0.0672291
  (8, 16, 16384, 16, 16384, 128) |            noop   57.247833 (±0.00%)           308.499         0.0375121
  (8, 16, 16384, 16, 16384, 128) |          causal   36.886311 (±0.17%)           241.267         0.058219
  (8, 16, 16384, 16, 16384, 128) |             rel   56.674625 (±0.00%)           311.619         0.0378914
  (8, 16, 16384, 16, 16384, 128) |       head_bias   60.159504 (±0.00%)           293.568         0.0356965
  (8, 16, 16384, 16, 16384, 128) |           alibi   41.121159 (±0.00%)           216.42          0.0522233
  (8, 16, 16384, 16, 16384, 128) |  sliding_window   15.262539 (±0.24%)           261.035         0.140703
(1, 16, 131072, 16, 131072, 128) |   document_mask  120.773773 (±0.00%)            74.6932        0.017781
  (8, 16, 16384, 16, 16384, 128) |       prefix_lm   36.375748 (±0.06%)           244.653         0.0590361
  (8, 16, 16384, 16, 16384, 128) |         softcap   52.546375 (±0.00%)           169.364         0.0408683
                                           average    9.537856116347635           156.562         0.404346
```

fwd, H100:

```
                 (B, Hq, M, Hkv, N, D) | Mask Type    compiled-latency    compiled-tflops    compiled-tbps
--------------------------------------------------  ------------------  -----------------  ---------------
      (8, 16, 128, 16, 128, 128) |            noop   0.027520 (±6.74%)            39.1692        0.609637
      (8, 16, 128, 16, 128, 128) |          causal   0.017888 (±3.94%)            60.2603        0.937903
      (8, 16, 128, 16, 128, 128) |             rel   0.027616 (±6.26%)            39.033         0.607518
      (8, 16, 128, 16, 128, 128) |       head_bias   0.027488 (±5.59%)            39.2148        0.610347
      (8, 16, 128, 16, 128, 128) |           alibi   0.017888 (±3.22%)            60.2603        0.937903
      (8, 16, 128, 16, 128, 128) |  sliding_window   0.018240 (±4.39%)            59.0974        0.919804
    (1, 16, 1024, 16, 1024, 128) |   document_mask   0.022624 (±3.54%)            83.38          0.741567
      (8, 16, 128, 16, 128, 128) |       prefix_lm   0.017536 (±4.38%)            61.4699        0.95673
      (8, 16, 128, 16, 128, 128) |         softcap   0.017920 (±3.21%)            60.1527        0.936229
      (8, 16, 256, 16, 256, 128) |            noop   0.040448 (±3.40%)           106.6           0.82957
      (8, 16, 256, 16, 256, 128) |          causal   0.033280 (±2.12%)            97.1697        1.00825
      (8, 16, 256, 16, 256, 128) |             rel   0.040608 (±4.33%)           106.18          0.826301
      (8, 16, 256, 16, 256, 128) |       head_bias   0.040032 (±3.84%)           107.707         0.83819
      (8, 16, 256, 16, 256, 128) |           alibi   0.033600 (±1.81%)            96.2443        0.998644
      (8, 16, 256, 16, 256, 128) |  sliding_window   0.034176 (±1.97%)            94.6222        0.981813
    (1, 16, 2048, 16, 2048, 128) |   document_mask   0.050208 (±1.98%)           104.663         0.668308
      (8, 16, 256, 16, 256, 128) |       prefix_lm   0.032512 (±2.36%)            99.4651        1.03206
      (8, 16, 256, 16, 256, 128) |         softcap   0.034080 (±1.78%)            94.8887        0.984578
      (8, 16, 512, 16, 512, 128) |            noop   0.075104 (±2.13%)           229.641         0.893546
      (8, 16, 512, 16, 512, 128) |          causal   0.063808 (±1.25%)           168.934         1.05173
      (8, 16, 512, 16, 512, 128) |             rel   0.077568 (±1.82%)           222.347         0.865162
      (8, 16, 512, 16, 512, 128) |       head_bias   0.074816 (±1.84%)           230.525         0.896985
      (8, 16, 512, 16, 512, 128) |           alibi   0.065184 (±0.93%)           165.368         1.02953
      (8, 16, 512, 16, 512, 128) |  sliding_window   0.065216 (±1.23%)           165.287         1.02902
    (1, 16, 4096, 16, 4096, 128) |   document_mask   0.100512 (±0.64%)           147.461         0.66767
      (8, 16, 512, 16, 512, 128) |       prefix_lm   0.063424 (±1.11%)           169.957         1.0581
      (8, 16, 512, 16, 512, 128) |         softcap   0.066816 (±0.96%)           161.329         1.00438
    (8, 16, 1024, 16, 1024, 128) |            noop   0.192128 (±0.82%)           359.073         0.698585
    (8, 16, 1024, 16, 1024, 128) |          causal   0.148416 (±0.52%)           261.466         0.904335
    (8, 16, 1024, 16, 1024, 128) |             rel   0.203008 (±0.91%)           339.829         0.661145
    (8, 16, 1024, 16, 1024, 128) |       head_bias   0.192512 (±1.18%)           358.356         0.697191
    (8, 16, 1024, 16, 1024, 128) |           alibi   0.153888 (±0.54%)           252.168         0.872178
    (8, 16, 1024, 16, 1024, 128) |  sliding_window   0.151552 (±0.42%)           256.055         0.885622
    (1, 16, 8192, 16, 8192, 128) |   document_mask   0.230336 (±0.25%)           201.818         0.582704
    (8, 16, 1024, 16, 1024, 128) |       prefix_lm   0.147424 (±0.39%)           263.225         0.91042
    (8, 16, 1024, 16, 1024, 128) |         softcap   0.160832 (±0.56%)           241.281         0.834521
    (8, 16, 2048, 16, 2048, 128) |            noop   0.654688 (±5.83%)           421.501         0.41002
    (8, 16, 2048, 16, 2048, 128) |          causal   0.435968 (±0.24%)           336.262         0.615723
    (8, 16, 2048, 16, 2048, 128) |             rel   0.719008 (±6.17%)           383.795         0.373341
    (8, 16, 2048, 16, 2048, 128) |       head_bias   0.648960 (±5.59%)           425.221         0.413639
    (8, 16, 2048, 16, 2048, 128) |           alibi   0.458656 (±0.24%)           319.628         0.585265
    (8, 16, 2048, 16, 2048, 128) |  sliding_window   0.440832 (±0.27%)           332.551         0.608929
  (1, 16, 16384, 16, 16384, 128) |   document_mask   0.627232 (±0.14%)           257.784         0.427968
    (8, 16, 2048, 16, 2048, 128) |       prefix_lm   0.435264 (±0.25%)           336.806         0.616719
    (8, 16, 2048, 16, 2048, 128) |         softcap   0.484096 (±0.35%)           302.831         0.554509
    (8, 16, 4096, 16, 4096, 128) |            noop   2.550496 (±0.92%)           432.781         0.210497
    (8, 16, 4096, 16, 4096, 128) |          causal   1.573248 (±1.04%)           361.768         0.34125
    (8, 16, 4096, 16, 4096, 128) |             rel   2.619616 (±0.12%)           421.362         0.204943
    (8, 16, 4096, 16, 4096, 128) |       head_bias   2.529504 (±3.49%)           436.373         0.212244
    (8, 16, 4096, 16, 4096, 128) |           alibi   1.637792 (±0.89%)           347.511         0.327802
    (8, 16, 4096, 16, 4096, 128) |  sliding_window   1.583392 (±0.04%)           359.45          0.339064
  (1, 16, 32768, 16, 32768, 128) |   document_mask   1.997696 (±0.34%)           300.214         0.268745
    (8, 16, 4096, 16, 4096, 128) |       prefix_lm   1.599648 (±1.79%)           355.797         0.335618
    (8, 16, 4096, 16, 4096, 128) |         softcap   1.744192 (±4.98%)           326.312         0.307805
    (8, 16, 8192, 16, 8192, 128) |            noop   9.965376 (±1.87%)           443.057         0.107747
    (8, 16, 8192, 16, 8192, 128) |          causal   5.947360 (±0.99%)           376.992         0.180541
    (8, 16, 8192, 16, 8192, 128) |             rel  10.226400 (±0.89%)           431.748         0.104997
    (8, 16, 8192, 16, 8192, 128) |       head_bias   9.962080 (±0.03%)           443.203         0.107783
    (8, 16, 8192, 16, 8192, 128) |           alibi   6.204544 (±0.22%)           361.365         0.173057
    (8, 16, 8192, 16, 8192, 128) |  sliding_window   4.556704 (±2.24%)           374.712         0.23564
  (1, 16, 65536, 16, 65536, 128) |   document_mask   7.186112 (±1.68%)           320.481         0.149419
    (8, 16, 8192, 16, 8192, 128) |       prefix_lm   5.887328 (±1.70%)           380.836         0.182382
    (8, 16, 8192, 16, 8192, 128) |         softcap   6.495744 (±1.12%)           345.166         0.165299
  (8, 16, 16384, 16, 16384, 128) |            noop  39.090240 (±0.00%)           451.798         0.0549366
  (8, 16, 16384, 16, 16384, 128) |          causal  22.785728 (±0.36%)           390.571         0.0942469
  (8, 16, 16384, 16, 16384, 128) |             rel  40.494846 (±0.01%)           436.127         0.053031
  (8, 16, 16384, 16, 16384, 128) |       head_bias  39.060577 (±0.01%)           452.141         0.0549783
  (8, 16, 16384, 16, 16384, 128) |           alibi  23.627745 (±0.64%)           376.652         0.0908882
  (8, 16, 16384, 16, 16384, 128) |  sliding_window  10.586560 (±0.88%)           376.331         0.20285
(1, 16, 131072, 16, 131072, 128) |   document_mask  26.721727 (±0.00%)           337.59          0.0803647
  (8, 16, 16384, 16, 16384, 128) |       prefix_lm  22.787359 (±0.01%)           390.543         0.0942401
  (8, 16, 16384, 16, 16384, 128) |         softcap  25.246944 (±0.01%)           352.496         0.0850592
                                           average   4.754720467763643           265.326         0.560274
```