### PR TITLE
Split bwd causal compute across 2 loops

### DIFF
--- a/tritonbench/kernels/tlx_attention_ws_pipelined.py
+++ b/tritonbench/kernels/tlx_attention_ws_pipelined.py
@@ -249,13 +249,13 @@ def _get_fused_loop_bounds(start_m, N_CTX, BLOCK_M, STAGE: tl.constexpr):
 
 
 @triton.jit
-def _get_unfused_bwd_loop_bounds(N_CTX, BLOCK_M, STAGE: tl.constexpr):
+def _get_unfused_bwd_loop_bounds(start_n, N_CTX, BLOCK_N1, STAGE: tl.constexpr):
     if STAGE == 1:
         # First part of STAGE == 3
-        lo, hi = 0, N_CTX
+        lo, hi = 0, (start_n + 1) * BLOCK_N1
     elif STAGE == 2:
         # Second part of STAGE == 3 in this function
-        lo, hi = N_CTX, N_CTX
+        lo, hi = (start_n + 1) * BLOCK_N1, N_CTX
     else:
         tl.static_assert(STAGE == 3)
         lo, hi = 0, N_CTX
@@ -1592,14 +1592,12 @@ def bwd_calculate_offsets_persistent(
     tile_idx,
     n_tile_num,
     num_pid_m,
-    num_pid_in_group,
     stride_z,
     stride_h,
     stride_tok,
     H,
     N_CTX,  #
     BLOCK_M1: tl.constexpr,
-    BLOCK_N1: tl.constexpr,
     GROUP_SIZE_M: tl.constexpr,
 ):
     # Apply PID swizzling similar to _compute_offsets_persistent
