### PR TITLE
Enable causal and move the persistent for backwards.

### DIFF
--- a/tritonbench/kernels/tlx_attention_ws_pipelined.py
+++ b/tritonbench/kernels/tlx_attention_ws_pipelined.py
@@ -125,6 +125,26 @@ configs_fwd_persistent = [
 ]
 
 configs_bwd_persistent = [
+    # H-DIM = 128 non-causal config,
+    # H-DIM = 64 non-causal config (large seq-len),
+    triton.Config(
+        {
+            "BLOCK_M1": 64,
+            "BLOCK_N1": 128,
+            "BLOCK_M2": 128,
+            "BLOCK_N2": 128,
+            "NUM_BUFFERS_KV": 1,
+            "NUM_BUFFERS_Q": 2,
+            "NUM_BUFFERS_DO": 1,
+            "NUM_BUFFERS_DS": 1,
+            "NUM_BUFFERS_TMEM": 1,
+            "EPILOGUE_SUBTILE": 2,
+        },
+        num_warps=4,
+        num_stages=1,
+        pre_hook=_bwd_host_descriptor_pre_hook,
+    ),
+    # H-DIM = 64 non-causal config (med seq-len),
     triton.Config(
         {
             "BLOCK_M1": 128,
@@ -136,12 +156,12 @@ configs_bwd_persistent = [
             "NUM_BUFFERS_DO": 1,
             "NUM_BUFFERS_DS": 1,
             "NUM_BUFFERS_TMEM": 1,
-            "EPILOGUE_SUBTILE": 4,
+            "EPILOGUE_SUBTILE": 2,
         },
         num_warps=4,
         num_stages=1,
         pre_hook=_bwd_host_descriptor_pre_hook,
-    )
+    ),
 ]
 
 
@@ -187,6 +207,20 @@ def _get_fused_loop_bounds(start_m, N_CTX, BLOCK_M, STAGE: tl.constexpr):
     else:
         tl.static_assert(STAGE == 3)
         return 0, (start_m + 1) * BLOCK_M
+
+
+@triton.jit
+def _get_unfused_bwd_loop_bounds(N_CTX, BLOCK_M, STAGE: tl.constexpr):
+    if STAGE == 1:
+        # First part of STAGE == 3
+        lo, hi = 0, N_CTX
+    elif STAGE == 2:
+        # Second part of STAGE == 3 in this function
+        lo, hi = N_CTX, N_CTX
+    else:
+        tl.static_assert(STAGE == 3)
+        lo, hi = 0, N_CTX
+    return lo, hi
 
 
 @triton.jit
@@ -1515,7 +1549,9 @@ def _attn_bwd_preprocess(
 
 
 @triton.jit
-def bwd_caculate_offsets_persistent(
+def bwd_calculate_offsets_persistent(
+    tile_idx,
+    n_tile_num,
     stride_z,
     stride_h,
     stride_tok,
@@ -1524,8 +1560,8 @@ def bwd_caculate_offsets_persistent(
     BLOCK_M1: tl.constexpr,
     BLOCK_N1: tl.constexpr,
 ):
-    bhid = tl.program_id(2)
-    pid = tl.program_id(0)
+    bhid = tile_idx // n_tile_num
+    pid = tile_idx % n_tile_num
     off_chz = (bhid * N_CTX).to(tl.int64)
     off_bh = (
         (stride_h * (bhid % H) + stride_z * (bhid // H)).to(tl.int64)
@@ -1555,6 +1591,7 @@ def _attn_bwd_ws_persistent(
     stride_tok,
     stride_d,  #
     H,
+    Z,
     N_CTX,  #
     BLOCK_M1: tl.constexpr,  #
     BLOCK_N1: tl.constexpr,  #
@@ -1568,7 +1605,30 @@ def _attn_bwd_ws_persistent(
     NUM_BUFFERS_DS: tl.constexpr,
     NUM_BUFFERS_TMEM: tl.constexpr,
     EPILOGUE_SUBTILE: tl.constexpr,
+    STAGE: tl.constexpr,
 ):
+    # If we have BLOCK_M1 == 128 and HEAD_DIM == 128 we don't have enough
+    # TMEM. We may need to expand this condition across other configs in
+    # the future.
+    # Note: Setting REUSE_DP_FOR_DQ=False with BLOCK_M1 == 64 and
+    # HEAD_DIM == 128 will result in an accuracy issue.
+    REUSE_DP_FOR_DQ: tl.constexpr = (BLOCK_M1 == 128) and (HEAD_DIM == 128)
+
+    # original grid
+    #   triton.cdiv(q.shape[2], META["BLOCK_N1"]),
+    #   1,
+    #   q.shape[0] * q.shape[1],
+    n_tile_num = tl.cdiv(N_CTX, BLOCK_N1)
+    prog_id = tl.program_id(0)
+    num_progs = tl.num_programs(0)
+    total_tiles = n_tile_num * Z * H
+
+    tiles_per_sm = total_tiles // num_progs
+    if prog_id < total_tiles % num_progs:
+        tiles_per_sm += 1
+
+    tile_idx = prog_id
+
     # allocate smem buffers
     k_tiles = tlx.local_alloc(
         (BLOCK_N1, HEAD_DIM), tlx.dtype_of(desc_k), NUM_BUFFERS_KV
@@ -1588,6 +1648,7 @@ def _attn_bwd_ws_persistent(
 
     # allocate barriers for smem buffers
     k_fulls = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_KV)
+    k_empties = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_KV)
     v_fulls = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_KV)
     q_fulls = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_Q)
     q_empties = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_Q)
@@ -1613,13 +1674,6 @@ def _attn_bwd_ws_persistent(
         tlx.storage_kind.tmem,
     )
 
-    dq_tiles = tlx.local_alloc(
-        (BLOCK_M1, HEAD_DIM),
-        tl.float32,
-        NUM_BUFFERS_TMEM,
-        tlx.storage_kind.tmem,
-        reuse=dp_tiles,
-    )
     dv_tiles = tlx.local_alloc(
         (BLOCK_N1, HEAD_DIM), tl.float32, NUM_BUFFERS_KV, tlx.storage_kind.tmem
     )
@@ -1636,244 +1690,248 @@ def _attn_bwd_ws_persistent(
     dq_empties = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_TMEM)
 
     dv_fulls = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_KV)
+    dv_empties = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_KV)
     dk_fulls = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_KV)
+    dk_empties = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_KV)
+
+    # Establish the barriers and allocations we will use if we need to
+    # share TMEM for dq and dp. For barriers we cannot modify the definition
+    # of dp_empties because we can only signal the arrive if the barrier
+    if REUSE_DP_FOR_DQ:
+        dq_tiles = tlx.local_alloc(
+            (BLOCK_M1, HEAD_DIM),
+            tl.float32,
+            NUM_BUFFERS_TMEM,
+            tlx.storage_kind.tmem,
+            reuse=dp_tiles,
+        )
+        dp_empties = dq_empties
+    else:
+        dq_tiles = tlx.local_alloc(
+            (BLOCK_M1, HEAD_DIM),
+            tl.float32,
+            NUM_BUFFERS_TMEM,
+            tlx.storage_kind.tmem,
+        )
+        dp_empties = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_TMEM)
 
     LN2: tl.constexpr = 0.6931471824645996  # = ln(2)
 
     with tlx.async_tasks():
         # reduction
         with tlx.async_task("default"):
