### PR TITLE
Add tunable epilogue subslicing and unify matmul kernels

### DIFF
--- a/tritonbench/operators/gemm/tlx_matmul.py
+++ b/tritonbench/operators/gemm/tlx_matmul.py
@@ -21,18 +21,20 @@ def get_cuda_autotune_config():
                 "NUM_TMEM_BUFFERS": t,
                 "EPILOGUE_SUBTILE": subtile,
                 "PAIR_CTA": pairCTA,
+                "PERSISTENT": persistent,
             },
             num_warps=4,
             num_stages=1,
             pre_hook=matmul_tma_set_block_size_hook,
         )
         for BM in [128]
-        for BN in [128, 256, 512]
+        for BN in [128, 256]
         for BK in [64, 128]
         for s in [2, 3, 4, 5, 6, 7]
         for t in [2, 3]
-        for subtile in [True, False]
+        for subtile in [1, 2, 4, 8]
         for pairCTA in [True, False]
+        for persistent in [True, False]
     ]
 
 
@@ -45,11 +47,8 @@ def matmul_tma_set_block_size_hook(nargs):
         nargs["b_desc"].block_shape = [BLOCK_K, BLOCK_N // 2]
     else:
         nargs["b_desc"].block_shape = [BLOCK_K, BLOCK_N]
-    EPILOGUE_SUBTILE = nargs.get("EPILOGUE_SUBTILE", False)
-    if EPILOGUE_SUBTILE:
-        nargs["c_desc"].block_shape = [BLOCK_M, BLOCK_N // 2]
-    else:
-        nargs["c_desc"].block_shape = [BLOCK_M, BLOCK_N]
+    EPILOGUE_SUBTILE = nargs.get("EPILOGUE_SUBTILE", 1)
+    nargs["c_desc"].block_shape = [BLOCK_M, BLOCK_N // EPILOGUE_SUBTILE]
 
 
 @triton.jit
@@ -82,6 +81,189 @@ def preprocess_configs(configs, named_args, **kwargs):
     return configs
 
 
+@triton.jit
+def _get_bufidx_phase(accum_cnt, NUM_BUFFERS_KV):
+    bufIdx = accum_cnt % NUM_BUFFERS_KV
+    phase = (accum_cnt // NUM_BUFFERS_KV) & 1
+    return bufIdx, phase
+
+
+@triton.jit
+def _compute_grid_info(M, N, K, BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K, GROUP_SIZE_M):
+    """Compute common grid information used across async tasks."""
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+    num_tiles = num_pid_m * num_pid_n
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    return start_pid, num_pid_m, num_pid_n, num_pid_in_group, num_tiles, k_tiles
+
+
+@triton.jit
+def _process_tile_epilogue_inner(
+    tile_id,
+    num_pid_in_group,
+    num_pid_m,
+    GROUP_SIZE_M,
+    BLOCK_SIZE_M,
+    BLOCK_SIZE_N,
+    EPILOGUE_SUBTILE,
+    c_desc,
+    tmem_buffers,
+    tmem_full_bars,
+    tmem_empty_bars,
+    cur_tmem_buf,
+    tmem_read_phase,
+    PERSISTENT,
+):
+    """Process epilogue for a single tile."""
+    pid_m, pid_n = _compute_pid(tile_id, num_pid_in_group, num_pid_m, GROUP_SIZE_M)
+    offs_am = pid_m * BLOCK_SIZE_M
+    offs_bn = pid_n * BLOCK_SIZE_N
+
+    tlx.barrier_wait(tmem_full_bars[cur_tmem_buf], tmem_read_phase)
+
+    # load the result from TMEM to registers
+    acc_tmem = tmem_buffers[cur_tmem_buf]
+    slice_size: tl.constexpr = BLOCK_SIZE_N // EPILOGUE_SUBTILE
+    for slice_id in tl.static_range(EPILOGUE_SUBTILE):
+        acc_tmem_subslice = tlx.local_slice(
+            acc_tmem,
+            [0, slice_id * slice_size],
+            [BLOCK_SIZE_M, slice_size],
+        )
+        result = tlx.local_load(acc_tmem_subslice)
+        c = result.to(tl.float16)
+        c_desc.store([offs_am, offs_bn + slice_id * slice_size], c)
+
+    # Signal MMA consumer if in persistent mode
+    if PERSISTENT:
+        tlx.barrier_arrive(tmem_empty_bars[cur_tmem_buf], 1)
+
+
+@triton.jit
+def _process_tile_mma_inner(
+    tile_id,
+    num_pid_in_group,
+    num_pid_m,
+    GROUP_SIZE_M,
+    k_tiles,
+    NUM_SMEM_BUFFERS,
+    buffers_A,
+    buffers_B,
+    tmem_buffers,
+    smem_full_bars,
+    smem_empty_bars,
+    tmem_full_bars,
+    cur_tmem_buf,
+    tmem_empty_bars,
+    tmem_write_phase,
+    smem_accum_cnt,
+    PAIR_CTA,
+    cta_bars,
+    pred_cta0,
+    PERSISTENT,
+):
+    """Process MMA for a single tile. Returns updated smem_accum_cnt."""
+    pid_m, pid_n = _compute_pid(tile_id, num_pid_in_group, num_pid_m, GROUP_SIZE_M)
+
+    if PERSISTENT:
+        # wait epilogue consumer to be done with the buffer before reusing it
+        # Note: we start with phase 1 since epilogue starts with phase 0
+        tlx.barrier_wait(tmem_empty_bars[cur_tmem_buf], tmem_write_phase ^ 1)
+
+    # now iterate along K to compute result for the block
+    for k in range(0, k_tiles):
+        buf, phase = _get_bufidx_phase(smem_accum_cnt, NUM_SMEM_BUFFERS)
+
+        # wait for current phase(round) of load for this buf
+        tlx.barrier_wait(smem_full_bars[buf], phase)
+        # CTA0 waits for CTA0 and CTA1 to finish loading A and B before issuing dot op
+        if PAIR_CTA:
+            cta_bar = tlx.remote_view(cta_bars[buf], 0)
+            tlx.barrier_arrive(cta_bar, 1)
+            tlx.barrier_wait(cta_bar, phase=phase, pred=pred_cta0)
+
+        # buffer is now ready with loaded data, tlx.async_dot will signal `mBarrier` when done
+        tlx.async_dot(
+            buffers_A[buf],
+            buffers_B[buf],
+            tmem_buffers[cur_tmem_buf],
+            use_acc=k > 0,
+            mBarriers=[smem_empty_bars[buf]],
+            two_ctas=PAIR_CTA,
+            out_dtype=tl.float32,
+        )
+        smem_accum_cnt += 1
+
+    # Wait for last MMA to complete before signaling epilogue
+    last_buf, last_phase = _get_bufidx_phase(smem_accum_cnt - 1, NUM_SMEM_BUFFERS)
+    tlx.barrier_wait(smem_empty_bars[last_buf], last_phase)
+
+    # Done filling this buffer, signal epilogue consumer
+    tlx.barrier_arrive(tmem_full_bars[cur_tmem_buf], 1)
+
+    return smem_accum_cnt
+
+
+@triton.jit
+def _process_tile_producer_inner(
+    tile_id,
+    num_pid_in_group,
+    num_pid_m,
+    GROUP_SIZE_M,
+    BLOCK_SIZE_M,
+    BLOCK_SIZE_N,
+    BLOCK_SIZE_K,
+    k_tiles,
+    NUM_SMEM_BUFFERS,
+    a_desc,
+    b_desc,
+    buffers_A,
+    buffers_B,
+    smem_full_bars,
+    smem_empty_bars,
+    smem_accum_cnt,
+    PAIR_CTA,
+    cluster_cta_rank,
+):
+    """Process TMA loads for a single tile. Returns updated smem_accum_cnt."""
+    pid_m, pid_n = _compute_pid(tile_id, num_pid_in_group, num_pid_m, GROUP_SIZE_M)
+    offs_am = pid_m * BLOCK_SIZE_M
+    # split B into two parts so each CTA has different offset
+    if PAIR_CTA:
+        offs_bn = pid_n * BLOCK_SIZE_N + cluster_cta_rank * (BLOCK_SIZE_N // 2)
+    else:
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+    for k in range(0, k_tiles):
+        buf, load_phase = _get_bufidx_phase(smem_accum_cnt, NUM_SMEM_BUFFERS)
+        # wait for previous phase(round) of dot for this buf
+        tlx.barrier_wait(smem_empty_bars[buf], load_phase ^ 1)
+        # buffer is now ready to be used again
+        offs_k = k * BLOCK_SIZE_K
+        if PAIR_CTA:
+            tlx.barrier_expect_bytes(
+                smem_full_bars[buf],
+                2 * (BLOCK_SIZE_M + BLOCK_SIZE_N // 2) * BLOCK_SIZE_K,
+            )  # float16
+        else:
+            tlx.barrier_expect_bytes(
+                smem_full_bars[buf],
+                2 * (BLOCK_SIZE_M + BLOCK_SIZE_N) * BLOCK_SIZE_K,
+            )  # float16
+        tlx.async_descriptor_load(
+            a_desc, buffers_A[buf], [offs_am, offs_k], smem_full_bars[buf]
+        )
+        tlx.async_descriptor_load(
+            b_desc, buffers_B[buf], [offs_k, offs_bn], smem_full_bars[buf]
+        )
+        smem_accum_cnt += 1
+
+    return smem_accum_cnt
+
+
 @triton.autotune(
     configs=get_cuda_autotune_config(),
     key=["M", "N", "K"],
@@ -101,9 +283,10 @@ def matmul_kernel_tma_ws_blackwell(
     GROUP_SIZE_M: tl.constexpr,  #
     NUM_SMEM_BUFFERS: tl.constexpr,  #
     NUM_TMEM_BUFFERS: tl.constexpr,  #
-    NUM_SMS: tl.constexpr,  #
     EPILOGUE_SUBTILE: tl.constexpr,  #
     PAIR_CTA: tl.constexpr,  #
+    PERSISTENT: tl.constexpr,  #
+    NUM_SMS: tl.constexpr,  #
 ):
     # allocate NUM_SMEM_BUFFERS buffers
     buffers_A = tlx.local_alloc(
@@ -118,7 +301,7 @@ def matmul_kernel_tma_ws_blackwell(
         buffers_B = tlx.local_alloc(
             (BLOCK_SIZE_K, BLOCK_SIZE_N), tl.float16, NUM_SMEM_BUFFERS
         )
-    # use multiple TMEM buffers to overlap MMA and epilogue
+    # use multiple TMEM buffers to overlap MMA and epilogue (only in persistent mode)
     tmem_buffers = tlx.local_alloc(
         (BLOCK_SIZE_M, BLOCK_SIZE_N),
         tl.float32,
@@ -133,186 +316,199 @@ def matmul_kernel_tma_ws_blackwell(
         cta_bars = tlx.alloc_barriers(
             num_barriers=NUM_SMEM_BUFFERS, arrive_count=2
         )  # CTA0 waits for CTA1's data before mma
+    else:
+        cluster_cta_rank = 0
+        pred_cta0 = False
+        cta_bars = None
 
     # allocate barriers
     smem_empty_bars = tlx.alloc_barriers(num_barriers=NUM_SMEM_BUFFERS, arrive_count=1)
     smem_full_bars = tlx.alloc_barriers(num_barriers=NUM_SMEM_BUFFERS, arrive_count=1)
     tmem_full_bars = tlx.alloc_barriers(num_barriers=NUM_TMEM_BUFFERS, arrive_count=1)
-    tmem_empty_bars = tlx.alloc_barriers(num_barriers=NUM_TMEM_BUFFERS, arrive_count=1)
+    if PERSISTENT:
+        tmem_empty_bars = tlx.alloc_barriers(
+            num_barriers=NUM_TMEM_BUFFERS, arrive_count=1
+        )
+    else:
+        tmem_empty_bars = None
 
     with tlx.async_tasks():
         with tlx.async_task("default"):  # epilogue consumer
-            # common code duplicated for each region to avoid SMEM overhead
-            start_pid = tl.program_id(axis=0)
-            num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
-            num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
-            num_pid_in_group = GROUP_SIZE_M * num_pid_n
-            num_tiles = num_pid_m * num_pid_n
-            k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
-            # end of common code
-
-            tmem_read_phase = 0
-            cur_tmem_buf = 0
-
-            for tile_id in range(start_pid, num_tiles, NUM_SMS):
-                pid_m, pid_n = _compute_pid(
-                    tile_id, num_pid_in_group, num_pid_m, GROUP_SIZE_M
+            start_pid, num_pid_m, num_pid_n, num_pid_in_group, num_tiles, k_tiles = (
+                _compute_grid_info(
+                    M, N, K, BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K, GROUP_SIZE_M
                 )
-                offs_am = pid_m * BLOCK_SIZE_M
-                offs_bn = pid_n * BLOCK_SIZE_N
+            )
 
-                tlx.barrier_wait(tmem_full_bars[cur_tmem_buf], tmem_read_phase)
-                # flip phase at the end of a round of using TMEM barriers
-                tmem_read_phase = tmem_read_phase ^ (
-                    cur_tmem_buf == NUM_TMEM_BUFFERS - 1
-                )
-
-                # load the result from TMEM to registers
-                acc_tmem = tmem_buffers[cur_tmem_buf]
-
-                if EPILOGUE_SUBTILE:
-                    # We load/store the result half by half to reduce SMEM pressure
-                    acc_tmem_subslice1 = tlx.subslice(acc_tmem, 0, BLOCK_SIZE_N // 2)
-                    result = tlx.local_load(acc_tmem_subslice1)
-                    c = result.to(tl.float16)
-                    c_desc.store([offs_am, offs_bn], c)
-
-                    acc_tmem_subslice2 = tlx.subslice(
-                        acc_tmem, BLOCK_SIZE_N // 2, BLOCK_SIZE_N // 2
+            if PERSISTENT:
+                # Persistent mode: process multiple tiles
+                tmem_accum_cnt = 0
+                for tile_id in range(start_pid, num_tiles, NUM_SMS):
+                    cur_tmem_buf, tmem_read_phase = _get_bufidx_phase(
+                        tmem_accum_cnt, NUM_TMEM_BUFFERS
                     )
-                    result = tlx.local_load(acc_tmem_subslice2)
-                    c = result.to(tl.float16)
-                    c_desc.store([offs_am, offs_bn + BLOCK_SIZE_N // 2], c)
-                else:
-                    result = tlx.local_load(acc_tmem)
-                    c = result.to(tl.float16)
-                    c_desc.store([offs_am, offs_bn], c)
-
-                # done storing this buffer, signal MMA consumer to resume writing to it
-                tlx.barrier_arrive(tmem_empty_bars[cur_tmem_buf], 1)
-
-                cur_tmem_buf = (cur_tmem_buf + 1) % NUM_TMEM_BUFFERS
-        with tlx.async_task(num_warps=1, num_regs=232):  # MMA consumer
-            # common code duplicated for each region to avoid SMEM overhead
-            start_pid = tl.program_id(axis=0)
-            num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
-            num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
-            num_pid_in_group = GROUP_SIZE_M * num_pid_n
-            num_tiles = num_pid_m * num_pid_n
-            k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
-            # end of common code
-
-            dot_phase = 0  # the current phase of dot op
-            tmem_write_phase = 1  # sync between epilogue consumer and MMA consumer
-            cur_tmem_buf = 0
-
-            processed_k_iters = 0
-            for tile_id in range(start_pid, num_tiles, NUM_SMS):
-                pid_m, pid_n = _compute_pid(
-                    tile_id, num_pid_in_group, num_pid_m, GROUP_SIZE_M
-                )
-                offs_am = pid_m * BLOCK_SIZE_M
-                offs_bn = pid_n * BLOCK_SIZE_N
-
-                # wait epilogue consumer to be done with the buffer before reusing it
-                tlx.barrier_wait(tmem_empty_bars[cur_tmem_buf], tmem_write_phase)
-                # flip phase at the end of a round of using TMEM barriers
-                tmem_write_phase = tmem_write_phase ^ (
-                    cur_tmem_buf == NUM_TMEM_BUFFERS - 1
+                    _process_tile_epilogue_inner(
+                        tile_id,
+                        num_pid_in_group,
+                        num_pid_m,
+                        GROUP_SIZE_M,
+                        BLOCK_SIZE_M,
+                        BLOCK_SIZE_N,
+                        EPILOGUE_SUBTILE,
+                        c_desc,
+                        tmem_buffers,
+                        tmem_full_bars,
+                        tmem_empty_bars,
+                        cur_tmem_buf,
+                        tmem_read_phase,
+                        PERSISTENT,
+                    )
+                    tmem_accum_cnt += 1
+            else:
+                # Non-persistent mode: process single tile
+                tile_id = start_pid
+                cur_tmem_buf = 0
+                tmem_read_phase = 0
+                _process_tile_epilogue_inner(
+                    tile_id,
+                    num_pid_in_group,
+                    num_pid_m,
+                    GROUP_SIZE_M,
+                    BLOCK_SIZE_M,
+                    BLOCK_SIZE_N,
+                    EPILOGUE_SUBTILE,
+                    c_desc,
+                    tmem_buffers,
+                    tmem_full_bars,
+                    tmem_empty_bars,
+                    cur_tmem_buf,
+                    tmem_read_phase,
+                    PERSISTENT,
                 )
 
-                # now iterate along K to compute result for the block
-                for k in range(0, k_tiles):
-                    # processed_k_iters + k means we use the immediate next buffer slot of tile_id x when we start tile_id x+1
-                    buf = (processed_k_iters + k) % NUM_SMEM_BUFFERS
-                    # wait for current phase(round) of load for this buf
-                    tlx.barrier_wait(smem_full_bars[buf], dot_phase)
-                    # CTA0 waits for CTA0 and CTA1 to finish loading A and B before issuing dot op
-                    if PAIR_CTA:
-                        cta_bar = tlx.remote_view(cta_bars[buf], 0)
-                        tlx.barrier_arrive(cta_bar, 1)
-                        tlx.barrier_wait(cta_bar, phase=dot_phase, pred=pred_cta0)
-
-                    # buffer is now ready with loaded data, tlx.async_dot will signal `mBarrier` when done
-                    tlx.async_dot(
-                        buffers_A[buf],
-                        buffers_B[buf],
-                        tmem_buffers[cur_tmem_buf],
-                        use_acc=k > 0,
-                        mBarriers=[smem_empty_bars[buf]],
-                        two_ctas=PAIR_CTA,
-                        out_dtype=tl.float32,
-                    )
-
-                    # flip phase at the end of a round
-                    dot_phase = dot_phase ^ (buf == NUM_SMEM_BUFFERS - 1)
-
-                # wait for last mma to complete
-                last_buf = (processed_k_iters + k_tiles - 1) % NUM_SMEM_BUFFERS
-                # in case phase was flipped, we should use the phase value when dot op was issued
-                last_dot_phase = dot_phase ^ (last_buf == NUM_SMEM_BUFFERS - 1)
-                tlx.barrier_wait(smem_empty_bars[last_buf], last_dot_phase)
-
-                # done filling this buffer, signal epilogue consumer
-                tlx.barrier_arrive(tmem_full_bars[cur_tmem_buf], 1)
-
-                # possibly enter next iteration (next tile) without waiting for epilogue
-                cur_tmem_buf = (cur_tmem_buf + 1) % NUM_TMEM_BUFFERS
-                processed_k_iters += k_tiles
-
-        with tlx.async_task(num_warps=1, num_regs=232):  # producer, TMA load
-            # common code duplicated for each region to avoid SMEM overhead
-            start_pid = tl.program_id(axis=0)
-            num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
-            num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
-            num_pid_in_group = GROUP_SIZE_M * num_pid_n
-            num_tiles = num_pid_m * num_pid_n
-            k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
-            # end of common code
-
-            load_phase = 0  # the current phase of TMA load
-            # we virtually "flatten" the two layer loop as if we're performing tma loads on
-            # one big list of data
-            processed_k_iters = 0
-            for tile_id in range(start_pid, num_tiles, NUM_SMS):
-                pid_m, pid_n = _compute_pid(
-                    tile_id, num_pid_in_group, num_pid_m, GROUP_SIZE_M
+        with tlx.async_task(num_warps=1, num_regs=24):  # MMA consumer
+            start_pid, num_pid_m, num_pid_n, num_pid_in_group, num_tiles, k_tiles = (
+                _compute_grid_info(
+                    M, N, K, BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K, GROUP_SIZE_M
                 )
-                offs_am = pid_m * BLOCK_SIZE_M
-                # split B into two parts so each CTA has different offset
-                if PAIR_CTA:
-                    offs_bn = pid_n * BLOCK_SIZE_N + cluster_cta_rank * (
-                        BLOCK_SIZE_N // 2
-                    )
-                else:
-                    offs_bn = pid_n * BLOCK_SIZE_N
+            )
 
-                for k in range(0, k_tiles):
-                    # processed_k_iters + k means we use the immediate next buffer slot of tile_id x when we start tile_id x+1
-                    buf = (processed_k_iters + k) % NUM_SMEM_BUFFERS
-                    # wait for previous phase(round) of dot for this buf
-                    tlx.barrier_wait(smem_empty_bars[buf], load_phase ^ 1)
-                    # buffer is now ready to be used again
-                    offs_k = k * BLOCK_SIZE_K
-                    if PAIR_CTA:
-                        tlx.barrier_expect_bytes(
-                            smem_full_bars[buf],
-                            2 * (BLOCK_SIZE_M + BLOCK_SIZE_N // 2) * BLOCK_SIZE_K,
-                        )  # float16
-                    else:
-                        tlx.barrier_expect_bytes(
-                            smem_full_bars[buf],
-                            2 * (BLOCK_SIZE_M + BLOCK_SIZE_N) * BLOCK_SIZE_K,
-                        )  # float16
-                    tlx.async_descriptor_load(
-                        a_desc, buffers_A[buf], [offs_am, offs_k], smem_full_bars[buf]
+            if PERSISTENT:
+                # Persistent mode: process multiple tiles
+                tmem_accum_cnt = 0
+                smem_accum_cnt = 0
+
+                for tile_id in range(start_pid, num_tiles, NUM_SMS):
+                    cur_tmem_buf, tmem_write_phase = _get_bufidx_phase(
+                        tmem_accum_cnt, NUM_TMEM_BUFFERS
                     )
-                    tlx.async_descriptor_load(
-                        b_desc, buffers_B[buf], [offs_k, offs_bn], smem_full_bars[buf]
+                    smem_accum_cnt = _process_tile_mma_inner(
+                        tile_id,
+                        num_pid_in_group,
+                        num_pid_m,
+                        GROUP_SIZE_M,
+                        k_tiles,
+                        NUM_SMEM_BUFFERS,
+                        buffers_A,
+                        buffers_B,
+                        tmem_buffers,
+                        smem_full_bars,
+                        smem_empty_bars,
+                        tmem_full_bars,
+                        cur_tmem_buf,
+                        tmem_empty_bars,
+                        tmem_write_phase,
+                        smem_accum_cnt,
+                        PAIR_CTA,
+                        cta_bars,
+                        pred_cta0,
+                        PERSISTENT,
                     )
-                    # flip phase at the end of a round
-                    load_phase = load_phase ^ (buf == NUM_SMEM_BUFFERS - 1)
-                processed_k_iters += k_tiles
+                    tmem_accum_cnt += 1
+            else:
+                # Non-persistent mode: process single tile
+                tile_id = start_pid
+                smem_accum_cnt = 0
+                cur_tmem_buf = 0
+                tmem_write_phase = 0  # Not used in non-persistent mode
+                _process_tile_mma_inner(
+                    tile_id,
+                    num_pid_in_group,
+                    num_pid_m,
+                    GROUP_SIZE_M,
+                    k_tiles,
+                    NUM_SMEM_BUFFERS,
+                    buffers_A,
+                    buffers_B,
+                    tmem_buffers,
+                    smem_full_bars,
+                    smem_empty_bars,
+                    tmem_full_bars,
+                    cur_tmem_buf,
+                    tmem_empty_bars,
+                    tmem_write_phase,
+                    smem_accum_cnt,
+                    PAIR_CTA,
+                    cta_bars,
+                    pred_cta0,
+                    PERSISTENT,
+                )
+
+        with tlx.async_task(num_warps=1, num_regs=24):  # producer, TMA load
+            start_pid, num_pid_m, num_pid_n, num_pid_in_group, num_tiles, k_tiles = (
+                _compute_grid_info(
+                    M, N, K, BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K, GROUP_SIZE_M
+                )
+            )
+
+            if PERSISTENT:
+                # Persistent mode: process multiple tiles
+                smem_accum_cnt = 0
+                for tile_id in range(start_pid, num_tiles, NUM_SMS):
+                    smem_accum_cnt = _process_tile_producer_inner(
+                        tile_id,
+                        num_pid_in_group,
+                        num_pid_m,
+                        GROUP_SIZE_M,
+                        BLOCK_SIZE_M,
+                        BLOCK_SIZE_N,
+                        BLOCK_SIZE_K,
+                        k_tiles,
+                        NUM_SMEM_BUFFERS,
+                        a_desc,
+                        b_desc,
+                        buffers_A,
+                        buffers_B,
+                        smem_full_bars,
+                        smem_empty_bars,
+                        smem_accum_cnt,
+                        PAIR_CTA,
+                        cluster_cta_rank,
+                    )
+            else:
+                # Non-persistent mode: process single tile
+                tile_id = start_pid
+                smem_accum_cnt = 0
+                _process_tile_producer_inner(
+                    tile_id,
+                    num_pid_in_group,
+                    num_pid_m,
+                    GROUP_SIZE_M,
+                    BLOCK_SIZE_M,
+                    BLOCK_SIZE_N,
+                    BLOCK_SIZE_K,
+                    k_tiles,
+                    NUM_SMEM_BUFFERS,
+                    a_desc,
+                    b_desc,
+                    buffers_A,
+                    buffers_B,
+                    smem_full_bars,
+                    smem_empty_bars,
+                    smem_accum_cnt,
+                    PAIR_CTA,
+                    cluster_cta_rank,
+                )
 
 
 def tlx_matmul(a, b):
@@ -332,20 +528,25 @@ def tlx_matmul(a, b):
 
     NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
 
-    # Persistent kernel to have thread block resident in SM as long as possible
-    grid = lambda META: (
-        min(
-            NUM_SMS,
-            triton.cdiv(M, META["BLOCK_SIZE_M"]) * triton.cdiv(N, META["BLOCK_SIZE_N"]),
-        ),
-    )
+    # Grid function that adapts based on PERSISTENT parameter from autotune
+    # For persistent mode: launch fewer CTAs (min of NUM_SMS or total tiles)
+    # For non-persistent mode: launch one CTA per tile
+    def grid(META):
+        total_tiles = triton.cdiv(M, META["BLOCK_SIZE_M"]) * triton.cdiv(
+            N, META["BLOCK_SIZE_N"]
+        )
+        if META.get("PERSISTENT", False):
+            return (min(NUM_SMS, total_tiles),)
+        else:
+            return (total_tiles,)
+
     matmul_kernel_tma_ws_blackwell[grid](
         a_desc,
         b_desc,
-        c_desc,  #
+        c_desc,
         M,
         N,
-        K,  #
-        NUM_SMS=NUM_SMS,  #
+        K,
+        NUM_SMS=NUM_SMS,
     )
     return c


### PR DESCRIPTION
Summary:
This diff unifies the two separate matmul kernel implementations (matmul_kernel_tma_ws_blackwell and matmul_kernel_tma_ws_blackwell_persistent) into a single kernel with PERSISTENT as an autotune parameter, and extracts shared code into reusable helper functions.


Key changes:
- EPILOGUE_SUBTILE autotune for epilogue optimization  
- Unified kernel with PERSISTENT autotune parameter
- Extracted shared logic into helper functions
- 2x configuration search space for better performance

Differential Revision: D88545552


