### PR TITLE
sync per critertion change

### DIFF
--- a/tritonbench/components/do_bench/run.py
+++ b/tritonbench/components/do_bench/run.py
@@ -547,9 +547,8 @@ def _do_bench_entropy(
             fn()
             batch_end_events[i].record()
 
-        torch.cuda.synchronize()
-
         for i in range(batch_size):
+            batch_end_events[i].synchronize()
             v = round(
                 batch_start_events[i].elapsed_time(batch_end_events[i]), rounding_factor
             )


### PR DESCRIPTION
Summary: adding measurements to the entropy criterion is not free, but its work is entirely based on the CPU. we can be a bit faster by pipelining this work with the GPU work of the warmups actually running. the strategy is simple: we synchronize only on the event that we want to add to the entropy criterion, such that the subsequent GPU work can continue to process while the entropy criterion is updated

Reviewed By: jhou-jpg

Differential Revision: D89196043


