### PR TITLE
[tritonparse] Enable more tensor information in tritonparse logging

### DIFF
--- a/tritonbench/utils/tritonparse_utils.py
+++ b/tritonbench/utils/tritonparse_utils.py
@@ -35,7 +35,9 @@ def tritonparse_init(tritonparse_log_path):
             import tritonparse.structured_logging
 
             tritonparse.structured_logging.init(
-                f"{tritonparse_log_path}/raw_logs", enable_trace_launch=True
+                f"{tritonparse_log_path}/raw_logs",
+                enable_trace_launch=True,
+                enable_more_tensor_information=True,
             )
             print(
                 f"TritonParse structured logging initialized with log path: {tritonparse_log_path}"


### PR DESCRIPTION

## Changes

This PR enables the `enable_more_tensor_information` flag in TritonParse structured logging initialization within tritonbench.

## What

- Added `enable_more_tensor_information=True` parameter to `tritonparse.structured_logging.init()` call in `tritonbench/utils/tritonparse_utils.py`

## Why

When running tritonbench with `--tritonparse` flag, the additional tensor metadata (tensor values' min, max, std, and mean) will now be captured during tracing. This provides richer debugging information for analyzing kernel behavior and reproducing issues and more robust reproduce quality.

## Test Plan

- Run tritonbench with `--tritonparse` flag and verify that additional tensor information is captured in the logs.