-            off_chz, off_bh, start_m, _, num_steps = bwd_caculate_offsets_persistent(
-                stride_z, stride_h, stride_tok, H, N_CTX, BLOCK_M1, BLOCK_N1
-            )
-            curr_m = start_m
-            step_m = BLOCK_M1
-            for blk_idx in range(num_steps):
-                tmem_buf_id, tmem_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_TMEM)
-
-                # wait for dq = tl.dot(tl.trans(dsT), k)
-                tlx.barrier_wait(dq_fulls[tmem_buf_id], tmem_phase)
-                slice_size: tl.constexpr = HEAD_DIM // EPILOGUE_SUBTILE
-                for slice_id in tl.static_range(EPILOGUE_SUBTILE):
-                    dq_slice = tlx.local_slice(
-                        dq_tiles[tmem_buf_id],
-                        [0, slice_id * slice_size],
-                        [BLOCK_M1, slice_size],
+            blk_idx = 0
+            for _ in range(0, tiles_per_sm):
+                off_chz, off_bh, start_m, _, num_steps = (
+                    bwd_calculate_offsets_persistent(
+                        tile_idx,
+                        n_tile_num,
+                        stride_z,
+                        stride_h,
+                        stride_tok,
+                        H,
+                        N_CTX,
+                        BLOCK_M1,
+                        BLOCK_N1,
                     )
-                    dq = tlx.local_load(dq_slice)
-                    dq = dq * LN2
-                    desc_dq.atomic_add(
-                        [(off_bh + curr_m).to(tl.int32), slice_id * slice_size], dq
+                )
+                curr_m = start_m
+                step_m = BLOCK_M1
+                for _ in range(num_steps):
+                    tmem_buf_id, tmem_phase = _get_bufidx_phase(
+                        blk_idx, NUM_BUFFERS_TMEM
                     )
 
-                # release dq
-                tlx.barrier_arrive(dq_empties[tmem_buf_id])
-                # Increment pointers.
-                curr_m += step_m
+                    # wait for dq = tl.dot(tl.trans(dsT), k)
+                    tlx.barrier_wait(dq_fulls[tmem_buf_id], tmem_phase)
+                    slice_size: tl.constexpr = HEAD_DIM // EPILOGUE_SUBTILE
+                    for slice_id in tl.static_range(EPILOGUE_SUBTILE):
+                        dq_slice = tlx.local_slice(
+                            dq_tiles[tmem_buf_id],
+                            [0, slice_id * slice_size],
+                            [BLOCK_M1, slice_size],
+                        )
+                        dq = tlx.local_load(dq_slice)
+                        dq = dq * LN2
+                        desc_dq.atomic_add(
+                            [(off_bh + curr_m).to(tl.int32), slice_id * slice_size], dq
+                        )
+
+                    # release dq
+                    tlx.barrier_arrive(dq_empties[tmem_buf_id])
+                    # Increment pointers.
+                    curr_m += step_m
+                    blk_idx += 1
+                tile_idx += num_progs
 
         # compute
         with tlx.async_task(num_warps=8, registers=192, replicate=1):
-            off_chz, off_bh, start_m, start_n, num_steps = (
-                bwd_caculate_offsets_persistent(
-                    stride_z, stride_h, stride_tok, H, N_CTX, BLOCK_M1, BLOCK_N1
-                )
-            )
-
-            # offset pointers for batch/head
-            M += off_chz
-            D += off_chz
-            curr_m = start_m
-            step_m = BLOCK_M1
-            for blk_idx in range(num_steps):
-                tmem_buf_id, tmem_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_TMEM)
-                ds_buf_id, _ = _get_bufidx_phase(blk_idx, NUM_BUFFERS_DS)
-
-                offs_m = curr_m + tl.arange(0, BLOCK_M1)
-                m = tl.load(M + offs_m)
-
-                # wait for qkT = tl.dot(k, qT)
-                tlx.barrier_wait(qk_fulls[tmem_buf_id], tmem_phase)
-                qkT = tlx.local_load(qk_tiles[tmem_buf_id])
-                tlx.barrier_arrive(qk_empties[tmem_buf_id])
-
-                pT = tl.math.exp2(qkT - m[None, :])
-
-                # ppT *= qk_scale
-                ppT = pT
-                ppT = ppT.to(tlx.dtype_of(desc_do))
-                tlx.local_store(p_tiles[tmem_buf_id], ppT)
-                tlx.barrier_arrive(p_fulls[tmem_buf_id])
-
-                # D (= delta) is pre-divided by ds_scale.
-                Di = tl.load(D + offs_m)
-
-                # Wait for dpT = tl.dot(v, tl.trans(do))
-                tlx.barrier_wait(dp_fulls[tmem_buf_id], tmem_phase)
-                dpT = tlx.local_load(dp_tiles[tmem_buf_id])
-                # No need to release dP, as dP uses the same tmem as dQ
-                # in the same iteration. Release dQ instead later.
-                dsT = pT * (dpT - Di[None, :])
-                dsT = dsT.to(tlx.dtype_of(desc_q))
-                tlx.local_store(ds_tiles[ds_buf_id], dsT)
-                tlx.fence_async_shared()
-                tlx.barrier_arrive(ds_fulls[ds_buf_id])
-                curr_m += step_m
-
-            # epilogue
-            kv_buf_id, kv_phase = _get_bufidx_phase(0, NUM_BUFFERS_KV)
-
-            tlx.barrier_wait(dv_fulls[kv_buf_id], kv_phase)
-            slice_size: tl.constexpr = HEAD_DIM // EPILOGUE_SUBTILE
-            for slice_id in tl.static_range(EPILOGUE_SUBTILE):
-                dv_slice = tlx.local_slice(
-                    dv_tiles[kv_buf_id],
-                    [0, slice_id * slice_size],
-                    [BLOCK_N1, slice_size],
-                )
-                dv = tlx.local_load(dv_slice)
-                desc_dv.store(
-                    [(off_bh + start_n).to(tl.int32), slice_id * slice_size],
-                    dv.to(tlx.dtype_of(desc_dv)),
+            blk_idx = 0
+            for i in range(0, tiles_per_sm):
+                off_chz, off_bh, start_m, start_n, num_steps = (
+                    bwd_calculate_offsets_persistent(
+                        tile_idx,
+                        n_tile_num,
+                        stride_z,
+                        stride_h,
+                        stride_tok,
+                        H,
+                        N_CTX,
+                        BLOCK_M1,
+                        BLOCK_N1,
+                    )
                 )
 
-            tlx.barrier_wait(dk_fulls[kv_buf_id], kv_phase)
-            for slice_id in tl.static_range(EPILOGUE_SUBTILE):
-                dk_slice = tlx.local_slice(
-                    dk_tiles[kv_buf_id],
-                    [0, slice_id * slice_size],
-                    [BLOCK_N1, slice_size],
-                )
-                dk = tlx.local_load(dk_slice)
-                dk *= sm_scale
-                desc_dk.store(
-                    [(off_bh + start_n).to(tl.int32), slice_id * slice_size],
-                    dk.to(tlx.dtype_of(desc_dk)),
-                )
+                # offset pointers for batch/head
+                M_updated = M + off_chz
+                D_updated = D + off_chz
+                curr_m = start_m
+                step_m = BLOCK_M1
+                do_out_dtype = tlx.dtype_of(desc_do)
+                q_out_dtype = tlx.dtype_of(desc_q)
+                if STAGE & 1:
+                    # TODO: Move to a helper function. Need to fix a layout bug in TLX.
+                    offs_n = start_n + tl.arange(0, BLOCK_N1)
+                    lo, hi = _get_unfused_bwd_loop_bounds(
+                        N_CTX, BLOCK_M1, STAGE=4 - STAGE
+                    )
+                    num_steps = (hi - lo) // BLOCK_M1
+                    for _ in range(num_steps):
+                        tmem_buf_id, tmem_phase = _get_bufidx_phase(
+                            blk_idx, NUM_BUFFERS_TMEM
+                        )
+                        ds_buf_id, ds_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_DS)
+
+                        offs_m = curr_m + tl.arange(0, BLOCK_M1)
+                        m = tl.load(M_updated + offs_m)
+
+                        # wait for qkT = tl.dot(k, qT)
+                        tlx.barrier_wait(
+                            tlx.local_view(qk_fulls, tmem_buf_id), tmem_phase
+                        )
+                        qkT = tlx.local_load(tlx.local_view(qk_tiles, tmem_buf_id))
+                        tlx.barrier_arrive(tlx.local_view(qk_empties, tmem_buf_id))
+
+                        pT = tl.math.exp2(qkT - m[None, :])
+                        if STAGE == 3:
+                            mask = offs_m[None, :] >= offs_n[:, None]
+                            pT = tl.where(mask, pT, 0.0)
+
+                        # ppT *= qk_scale
+                        ppT = pT
+                        ppT = ppT.to(do_out_dtype)
+                        tlx.local_store(tlx.local_view(p_tiles, tmem_buf_id), ppT)
+                        tlx.barrier_arrive(tlx.local_view(p_fulls, tmem_buf_id))
+
+                        # D (= delta) is pre-divided by ds_scale.
+                        Di = tl.load(D_updated + offs_m)
+
+                        # Wait for dpT = tl.dot(v, tl.trans(do))
+                        tlx.barrier_wait(
+                            tlx.local_view(dp_fulls, tmem_buf_id), tmem_phase
+                        )
+                        dpT = tlx.local_load(tlx.local_view(dp_tiles, tmem_buf_id))
+                        # We can only signal the arrive if DP is not shared with DQ.
+                        # Otherwise we need to wait for DQ to be done.
+                        if not REUSE_DP_FOR_DQ:
+                            tlx.barrier_arrive(tlx.local_view(dp_empties, tmem_buf_id))
+                        dsT = pT * (dpT - Di[None, :])
+                        dsT = dsT.to(q_out_dtype)
+                        tlx.local_store(tlx.local_view(ds_tiles, ds_buf_id), dsT)
+                        tlx.fence_async_shared()
+                        tlx.barrier_arrive(tlx.local_view(ds_fulls, ds_buf_id))
+                        curr_m += step_m
+                        blk_idx += 1
+                # TODO: Add the STAGE & 2 handling when we can determine bounds to divide
+                # the work across two loops, based on optimizing out the mask.
+                # epilogue
+                kv_buf_id, kv_phase = _get_bufidx_phase(i, NUM_BUFFERS_KV)
+
+                tlx.barrier_wait(dv_fulls[kv_buf_id], kv_phase)
+                slice_size: tl.constexpr = HEAD_DIM // EPILOGUE_SUBTILE
+                for slice_id in tl.static_range(EPILOGUE_SUBTILE):
+                    dv_slice = tlx.local_slice(
+                        dv_tiles[kv_buf_id],
+                        [0, slice_id * slice_size],
+                        [BLOCK_N1, slice_size],
+                    )
+                    dv = tlx.local_load(dv_slice)
+                    desc_dv.store(
+                        [(off_bh + start_n).to(tl.int32), slice_id * slice_size],
+                        dv.to(tlx.dtype_of(desc_dv)),
+                    )
+                tlx.barrier_arrive(dv_empties[kv_buf_id])
+
+                tlx.barrier_wait(dk_fulls[kv_buf_id], kv_phase)
+                for slice_id in tl.static_range(EPILOGUE_SUBTILE):
+                    dk_slice = tlx.local_slice(
+                        dk_tiles[kv_buf_id],
+                        [0, slice_id * slice_size],
+                        [BLOCK_N1, slice_size],
+                    )
+                    dk = tlx.local_load(dk_slice)
+                    dk *= sm_scale
+                    desc_dk.store(
+                        [(off_bh + start_n).to(tl.int32), slice_id * slice_size],
+                        dk.to(tlx.dtype_of(desc_dk)),
+                    )
+                tlx.barrier_arrive(dk_empties[kv_buf_id])
+
+                tile_idx += num_progs
 
         # mma
         with tlx.async_task(num_warps=1, registers=48):
-            _, _, start_m, _, num_steps = bwd_caculate_offsets_persistent(
-                stride_z, stride_h, stride_tok, H, N_CTX, BLOCK_M1, BLOCK_N1
-            )
-
-            kv_buf_id, kv_phase = _get_bufidx_phase(0, NUM_BUFFERS_KV)
-            tlx.barrier_wait(k_fulls[kv_buf_id], kv_phase)
-            tlx.barrier_wait(v_fulls[kv_buf_id], kv_phase)
-
-            # BLOCK_N1 must be a multiple of BLOCK_M1, otherwise the code wouldn't work.
-            tl.static_assert(BLOCK_N1 % BLOCK_M1 == 0)
-            curr_m = start_m
-            step_m = BLOCK_M1
             blk_idx = 0
+            for i in range(0, tiles_per_sm):
+                _, _, _, _, num_steps = bwd_calculate_offsets_persistent(
+                    tile_idx,
+                    n_tile_num,
+                    stride_z,
+                    stride_h,
+                    stride_tok,
+                    H,
+                    N_CTX,
+                    BLOCK_M1,
+                    BLOCK_N1,
+                )
 
-            # -----------------------------------------------------------
-            # Prolog
-            #
-            # 1. qkT = tl.dot(k, qT)
-            # 2. dpT = tl.dot(v, tl.trans(do))
-            # 3. dv += tl.dot(ppT, do)
-            # -----------------------------------------------------------
+                kv_buf_id, kv_phase = _get_bufidx_phase(i, NUM_BUFFERS_KV)
+                tlx.barrier_wait(k_fulls[kv_buf_id], kv_phase)
+                tlx.barrier_wait(v_fulls[kv_buf_id], kv_phase)
 
-            q_buf_id, q_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_Q)
-            do_buf_id, do_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_DO)
-            tmem_buf_id, tmem_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_TMEM)
+                # BLOCK_N1 must be a multiple of BLOCK_M1, otherwise the code wouldn't work.
+                tl.static_assert(BLOCK_N1 % BLOCK_M1 == 0)
 
