### PR TITLE
Fix NUM_TMEM_BUFFERS assignment in non-persistent mode

### DIFF
--- a/tritonbench/operators/gemm/tlx_matmul.py
+++ b/tritonbench/operators/gemm/tlx_matmul.py
@@ -82,7 +82,7 @@ def preprocess_configs(configs, named_args, **kwargs):
         # so we force single TMEM buffer and disable PAIR_CTA optimizations
         if not PERSISTENT:
             NUM_TMEM_BUFFERS = 1
-            conf.kwargs["PAIR_CTA"] = 1
+            conf.kwargs["NUM_TMEM_BUFFERS"] = 1
 
         num_tiles_m = math.ceil(M / BLOCK_M)
         num_tiles_n = math.ceil(N / BLOCK_N)


### PR DESCRIPTION
Summary:
In non-persistent mode, the code was incorrectly setting `conf.kwargs["PAIR_CTA"] = 1` instead of `conf.kwargs["NUM_TMEM_BUFFERS"] = 1`. This was a copy-paste error from the previous line where we set the local variable `NUM_TMEM_BUFFERS = 1`.

The fix ensures that non-persistent mode properly configures a single TMEM buffer (which was already set in the local variable but not being passed to the kernel config), while leaving PAIR_CTA optimization unchanged.

Differential Revision: D88768252


