### PR TITLE
[BE] Fix Quack CI failures

### DIFF
--- a/tritonbench/operators/rms_norm/quack.py
+++ b/tritonbench/operators/rms_norm/quack.py
@@ -13,4 +13,6 @@ class QuackRMSNorm(torch.nn.Module):
         self.variance_epsilon = eps
 
     def forward(self, hidden_states):
-        return quack_rmsnorm(hidden_states, self.weight, self.variance_epsilon)
+        return quack_rmsnorm(
+            hidden_states, weight=self.weight, eps=self.variance_epsilon
+        )


### PR DESCRIPTION
Summary: Looks like Quack added additional arguments which broke the old code. This passes values by name to avoid this issue.

Differential Revision: D88979603