-            # Compute qkT = tl.dot(k, qT)
-            tlx.barrier_wait(q_fulls[q_buf_id], q_phase)
-            tlx.barrier_wait(qk_empties[tmem_buf_id], tmem_phase ^ 1)
-            qT = tlx.local_trans(q_tiles[q_buf_id])
-            tlx.async_dot(
-                k_tiles[0],
-                qT,
-                qk_tiles[tmem_buf_id],
-                use_acc=False,
-                mBarriers=[qk_fulls[tmem_buf_id]],
-            )
+                # -----------------------------------------------------------
+                # Prolog
+                #
+                # 1. qkT = tl.dot(k, qT)
+                # 2. dpT = tl.dot(v, tl.trans(do))
+                # 3. dv += tl.dot(ppT, do)
+                # -----------------------------------------------------------
 
-            # Compute dpT = tl.dot(v, tl.trans(do))
-            tlx.barrier_wait(do_fulls[do_buf_id], do_phase)
-            # As dP uses the same tmem as dQ, wait for dQ release.
-            tlx.barrier_wait(dq_empties[tmem_buf_id], tmem_phase ^ 1)
-            doT = tlx.local_trans(do_tiles[do_buf_id])
-            tlx.async_dot(
-                v_tiles[0],
-                doT,
-                dp_tiles[tmem_buf_id],
-                use_acc=False,
-                mBarriers=[dp_fulls[tmem_buf_id]],
-            )
-
-            # Compute dv += tl.dot(ppT, do)
-            tlx.barrier_wait(p_fulls[tmem_buf_id], tmem_phase)
-            tlx.async_dot(
-                p_tiles[tmem_buf_id],
-                do_tiles[do_buf_id],
-                dv_tiles[tmem_buf_id],
-                use_acc=False,
-                mBarriers=[do_empties[do_buf_id]],
-            )
-
-            # -----------------------------------------------------------
-            # Main loop
-            # 1. qkT = tl.dot(k, qT)
-            # 2. dq = tl.dot(tl.trans(dsT), k) from previous iteration
-            # 3. dk += tl.dot(dsT, tl.trans(qT)) from previous iteration
-            # 4. dpT = tl.dot(v, tl.trans(do))
-            # 5. dv += tl.dot(ppT, do)
-            # -----------------------------------------------------------
-            for blk_idx in range(1, num_steps):
                 q_buf_id, q_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_Q)
