### PR TITLE
Update tritonparse import path after module refactor

### DIFF
--- a/tritonbench/utils/tritonparse_utils.py
+++ b/tritonbench/utils/tritonparse_utils.py
@@ -65,7 +65,7 @@ def tritonparse_parse(tritonparse_log_path):
     if tritonparse_log_path is not None:
         # capture errors but don't fail the entire script
         try:
-            from tritonparse.utils import unified_parse
+            from tritonparse.parse.utils import unified_parse
 
             if is_fbcode():
                 out = None


### PR DESCRIPTION
Summary:
Update import path for `unified_parse` function from `tritonparse.utils` to `tritonparse.parse.utils` following the tritonparse module reorganization in D89906982.

The tritonparse library has moved parse-related functionality into a dedicated `parse/` subdirectory for better code organization.

Differential Revision: D89907203


