### PR TITLE
Add Diode Inductor max-autotune benchmarks to gemm, addmm

### DIFF
--- a/tritonbench/utils/diode_utils.py
+++ b/tritonbench/utils/diode_utils.py
@@ -1,0 +1,47 @@
+"""Diode (ML model for pruning autotuning configs) utils for TritonBench operators."""
+
+import logging
+
+from torch._inductor.choices import InductorChoices
+from torch._inductor.virtualized import V
+from tritonbench.utils.env_utils import is_fbcode
+
+if is_fbcode():  # Diode not available in OSS
+    import diode.torch_diode.config as diode_config
+    from diode.torch_diode.choices import DiodeInductorChoices
+    from diode.torch_diode.models.triton_gemm.model import GEMMModelV2, MODEL_CONFIGS
+    from diode.torch_diode.registry import get_registry, register
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+def setup_diode_model(
+    diode_version, topk: int = 1, expand_search_space: bool = True
+) -> tuple[int, bool]:
+    logger.info("[DIODE][TritonBench] Setup Diode model.")
+
+    old_topk = diode_config.topk
+    old_expand_search_space = diode_config.expand_search_space
+
+    diode_config.topk = topk
+    diode_config.expand_search_space = expand_search_space
+
+    gemm_diode_model: GEMMModelV2 = GEMMModelV2(
+        model_config=MODEL_CONFIGS[diode_version]
+    )
+    register(gemm_diode_model)
+
+    V.set_choices_handler(DiodeInductorChoices())
+
+    return old_topk, old_expand_search_space
+
+
+def teardown_diode_model(old_configs):
+    logger.info("[DIODE][TritonBench] Teardown Diode model.")
+
+    old_topk, old_expand_search_space = old_configs
+    diode_config.topk = old_topk
+    diode_config.expand_search_space = old_expand_search_space
+    get_registry().clear()
+    V.set_choices_handler(InductorChoices())

--- a/tritonbench/utils/env_utils.py
+++ b/tritonbench/utils/env_utils.py
@@ -238,3 +238,9 @@ def apply_precision(
         torch.backends.cudnn.allow_tf32 = True
     else:
         log.warning(f"[tritonbench] Precision {precision} is handled by operator.")
+
+
+def get_logger(name, level: int = logging.INFO):
+    logger = logging.getLogger(name)
+    logger.setLevel(level)
+    return logger

--- a/tritonbench/utils/parser.py
+++ b/tritonbench/utils/parser.py
@@ -383,6 +383,12 @@ def get_parser(args=None):
             type=str,
             help="Set what version of Triton we are using for logging purposes.",
         )
+        parser.add_argument(
+            "--diode-version",
+            type=str,
+            default="v4",
+            help="Version of diode to use. Default: v4",
+        )  # Diode not available in OSS
 
     args, extra_args = parser.parse_known_args(args)
     if args.op and args.ci:


### PR DESCRIPTION
Summary: Add Inductor max-autotune benchmarking using Diode to TritonBench for the `gemm` and `addmm` operators. This diff reduces friction in verifying Diode results against the base max-autotune results.

Differential Revision: D89835679