+                do_buf_id, do_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_DO)
                 tmem_buf_id, tmem_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_TMEM)
+
                 # Compute qkT = tl.dot(k, qT)
                 tlx.barrier_wait(q_fulls[q_buf_id], q_phase)
                 tlx.barrier_wait(qk_empties[tmem_buf_id], tmem_phase ^ 1)
                 qT = tlx.local_trans(q_tiles[q_buf_id])
                 tlx.async_dot(
-                    k_tiles[0],
+                    k_tiles[kv_buf_id],
                     qT,
                     qk_tiles[tmem_buf_id],
                     use_acc=False,
                     mBarriers=[qk_fulls[tmem_buf_id]],
                 )
 
-                prev_blk_idx = blk_idx - 1
-                q_buf_id_prev, _ = _get_bufidx_phase(prev_blk_idx, NUM_BUFFERS_Q)
-                tmem_buf_id_prev, tmem_phase_prev = _get_bufidx_phase(
-                    prev_blk_idx, NUM_BUFFERS_TMEM
-                )
-                ds_buf_id_prev, ds_phase_prev = _get_bufidx_phase(
-                    prev_blk_idx, NUM_BUFFERS_DS
-                )
-
-                # Compute dq = tl.dot(tl.trans(dsT), k) from previous iteration
-                tlx.barrier_wait(ds_fulls[tmem_buf_id_prev], ds_phase_prev)
-                tlx.barrier_wait(dq_empties[tmem_buf_id_prev], tmem_phase_prev ^ 1)
-                dsT_view = tlx.local_trans(ds_tiles[ds_buf_id_prev])
-                tlx.async_dot(
-                    dsT_view,
-                    k_tiles[0],
-                    dq_tiles[tmem_buf_id_prev],
-                    use_acc=False,
-                    mBarriers=[dq_fulls[tmem_buf_id_prev]],
-                )
-
-                # Compute dk += tl.dot(dsT, tl.trans(qT)) from previous iteration
-                tlx.async_dot(
-                    ds_tiles[ds_buf_id_prev],
-                    q_tiles[q_buf_id_prev],
-                    dk_tiles[tmem_buf_id_prev],
-                    use_acc=prev_blk_idx > 0,
-                    mBarriers=[q_empties[q_buf_id_prev]],
-                )
-
-                do_buf_id, do_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_DO)
                 # Compute dpT = tl.dot(v, tl.trans(do))
                 tlx.barrier_wait(do_fulls[do_buf_id], do_phase)
