### PR TITLE
[amd] fix gpu name on amd

### DIFF
--- a/tritonbench/utils/gpu_utils.py
+++ b/tritonbench/utils/gpu_utils.py
@@ -109,6 +109,7 @@ AMD_DEVICE_NAME_MAPPING = {
     (9, 5): "AMD MI350X",
 }
 
+
 def _set_pm():
     command = ["sudo", "nvidia-smi", "-i", CUDA_VISIBLE_DEVICES, "-pm", "1"]
     subprocess.check_call(command)
@@ -259,8 +260,10 @@ def has_nvidia_smi() -> bool:
     except (subprocess.SubprocessError, FileNotFoundError):
         return False
 
+
 def get_amd_device_name() -> str:
     import torch
+
     assert is_hip(), "get_amd_device_name() is only supported on AMD GPUs"
     current_device = torch.cuda.current_device()
     device_name = torch.cuda.get_device_name()
@@ -270,5 +273,7 @@ def get_amd_device_name() -> str:
     # if device name is "AMD Radeon Graphics", we need to infer the actual device name from gfx arch
     gcn_arch_major = torch.cuda.get_device_properties(current_device).major
     gcn_arch_minor = torch.cuda.get_device_properties(current_device).minor
-    assert (gcn_arch_major, gcn_arch_minor) in AMD_DEVICE_NAME_MAPPING, f"Unsupported AMD GCN Arch {gcn_arch_major}.{gcn_arch_minor}"
+    assert (
+        (gcn_arch_major, gcn_arch_minor) in AMD_DEVICE_NAME_MAPPING
+    ), f"Unsupported AMD GCN Arch {gcn_arch_major}.{gcn_arch_minor}"
     return AMD_DEVICE_NAME_MAPPING[(gcn_arch_major, gcn_arch_minor)]

--- a/tritonbench/utils/run_utils.py
+++ b/tritonbench/utils/run_utils.py
@@ -20,7 +20,7 @@ from tritonbench.operators_collection import list_operators_by_collection
 from tritonbench.utils.ab_test import compare_ab_results, run_ab_test
 from tritonbench.utils.env_utils import is_fbcode, is_hip
 from tritonbench.utils.git_utils import get_branch, get_commit_time, get_current_hash
-from tritonbench.utils.gpu_utils import gpu_lockdown, get_amd_device_name
+from tritonbench.utils.gpu_utils import get_amd_device_name, gpu_lockdown
 from tritonbench.utils.list_operator_details import list_operator_details
 from tritonbench.utils.parser import get_parser
 from tritonbench.utils.path_utils import (
@@ -68,9 +68,13 @@ def get_run_env(
     if is_hip():
         run_env["cuda_version"] = torch.version.hip
     else:
-        run_env["cuda_version"] = torch.version.cuda if torch.version.cuda else "unknown"
+        run_env["cuda_version"] = (
+            torch.version.cuda if torch.version.cuda else "unknown"
+        )
     try:
-        run_env["device"] = get_amd_device_name() if is_hip() else torch.cuda.get_device_name()
+        run_env["device"] = (
+            get_amd_device_name() if is_hip() else torch.cuda.get_device_name()
+        )
     except AssertionError:
         run_env["device"] = "unknown"
     run_env["conda_env"] = os.environ.get("CONDA_ENV", "unknown")


### PR DESCRIPTION
Currently, all AMD gpu name will be `AMD Radeon Graphics`.

Fix the device name by identifying the device name by their gfx Arch version.