@@ -1610,7 +1608,7 @@ def bwd_calculate_offsets_persistent(
     off_bh = (
         (stride_h * (bhid % H) + stride_z * (bhid // H)).to(tl.int64)
     ) // stride_tok
-    start_n = pid * BLOCK_N1
+    start_n = pid
     start_m = 0
     num_steps = (N_CTX - start_m) // BLOCK_M1
     return off_chz, off_bh, start_m, start_n, num_steps
@@ -1670,7 +1668,6 @@ def _attn_bwd_ws_persistent(
     #   q.shape[0] * q.shape[1],
     n_tile_num = tl.cdiv(N_CTX, BLOCK_N1)
     num_pid_m = Z * H
-    num_pid_in_group = GROUP_SIZE_M * n_tile_num
     prog_id = tl.program_id(0)
     num_progs = tl.num_programs(0)
     total_tiles = n_tile_num * Z * H
@@ -1779,14 +1776,12 @@ def _attn_bwd_ws_persistent(
                         tile_idx,
                         n_tile_num,
                         num_pid_m,
-                        num_pid_in_group,
                         stride_z,
                         stride_h,
                         stride_tok,
                         H,
                         N_CTX,
                         BLOCK_M1,
-                        BLOCK_N1,
                         GROUP_SIZE_M,
                     )
                 )
@@ -1828,17 +1823,16 @@ def _attn_bwd_ws_persistent(
                         tile_idx,
                         n_tile_num,
                         num_pid_m,
-                        num_pid_in_group,
                         stride_z,
                         stride_h,
                         stride_tok,
                         H,
                         N_CTX,
                         BLOCK_M1,
-                        BLOCK_N1,
                         GROUP_SIZE_M,
                     )
                 )
+                start_block_n = start_n * BLOCK_N1
 
                 # offset pointers for batch/head
                 M_updated = M + off_chz
@@ -1849,9 +1843,9 @@ def _attn_bwd_ws_persistent(
                 q_out_dtype = tlx.dtype_of(desc_q)
                 if STAGE & 1:
                     # TODO: Move to a helper function. Need to fix a layout bug in TLX.
-                    offs_n = start_n + tl.arange(0, BLOCK_N1)
+                    offs_n = start_block_n + tl.arange(0, BLOCK_N1)
                     lo, hi = _get_unfused_bwd_loop_bounds(
-                        N_CTX, BLOCK_M1, STAGE=4 - STAGE
+                        start_n, N_CTX, BLOCK_N1, STAGE=4 - STAGE
                     )
                     num_steps = (hi - lo) // BLOCK_M1
                     for _ in range(num_steps):
@@ -1900,9 +1894,54 @@ def _attn_bwd_ws_persistent(
                         tlx.barrier_arrive(tlx.local_view(ds_fulls, ds_buf_id))
                         curr_m += step_m
                         blk_idx += 1
-                # TODO: Add the STAGE & 2 handling when we can determine bounds to divide
-                # the work across two loops, based on optimizing out the mask.
-                # epilogue
+                if STAGE & 2:
+                    # TODO: Move to a helper function. Need to fix a layout bug in TLX.
+                    lo, hi = _get_unfused_bwd_loop_bounds(
+                        start_n, N_CTX, BLOCK_N1, STAGE=2
+                    )
+                    num_steps = (hi - lo) // BLOCK_M1
+                    for _ in range(num_steps):
+                        tmem_buf_id, tmem_phase = _get_bufidx_phase(
+                            blk_idx, NUM_BUFFERS_TMEM
+                        )
+                        ds_buf_id, ds_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_DS)
+
+                        offs_m = curr_m + tl.arange(0, BLOCK_M1)
+                        m = tl.load(M_updated + offs_m)
+
+                        # wait for qkT = tl.dot(k, qT)
+                        tlx.barrier_wait(
+                            tlx.local_view(qk_fulls, tmem_buf_id), tmem_phase
+                        )
+                        qkT = tlx.local_load(tlx.local_view(qk_tiles, tmem_buf_id))
+                        tlx.barrier_arrive(tlx.local_view(qk_empties, tmem_buf_id))
+
+                        pT = tl.math.exp2(qkT - m[None, :])
+                        # ppT *= qk_scale
+                        ppT = pT
+                        ppT = ppT.to(do_out_dtype)
+                        tlx.local_store(tlx.local_view(p_tiles, tmem_buf_id), ppT)
+                        tlx.barrier_arrive(tlx.local_view(p_fulls, tmem_buf_id))
+
+                        # D (= delta) is pre-divided by ds_scale.
+                        Di = tl.load(D_updated + offs_m)
+
+                        # Wait for dpT = tl.dot(v, tl.trans(do))
+                        tlx.barrier_wait(
+                            tlx.local_view(dp_fulls, tmem_buf_id), tmem_phase
+                        )
+                        dpT = tlx.local_load(tlx.local_view(dp_tiles, tmem_buf_id))
+                        # We can only signal the arrive if DP is not shared with DQ.
+                        # Otherwise we need to wait for DQ to be done.
+                        if not REUSE_DP_FOR_DQ:
+                            tlx.barrier_arrive(tlx.local_view(dp_empties, tmem_buf_id))
+                        dsT = pT * (dpT - Di[None, :])
+                        dsT = dsT.to(q_out_dtype)
+                        tlx.local_store(tlx.local_view(ds_tiles, ds_buf_id), dsT)
+                        tlx.fence_async_shared()
+                        tlx.barrier_arrive(tlx.local_view(ds_fulls, ds_buf_id))
+                        curr_m += step_m
+                        blk_idx += 1
                 kv_buf_id, kv_phase = _get_bufidx_phase(i, NUM_BUFFERS_KV)
 
                 tlx.barrier_wait(dv_fulls[kv_buf_id], kv_phase)
@@ -1915,7 +1954,7 @@ def _attn_bwd_ws_persistent(
                     )
                     dv = tlx.local_load(dv_slice)
                     desc_dv.store(
-                        [(off_bh + start_n).to(tl.int32), slice_id * slice_size],
+                        [(off_bh + start_block_n).to(tl.int32), slice_id * slice_size],
                         dv.to(tlx.dtype_of(desc_dv)),
                     )
                 tlx.barrier_arrive(dv_empties[kv_buf_id])
@@ -1930,7 +1969,7 @@ def _attn_bwd_ws_persistent(
                     dk = tlx.local_load(dk_slice)
                     dk *= sm_scale
                     desc_dk.store(
-                        [(off_bh + start_n).to(tl.int32), slice_id * slice_size],
+                        [(off_bh + start_block_n).to(tl.int32), slice_id * slice_size],
                         dk.to(tlx.dtype_of(desc_dk)),
                     )
                 tlx.barrier_arrive(dk_empties[kv_buf_id])
@@ -1945,14 +1984,12 @@ def _attn_bwd_ws_persistent(
                     tile_idx,
                     n_tile_num,
                     num_pid_m,
-                    num_pid_in_group,
                     stride_z,
                     stride_h,
                     stride_tok,
                     H,
                     N_CTX,
                     BLOCK_M1,
-                    BLOCK_N1,
                     GROUP_SIZE_M,
                 )
 
@@ -2140,17 +2177,16 @@ def _attn_bwd_ws_persistent(
                         tile_idx,
                         n_tile_num,
                         num_pid_m,
-                        num_pid_in_group,
                         stride_z,
                         stride_h,
                         stride_tok,
                         H,
                         N_CTX,
                         BLOCK_M1,
-                        BLOCK_N1,
                         GROUP_SIZE_M,
                     )
                 )
+                start_block_n = start_n * BLOCK_N1
                 # Load K
                 kv_buf_id, kv_phase = _get_bufidx_phase(i, NUM_BUFFERS_KV)
                 tlx.barrier_wait(k_empties[kv_buf_id], kv_phase ^ 1)
@@ -2160,7 +2196,7 @@ def _attn_bwd_ws_persistent(
                 tlx.async_descriptor_load(
                     desc_k,
                     k_tiles[kv_buf_id],
-                    [(off_bh + start_n).to(tl.int32), 0],
+                    [(off_bh + start_block_n).to(tl.int32), 0],
                     k_fulls[kv_buf_id],
                 )
 
@@ -2185,7 +2221,7 @@ def _attn_bwd_ws_persistent(
                 tlx.async_descriptor_load(
                     desc_v,
                     v_tiles[kv_buf_id],
-                    [(off_bh + start_n).to(tl.int32), 0],
+                    [(off_bh + start_block_n).to(tl.int32), 0],
                     v_fulls[kv_buf_id],
                 )
 


### PR DESCRIPTION
Summary: Splits the causal calculation across 2 loops to optimze out the masking generration.

Reviewed By: htyu

Differential Revision: D89000388