-                # As dP uses the same tmem as dQ, wait for dQ release.
-                tlx.barrier_wait(dq_empties[tmem_buf_id], tmem_phase ^ 1)
+                tlx.barrier_wait(dp_empties[tmem_buf_id], tmem_phase ^ 1)
                 doT = tlx.local_trans(do_tiles[do_buf_id])
                 tlx.async_dot(
-                    v_tiles[0],
+                    v_tiles[kv_buf_id],
                     doT,
                     dp_tiles[tmem_buf_id],
                     use_acc=False,
@@ -1882,103 +1940,170 @@ def _attn_bwd_ws_persistent(
 
                 # Compute dv += tl.dot(ppT, do)
                 tlx.barrier_wait(p_fulls[tmem_buf_id], tmem_phase)
+                tlx.barrier_wait(dv_empties[kv_buf_id], kv_phase ^ 1)
                 tlx.async_dot(
                     p_tiles[tmem_buf_id],
                     do_tiles[do_buf_id],
-                    dv_tiles[tmem_buf_id],
-                    use_acc=True,
+                    dv_tiles[kv_buf_id],
+                    use_acc=False,
                     mBarriers=[do_empties[do_buf_id]],
                 )
+                blk_idx += 1
 
-            tlx.tcgen05_commit(dv_fulls[kv_buf_id])
+                # -----------------------------------------------------------
+                # Main loop
+                # 1. qkT = tl.dot(k, qT)
+                # 2. dq = tl.dot(tl.trans(dsT), k) from previous iteration
+                # 3. dk += tl.dot(dsT, tl.trans(qT)) from previous iteration
+                # 4. dpT = tl.dot(v, tl.trans(do))
+                # 5. dv += tl.dot(ppT, do)
+                # -----------------------------------------------------------
+                tlx.barrier_wait(dk_empties[kv_buf_id], kv_phase ^ 1)
+                for j in range(1, num_steps):
+                    q_buf_id, q_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_Q)
+                    tmem_buf_id, tmem_phase = _get_bufidx_phase(
+                        blk_idx, NUM_BUFFERS_TMEM
+                    )
+                    # Compute qkT = tl.dot(k, qT)
+                    tlx.barrier_wait(q_fulls[q_buf_id], q_phase)
+                    tlx.barrier_wait(qk_empties[tmem_buf_id], tmem_phase ^ 1)
+                    qT = tlx.local_trans(q_tiles[q_buf_id])
+                    tlx.async_dot(
+                        k_tiles[kv_buf_id],
+                        qT,
+                        qk_tiles[tmem_buf_id],
+                        use_acc=False,
+                        mBarriers=[qk_fulls[tmem_buf_id]],
+                    )
 
-            # -----------------------------------------------------------
-            # Epilog
-            # 4. dk += tl.dot(dsT, tl.trans(qT))
-            # 5. dq = tl.dot(tl.trans(dsT), k)
-            # -----------------------------------------------------------
-            q_buf_id, _ = _get_bufidx_phase(num_steps - 1, NUM_BUFFERS_Q)
-            tmem_buf_id, tmem_phase = _get_bufidx_phase(num_steps - 1, NUM_BUFFERS_TMEM)
-            ds_buf_id, ds_phase = _get_bufidx_phase(num_steps - 1, NUM_BUFFERS_DS)
-            # Compute dk += tl.dot(dsT, tl.trans(qT))
-            tlx.barrier_wait(ds_fulls[tmem_buf_id], ds_phase)
-            tlx.async_dot(
-                ds_tiles[ds_buf_id],
-                q_tiles[q_buf_id],
-                dk_tiles[tmem_buf_id],
-                use_acc=num_steps > 1,
-                mBarriers=[q_empties[q_buf_id], dk_fulls[kv_buf_id]],
-            )
+                    prev_blk_idx = blk_idx - 1
+                    q_buf_id_prev, _ = _get_bufidx_phase(prev_blk_idx, NUM_BUFFERS_Q)
+                    tmem_buf_id_prev, tmem_phase_prev = _get_bufidx_phase(
+                        prev_blk_idx, NUM_BUFFERS_TMEM
+                    )
+                    ds_buf_id_prev, ds_phase_prev = _get_bufidx_phase(
+                        prev_blk_idx, NUM_BUFFERS_DS
+                    )
 
-            # Compute dq = tl.dot(tl.trans(dsT), k)
-            tlx.barrier_wait(dq_empties[tmem_buf_id], tmem_phase ^ 1)
-            dsT_view = tlx.local_trans(ds_tiles[ds_buf_id])
-            tlx.async_dot(
-                dsT_view,
-                k_tiles[0],
-                dq_tiles[tmem_buf_id],
-                use_acc=False,
-                mBarriers=[dq_fulls[tmem_buf_id]],
-            )
+                    # Compute dq = tl.dot(tl.trans(dsT), k) from previous iteration
+                    tlx.barrier_wait(ds_fulls[ds_buf_id_prev], ds_phase_prev)
+                    tlx.barrier_wait(dq_empties[tmem_buf_id_prev], tmem_phase_prev ^ 1)
+                    dsT_view = tlx.local_trans(ds_tiles[ds_buf_id_prev])
+                    tlx.async_dot(
+                        dsT_view,
+                        k_tiles[kv_buf_id],
+                        dq_tiles[tmem_buf_id_prev],
+                        use_acc=False,
+                        mBarriers=[
+                            dq_fulls[tmem_buf_id_prev],
+                        ],
+                    )
+
+                    # Compute dk += tl.dot(dsT, tl.trans(qT)) from previous iteration
+                    tlx.async_dot(
+                        ds_tiles[ds_buf_id_prev],
+                        q_tiles[q_buf_id_prev],
+                        dk_tiles[kv_buf_id],
+                        use_acc=(j - 1) > 0,
+                        mBarriers=[
+                            q_empties[q_buf_id_prev],
+                        ],
+                    )
+
+                    do_buf_id, do_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_DO)
+                    # Compute dpT = tl.dot(v, tl.trans(do))
+                    tlx.barrier_wait(do_fulls[do_buf_id], do_phase)
+                    tlx.barrier_wait(dp_empties[tmem_buf_id], tmem_phase ^ 1)
+                    doT = tlx.local_trans(do_tiles[do_buf_id])
+                    tlx.async_dot(
+                        v_tiles[kv_buf_id],
+                        doT,
+                        dp_tiles[tmem_buf_id],
+                        use_acc=False,
+                        mBarriers=[dp_fulls[tmem_buf_id]],
+                    )
+
+                    # Compute dv += tl.dot(ppT, do)
+                    tlx.barrier_wait(p_fulls[tmem_buf_id], tmem_phase)
+                    tlx.async_dot(
+                        p_tiles[tmem_buf_id],
+                        do_tiles[do_buf_id],
+                        dv_tiles[kv_buf_id],
+                        use_acc=True,
+                        mBarriers=[do_empties[do_buf_id]],
+                    )
+                    blk_idx += 1
+
+                tlx.tcgen05_commit(dv_fulls[kv_buf_id])
+
+                # -----------------------------------------------------------
+                # Epilog
+                # 4. dk += tl.dot(dsT, tl.trans(qT))
+                # 5. dq = tl.dot(tl.trans(dsT), k)
+                # -----------------------------------------------------------
+                prev_blk_idx = blk_idx - 1
+                q_buf_id, _ = _get_bufidx_phase(prev_blk_idx, NUM_BUFFERS_Q)
+                tmem_buf_id, tmem_phase = _get_bufidx_phase(
+                    prev_blk_idx, NUM_BUFFERS_TMEM
+                )
+                ds_buf_id, ds_phase = _get_bufidx_phase(prev_blk_idx, NUM_BUFFERS_DS)
+                # Compute dk += tl.dot(dsT, tl.trans(qT))
+                tlx.barrier_wait(ds_fulls[ds_buf_id], ds_phase)
+                tlx.async_dot(
+                    ds_tiles[ds_buf_id],
+                    q_tiles[q_buf_id],
+                    dk_tiles[kv_buf_id],
+                    use_acc=num_steps > 1,
+                    mBarriers=[q_empties[q_buf_id], dk_fulls[kv_buf_id]],
+                )
+
+                # Compute dq = tl.dot(tl.trans(dsT), k)
+                tlx.barrier_wait(dq_empties[tmem_buf_id], tmem_phase ^ 1)
+                dsT_view = tlx.local_trans(ds_tiles[ds_buf_id])
+                tlx.async_dot(
+                    dsT_view,
+                    k_tiles[kv_buf_id],
+                    dq_tiles[tmem_buf_id],
+                    use_acc=False,
+                    mBarriers=[dq_fulls[tmem_buf_id]],
+                )
+                tlx.tcgen05_commit(k_empties[kv_buf_id])
+                tile_idx += num_progs
 
         # load
         with tlx.async_task(num_warps=1, registers=88):
