### PR TITLE
fix: remove flush from logger.info (not a valid argument)

### DIFF
--- a/tritonbench/utils/run_utils.py
+++ b/tritonbench/utils/run_utils.py
@@ -117,8 +117,8 @@ def run_in_helion(op_args: Dict[str, str], extra_envs: Dict[str, str]):
     cmd = [sys.executable, "benchmarks/run.py"] + op_args
     logger.info(
         f"[tritonbench] Running helion benchmark: " + " ".join(cmd),
-        flush=True,
     )
+
     subprocess.check_call(
         cmd,
         cwd=helion_root,


### PR DESCRIPTION
When running KernelGeneration using TritonBench, the benchmark crashed due to `logger.info(..., flush=True)`. 

`flush` is not a valid argument for `logger.info`, so this change removes it.