### PR TITLE
[ci] Test meta-triton instead of pytorch

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -13,7 +13,7 @@ jobs:
   h100-pytorch-test:
     uses: ./.github/workflows/_linux-test-h100.yml
     with:
-      conda_env: "pytorch"
+      conda_env: "meta-triton"
   h100-triton-main-test:
     uses: ./.github/workflows/_linux-test-h100.yml
     with:


### PR DESCRIPTION
We don't find testing pytorch triton env very useful, assume pytorch version of triton is already tested thoroughly.

Moving forward to test facebookexperimental/triton instead.