-            _, off_bh, start_m, start_n, num_steps = bwd_caculate_offsets_persistent(
-                stride_z, stride_h, stride_tok, H, N_CTX, BLOCK_M1, BLOCK_N1
-            )
-            # Load K
-            kv_buf_id, _ = _get_bufidx_phase(0, NUM_BUFFERS_KV)
-            tlx.barrier_expect_bytes(
-                k_fulls[kv_buf_id], 2 * BLOCK_N1 * HEAD_DIM
-            )  # float16
-            tlx.async_descriptor_load(
-                desc_k,
-                k_tiles[kv_buf_id],
-                [(off_bh + start_n).to(tl.int32), 0],
-                k_fulls[kv_buf_id],
-            )
-
-            # Load Q
-            curr_m = start_m
-            step_m = BLOCK_M1
             blk_idx = 0
-            q_buf_id, q_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_Q)
-            tlx.barrier_wait(q_empties[q_buf_id], q_phase ^ 1)
-            tlx.barrier_expect_bytes(q_fulls[q_buf_id], 2 * BLOCK_M1 * HEAD_DIM)
-            tlx.async_descriptor_load(
-                desc_q,
-                q_tiles[q_buf_id],
-                [(off_bh + curr_m).to(tl.int32), 0],
-                q_fulls[q_buf_id],
-            )
+            for i in range(0, tiles_per_sm):
+                _, off_bh, start_m, start_n, num_steps = (
+                    bwd_calculate_offsets_persistent(
+                        tile_idx,
+                        n_tile_num,
+                        stride_z,
+                        stride_h,
+                        stride_tok,
+                        H,
+                        N_CTX,
+                        BLOCK_M1,
+                        BLOCK_N1,
+                    )
+                )
+                # Load K
+                kv_buf_id, kv_phase = _get_bufidx_phase(i, NUM_BUFFERS_KV)
+                tlx.barrier_wait(k_empties[kv_buf_id], kv_phase ^ 1)
+                tlx.barrier_expect_bytes(
+                    k_fulls[kv_buf_id], 2 * BLOCK_N1 * HEAD_DIM
+                )  # float16
+                tlx.async_descriptor_load(
+                    desc_k,
+                    k_tiles[kv_buf_id],
+                    [(off_bh + start_n).to(tl.int32), 0],
+                    k_fulls[kv_buf_id],
+                )
 
