### PR TITLE
Add ctas_per_cga for PAIR_CTA mode in TLX kernels

### DIFF
--- a/tritonbench/operators/gemm/tlx_matmul.py
+++ b/tritonbench/operators/gemm/tlx_matmul.py
@@ -27,6 +27,7 @@ def get_cuda_autotune_config():
             num_warps=4,
             num_stages=1,
             pre_hook=matmul_tma_set_block_size_hook,
+            ctas_per_cga=(2, 1, 1) if pairCTA else None,
         )
         for BM in [128, 256]
         for BN in [128, 256, 512]


### PR DESCRIPTION
Summary:
X-link: https://github.com/meta-recsys/generative-recommenders/pull/431

Add `ctas_per_cga` parameter to `triton.Config` when `PAIR_CTA` is enabled, following the pattern from D89389230 which introduces CUDA-native cluster launch semantics.

This change affects:
- `tritonbench/operators/gemm/tlx_matmul.py`: Added `ctas_per_cga=(2, 1, 1) if pairCTA else None` to the autotune config
- `generative_recommenders/ops/triton/triton_addmm.py`: Added `c.ctas_per_cga = (2, 1, 1) if pair_cta_compatible else None` in `_prune_configs_for_pair_cta`

The `ctas_per_cga` parameter enables CUDA-native cluster launch semantics (TLX way), which differs from Triton's `num_ctas` approach:
- **Triton's way** (`num_ctas`): Grid is multiplied by cluster_dims to get total CTAs
- **TLX/CUDA way** (`ctas_per_cga`): Grid equals total CTAs, ctas_per_cga regroups them into clusters

Reviewed By: rafaykhurram

Differential Revision: D89439254


