### PR TITLE
Gate Diode benchmark behind is_fbcode()

### DIFF
--- a/tritonbench/operators/addmm/operator.py
+++ b/tritonbench/operators/addmm/operator.py
@@ -151,7 +151,7 @@ class Operator(BenchmarkOperator):
             compiled(a, mat1, mat2)
         return lambda: compiled(a, mat1, mat2)
 
-    @register_benchmark(enabled=False)
+    @register_benchmark(enabled=is_fbcode())
     def pt2_addmm_maxautotune_diode(self, a, mat1, mat2) -> Callable:
         torch._dynamo.reset()
         logger.info("[DIODE][TritonBench] Run PT2 addmm Max-Autotune Diode benchmark")

--- a/tritonbench/operators/gemm/operator.py
+++ b/tritonbench/operators/gemm/operator.py
@@ -368,7 +368,7 @@ class Operator(BenchmarkOperator):
 
         return lambda: compiled(a, b)
 
-    @register_benchmark(enabled=False)
+    @register_benchmark(enabled=is_fbcode())
     def pt2_matmul_maxautotune_diode(self, a, b, bias) -> Callable:
         torch._dynamo.reset()
         logger.info("[DIODE][TritonBench] Run PT2 gemm Max-Autotune Diode benchmark")


### PR DESCRIPTION
Summary: Gate Diode benchmark behind `is_fbcode()`, as Diode isn't available in OSS.

Differential Revision: D90034463