-            # Load V
-            tlx.barrier_expect_bytes(
-                v_fulls[kv_buf_id], 2 * BLOCK_N1 * HEAD_DIM
-            )  # float16
-            tlx.async_descriptor_load(
-                desc_v,
-                v_tiles[kv_buf_id],
-                [(off_bh + start_n).to(tl.int32), 0],
-                v_fulls[kv_buf_id],
-            )
-
-            # Load dO
-            do_buf_id, do_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_DO)
-            tlx.barrier_wait(do_empties[do_buf_id], do_phase ^ 1)
-            tlx.barrier_expect_bytes(do_fulls[do_buf_id], 2 * BLOCK_M1 * HEAD_DIM)
-            tlx.async_descriptor_load(
-                desc_do,
-                do_tiles[do_buf_id],
-                [(off_bh + curr_m).to(tl.int32), 0],
-                do_fulls[do_buf_id],
-            )
-            curr_m += step_m
-
-            for blk_idx in range(1, num_steps):
-                q_buf_id, q_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_Q)
-                do_buf_id, do_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_DO)
                 # Load Q
+                curr_m = start_m
+                step_m = BLOCK_M1
+                q_buf_id, q_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_Q)
                 tlx.barrier_wait(q_empties[q_buf_id], q_phase ^ 1)
                 tlx.barrier_expect_bytes(q_fulls[q_buf_id], 2 * BLOCK_M1 * HEAD_DIM)
                 tlx.async_descriptor_load(
@@ -1988,7 +2113,20 @@ def _attn_bwd_ws_persistent(
                     q_fulls[q_buf_id],
                 )
 
+                # Note: No need for v_empties because k is finished after v.
+                # Load V
+                tlx.barrier_expect_bytes(
+                    v_fulls[kv_buf_id], 2 * BLOCK_N1 * HEAD_DIM
+                )  # float16
+                tlx.async_descriptor_load(
+                    desc_v,
+                    v_tiles[kv_buf_id],
+                    [(off_bh + start_n).to(tl.int32), 0],
+                    v_fulls[kv_buf_id],
+                )
+
                 # Load dO
+                do_buf_id, do_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_DO)
                 tlx.barrier_wait(do_empties[do_buf_id], do_phase ^ 1)
                 tlx.barrier_expect_bytes(do_fulls[do_buf_id], 2 * BLOCK_M1 * HEAD_DIM)
                 tlx.async_descriptor_load(
@@ -1998,6 +2136,36 @@ def _attn_bwd_ws_persistent(
                     do_fulls[do_buf_id],
                 )
                 curr_m += step_m
+                blk_idx += 1
+
+                for _ in range(1, num_steps):
+                    q_buf_id, q_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_Q)
+                    do_buf_id, do_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_DO)
+                    # Load Q
+                    tlx.barrier_wait(q_empties[q_buf_id], q_phase ^ 1)
+                    tlx.barrier_expect_bytes(q_fulls[q_buf_id], 2 * BLOCK_M1 * HEAD_DIM)
+                    tlx.async_descriptor_load(
+                        desc_q,
+                        q_tiles[q_buf_id],
+                        [(off_bh + curr_m).to(tl.int32), 0],
+                        q_fulls[q_buf_id],
+                    )
+
+                    # Load dO
+                    tlx.barrier_wait(do_empties[do_buf_id], do_phase ^ 1)
+                    tlx.barrier_expect_bytes(
+                        do_fulls[do_buf_id], 2 * BLOCK_M1 * HEAD_DIM
+                    )
+                    tlx.async_descriptor_load(
+                        desc_do,
+                        do_tiles[do_buf_id],
+                        [(off_bh + curr_m).to(tl.int32), 0],
+                        do_fulls[do_buf_id],
+                    )
+                    curr_m += step_m
+                    blk_idx += 1
+
+                tile_idx += num_progs
 
 
 class _attention(torch.autograd.Function):
@@ -2126,8 +2294,6 @@ class _attention(torch.autograd.Function):
     def backward(ctx, do):
         if not ctx.use_persistent:
             raise NotImplementedError("Only persistent backward is supported")
-        if ctx.causal:
-            raise NotImplementedError("Causal is not supported")
         q, k, v, o, M = ctx.saved_tensors
         assert do.is_contiguous()
         assert q.stride() == k.stride() == v.stride() == o.stride() == do.stride()
@@ -2203,14 +2369,22 @@ class _attention(torch.autograd.Function):
 
         triton.set_allocator(alloc_fn)
 
-        def grid(meta):
-            return (
-                triton.cdiv(N_CTX, meta["BLOCK_N1"]),  # tiles along N (K/V)
-                1,  # (or cdiv over M if you need)
-                BATCH * N_HEAD,
-            )  # batch*heads
+        NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
 
-        _attn_bwd_ws_persistent[grid](
+        def grid_persistent(meta):
+            return (
+                min(
+                    NUM_SMS,
+                    # tiles along N (K/V)
+                    triton.cdiv(N_CTX, meta["BLOCK_N1"]) * BATCH * N_HEAD,
+                ),
+                1,
+                1,
+            )
+
+        stage = 3 if ctx.causal else 1
+
+        _attn_bwd_ws_persistent[grid_persistent](
             desc_q,
             desc_k,
             desc_v,
@@ -2226,9 +2400,11 @@ class _attention(torch.autograd.Function):
             q.stride(2),
             q.stride(3),  #
             N_HEAD,
+            BATCH,
             N_CTX,  #
             BLK_SLICE_FACTOR=BLK_SLICE_FACTOR,  #
             HEAD_DIM=ctx.HEAD_DIM,  #
+            STAGE=stage,  #
         )
 
         return dq, dk, dv, None, None, None, None

--- a/tritonbench/operators/blackwell_attentions/operator.py
+++ b/tritonbench/operators/blackwell_attentions/operator.py
@@ -543,6 +543,9 @@ class Operator(BenchmarkOperator):
     def tlx_blackwell_ws_pipelined_persistent(self, *args) -> Tuple[Callable, Callable]:
         def fn(q, k, v):
             return tlx_blackwell(
+                q,
+                k,
+                v,
                 self.causal,
                 self.sm_scale,
                 True,


### PR DESCRIPTION
Summary: Applies the changes from the TLX tutorial to move backwards to use a persistent implementation and add initial causal support.

Differential Revision: D88766359


