### PR TITLE
Migrate FBGEMM GenAI calls to MSLK

### DIFF
--- a/benchmarks/tagging/ast_analyzer.py
+++ b/benchmarks/tagging/ast_analyzer.py
@@ -438,6 +438,8 @@ def validate_edges(edges) -> Dict[str, str]:
             result_tags["kernels"].append(edge.caller)
         if "torch.ops.fbgemm" in edge.callee:
             result_tags["tags"].append("fbgemm")
+        if "torch.ops.mslk" in edge.callee:
+            result_tags["tags"].append("mslk")
         # heuristic: if no tag is found and maybe triton, apply triton tag
         if (
             not result_tags["tags"]

--- a/benchmarks/tagging/run.py
+++ b/benchmarks/tagging/run.py
@@ -166,6 +166,8 @@ def prevalidate_backends(backend_edges, op_name=None):
             }
             if any(["fbgemm" in callee for callee in callees]):
                 op_with_tags[backend]["tags"].append("fbgemm")
+            if any(["mslk" in callee for callee in callees]):
+                op_with_tags[backend]["tags"].append("mslk")
 
     # Apply name-based heuristics for all prevalidated backends
     for backend in op_with_tags.keys():

--- a/docs/install.md
+++ b/docs/install.md
@@ -18,7 +18,8 @@ If you run `python install.py` without any argument, it will do the following:
 - `--liger`: Install [liger-kernel-nightly](https://github.com/linkedin/Liger-Kernel) package (Triton).
 - `--fa3`: Install Flash Attention 3 (CUTLASS).
 - `--fa2`: Install Flash Attention 2 (CUTLASS).
-- `--fbgemm`: Install FBGEMM GenAI kernels (CUTLASS and Triton).
+- `--fbgemm`: Install FBGEMM GPU kernels.
+- `--mslk`: Install MSLK kernels (CUTLASS and Triton).
 - `--jax`: Install JAX (Pallas and Mosaic).
 - `--tk`: Install [ThunderKittens](https://github.com/HazyResearch/ThunderKittens).
 - `--tile`: Install [Tile Lang](https://github.com/tile-ai/tilelang).

--- a/install.py
+++ b/install.py
@@ -88,24 +88,22 @@ def setup_hip(args: argparse.Namespace):
     args.all = False
     args.liger = True
     args.aiter = True
-    args.fbgemm = True
+    args.mslk = True
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(allow_abbrev=False)
     parser.add_argument("--numpy", action="store_true", help="Install suggested numpy")
     parser.add_argument(
-        "--fbgemm", action="store_true", help="Install prebuilt FBGEMM GPU (genai only)"
+        "--fbgemm", action="store_true", help="Install prebuilt FBGEMM"
     )
     parser.add_argument(
-        "--fbgemm-compile",
-        action="store_true",
-        help="Compile and install FBGEMM GPU (genai only)",
+        "--mslk", action="store_true", help="Install prebuilt MSLK"
     )
     parser.add_argument(
-        "--fbgemm-all",
+        "--mslk-compile",
         action="store_true",
-        help="Compoile and install all FBGEMM GPU kernels.",
+        help="Compile and install MSLK",
     )
     parser.add_argument(
         "--fa2", action="store_true", help="Install optional flash_attention 2 kernels"
@@ -156,16 +154,23 @@ if __name__ == "__main__":
 
         install_fa3()
     if args.fbgemm or args.all:
-        logger.info("[tritonbench] installing prebuilt FBGEMM GenAI variant...")
+        logger.info("[tritonbench] installing prebuilt FBGEMM GPU...")
         from tools.fbgemm.install import install_fbgemm, test_fbgemm
 
-        install_fbgemm(genai=True, prebuilt=True)
-    elif args.fbgemm_compile or args.fbgemm_all:
-        logger.info("[tritonbench] compiling and installing FBGEMM...")
-        from tools.fbgemm.install import install_fbgemm, test_fbgemm
-
-        install_fbgemm(genai=(not args.fbgemm_all), prebuilt=False)
+        install_fbgemm(prebuilt=True)
         test_fbgemm()
+    if args.mslk or args.all:
+        logger.info("[tritonbench] installing prebuilt MSLK...")
+        from tools.mslk.install import install_mslk, test_mslk
+
+        install_mslk(prebuilt=True)
+        test_mslk()
+    elif args.mslk_compile:
+        logger.info("[tritonbench] compiling and installing MSLK...")
+        from tools.mslk.install import install_mslk, test_mslk
+
+        install_mslk(prebuilt=False)
+        test_mslk()
     if args.fa2:
         logger.info("[tritonbench] installing fa2 from source...")
         install_fa2(compile=True)

--- a/tools/fbgemm/install.py
+++ b/tools/fbgemm/install.py
@@ -13,21 +13,20 @@ FBGEMM_REPO = "https://github.com/pytorch/FBGEMM"
 FBGEMM_COMMIT = "7cbaff699e784736b5650dfa51d62c251b028717"
 
 
-def install_fbgemm(genai=True, prebuilt=True):
+def install_fbgemm(prebuilt=True):
     if prebuilt:
-        install_prebuilt_fbgemm(genai)
+        install_prebuilt_fbgemm()
     else:
-        install_build_fbgemm(genai)
+        install_build_fbgemm()
 
 
-def install_prebuilt_fbgemm(genai=True):
-    assert genai, "in prebuilt fbgemm package, we only support genai now"
+def install_prebuilt_fbgemm():
     toolkit_version = get_toolkit_version_from_torch()
     cmd = [
         "pip",
         "install",
         "--pre",
-        "fbgemm-gpu-genai",
+        "fbgemm-gpu",
         "-i",
         f"https://download.pytorch.org/whl/nightly/{toolkit_version}",
     ]
@@ -60,36 +59,13 @@ def install_build_fbgemm(genai=True):
     )
     # Build target H100(9.0, 9.0a) and blackwell (10.0, 12.0)
     extra_envs = os.environ.copy()
-    if genai:
-        if not is_hip():
-            cmd = [
-                sys.executable,
-                "setup.py",
-                "install",
-                "--build-target=genai",
-                "-DTORCH_CUDA_ARCH_LIST=9.0;9.0a;10.0;12.0",
-            ]
-        elif is_hip():
-            # build for MI300(gfx942) and MI350(gfx950)
-            current_conda_env = os.environ.get("CONDA_DEFAULT_ENV")
-            cmd = [
-                "bash",
-                "-c",
-                f'. .github/scripts/setup_env.bash; integration_fbgemm_gpu_build_and_install {current_conda_env} genai/rocm "{fbgemm_repo_path}"',
-            ]
-            extra_envs["BUILD_ROCM_VERSION"] = "7.0"
-            subprocess.check_call(
-                cmd, cwd=str(fbgemm_repo_path.resolve()), env=extra_envs
-            )
-            return
-    else:
-        cmd = [
-            sys.executable,
-            "setup.py",
-            "install",
-            "--build-target=cuda",
-            "-DTORCH_CUDA_ARCH_LIST=9.0;9.0a;10.0;12.0",
-        ]
+    cmd = [
+        sys.executable,
+        "setup.py",
+        "install",
+        "--build-target=cuda",
+        "-DTORCH_CUDA_ARCH_LIST=9.0;9.0a;10.0;12.0",
+    ]
     subprocess.check_call(cmd, cwd=str(fbgemm_repo_path.resolve()), env=extra_envs)
 
 
@@ -99,10 +75,7 @@ def test_fbgemm():
     cmd = [
         sys.executable,
         "-c",
-        "import fbgemm_gpu.experimental.gemm.triton_gemm.fp8_gemm",
+        "from fbgemm_gpu.quantize_utils import fp32_to_mx4",
     ]
-    subprocess.check_call(cmd)
-    # test genai (cutlass or ck)
-    cmd = [sys.executable, "-c", "import fbgemm_gpu.experimental.gen_ai"]
     subprocess.check_call(cmd)
     print("OK")

--- a/tools/mslk/install.py
+++ b/tools/mslk/install.py
@@ -1,0 +1,99 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from tritonbench.utils.env_utils import is_hip
+
+# requires torch
+from ..cuda_utils import get_toolkit_version_from_torch
+
+REPO_PATH = Path(os.path.abspath(__file__)).parent.parent.parent
+MSLK_INSTALL_PATH = REPO_PATH.joinpath(".install", "MSLK")
+MSLK_REPO = "https://github.com/meta-pytorch/MSLK"
+MSLK_COMMIT = "7ad994918da19fe2d148533670f472ad661c54ce"
+
+
+def install_mslk(prebuilt=True):
+    if prebuilt:
+        install_prebuilt_mslk()
+    else:
+        install_build_mslk()
+
+
+def install_prebuilt_mslk():
+    toolkit_version = get_toolkit_version_from_torch()
+    cmd = [
+        "pip",
+        "install",
+        "--pre",
+        "mslk",
+        "-i",
+        f"https://download.pytorch.org/whl/nightly/{toolkit_version}",
+    ]
+    subprocess.check_call(cmd)
+
+
+def checkout_mslk():
+    git_clone_cmd = ["git", "clone", MSLK_REPO]
+    subprocess.check_call(git_clone_cmd, cwd=MSLK_INSTALL_PATH)
+    mslk_repo_path = MSLK_INSTALL_PATH.joinpath("MSLK")
+    git_checkout_cmd = ["git", "checkout", MSLK_COMMIT]
+    subprocess.check_call(git_checkout_cmd, cwd=mslk_repo_path)
+    git_submodule_checkout_cmd = [
+        "git",
+        "submodule",
+        "update",
+        "--init",
+        "--recursive",
+    ]
+    subprocess.check_call(git_submodule_checkout_cmd, cwd=mslk_repo_path)
+
+
+def install_build_mslk():
+    mslk_repo_path = MSLK_INSTALL_PATH.joinpath("MSLK")
+    if not os.path.exists(mslk_repo_path):
+        checkout_mslk()
+    cmd = ["pip", "install", "-r", "requirements.txt"]
+    subprocess.check_call(
+        cmd, cwd=str(mslk_repo_path)
+    )
+    # Build target H100(9.0, 9.0a) and blackwell (10.0, 12.0)
+    extra_envs = os.environ.copy()
+    if not is_hip():
+        cmd = [
+            sys.executable,
+            "setup.py",
+            "install",
+            "--build-target=default",
+            "-DTORCH_CUDA_ARCH_LIST=9.0;9.0a;10.0;12.0",
+        ]
+    elif is_hip():
+        # build for MI300(gfx942) and MI350(gfx950)
+        current_conda_env = os.environ.get("CONDA_DEFAULT_ENV")
+        cmd = [
+            "bash",
+            "-c",
+            f'. .github/scripts/setup_env.bash; integration_mslk_build_and_install {current_conda_env} default/rocm "{mslk_repo_path}"',
+        ]
+        extra_envs["BUILD_ROCM_VERSION"] = "7.0"
+        subprocess.check_call(
+            cmd, cwd=str(mslk_repo_path.resolve()), env=extra_envs
+        )
+        return
+    subprocess.check_call(cmd, cwd=str(mslk_repo_path.resolve()), env=extra_envs)
+
+
+def test_mslk():
+    print("Checking mslk installation...", end="")
+    # test triton
+    cmd = [
+        sys.executable,
+        "-c",
+        "import mslk.gemm.triton.fp8_gemm as fp8_gemm",
+    ]
+    subprocess.check_call(cmd)
+    # test mslk
+    cmd = [sys.executable, "-c", "import mslk"]
+    subprocess.check_call(cmd)
+    print("OK")

--- a/tritonbench/metadata/oss_cuda_kernels.yaml
+++ b/tritonbench/metadata/oss_cuda_kernels.yaml
@@ -141,12 +141,12 @@ decoding_attention:
   fa3_mha_varlen_fwd:
     tags:
     - xformers
-  fbgemm_gqa_fp8kv:
+  mslk_gqa_fp8kv:
     kernels:
-    - torch.ops.fbgemm.gqa_attn_splitk
+    - torch.ops.mslk.gqa_attn_splitk
     tags:
     - native_custom_ops
-    - fbgemm
+    - mslk
   flash_cute_dsl:
     tags: []
   triton_splitk:
@@ -318,10 +318,10 @@ fp8_gemm:
 fp8_gemm_blockwise:
   _cutlass:
     kernels:
-    - torch.ops.fbgemm.f8f8bf16_blockwise
+    - torch.ops.mslk.f8f8bf16_blockwise
     tags:
     - native_custom_ops
-    - fbgemm
+    - mslk
     - cutlass
   _triton:
     kernels:
@@ -337,18 +337,18 @@ fp8_gemm_rowwise:
     - triton
   _cublas:
     kernels:
-    - torch.ops.fbgemm.f8f8bf16_cublas
-    - torch.ops.fbgemm.f8f8bf16_cublas
+    - torch.ops.mslk.f8f8bf16_cublas
+    - torch.ops.mslk.f8f8bf16_cublas
     tags:
     - native_custom_ops
-    - fbgemm
+    - mslk
   _cutlass_or_ck:
     kernels:
-    - torch.ops.fbgemm.f8f8bf16_rowwise
-    - torch.ops.fbgemm.f8f8bf16_rowwise
+    - torch.ops.mslk.f8f8bf16_rowwise
+    - torch.ops.mslk.f8f8bf16_rowwise
     tags:
     - native_custom_ops
-    - fbgemm
+    - mslk
     - cutlass
   _triton:
     kernels:
@@ -363,10 +363,10 @@ fp8_gemm_rowwise:
 fp8_gemm_rowwise_grouped:
   _cutlass_or_ck:
     kernels:
-    - torch.ops.fbgemm.f8f8bf16_rowwise_grouped_stacked
+    - torch.ops.mslk.f8f8bf16_rowwise_grouped_stacked
     tags:
     - native_custom_ops
-    - fbgemm
+    - mslk
     - cutlass
   _triton:
     kernels:

--- a/tritonbench/operators/decoding_attention/operator.py
+++ b/tritonbench/operators/decoding_attention/operator.py
@@ -52,11 +52,8 @@ except (ImportError, IOError, AttributeError):
     HAS_XFORMERS = False
 
 try:
+    import mslk.attention.gqa_attn_splitk  # noqa: F401
     from gen_ai.llm_inference.fb.llm.quantization.kv_quantize import quantize_kv_fp8
-
-    torch.ops.load_library(
-        "//deeplearning/fbgemm/fbgemm_gpu/experimental:gen_ai_attention_ops"
-    )
 
     HAS_FB_IMPORT = True
 except ImportError:
@@ -81,7 +78,7 @@ except (ImportError, IOError, AttributeError):
 # [Optional] cutlass_blackwell_fmha backend
 HAS_CUTLASS_BLACKWELL = True
 try:
-    from fbgemm_gpu.experimental.gen_ai.attention.cutlass_blackwell_fmha import (
+    from mslk.attention.cutlass_blackwell_fmha import (
         cutlass_blackwell_fmha_interface as blackwell,
     )
 
@@ -566,7 +563,7 @@ class Operator(BenchmarkOperator):
         )
 
     @register_benchmark(enabled=False)
-    def fbgemm_gqa_fp8kv(
+    def mslk_gqa_fp8kv(
         self,
         q: torch.Tensor,
         k_cache: torch.Tensor,
@@ -577,7 +574,7 @@ class Operator(BenchmarkOperator):
 
         k_fp8 = quantize_kv_fp8(k_cache, kv_cache_quant_num_groups).view(torch.uint8)
         v_fp8 = quantize_kv_fp8(v_cache, kv_cache_quant_num_groups).view(torch.uint8)
-        return lambda: torch.ops.fbgemm.gqa_attn_splitk(
+        return lambda: torch.ops.mslk.gqa_attn_splitk(
             q,
             k_fp8,
             v_fp8,

--- a/tritonbench/operators/fp8_gemm_blockwise/operator.py
+++ b/tritonbench/operators/fp8_gemm_blockwise/operator.py
@@ -29,9 +29,7 @@ def parse_args(args: List[str]) -> argparse.Namespace:
 HAS_TRITON = False
 if is_cuda():
     try:
-        from fbgemm_gpu.experimental.gemm.triton_gemm.fp8_gemm import (
-            matmul_fp8_block as triton_fp8_block,
-        )
+        from mslk.gemm.triton.fp8_gemm import matmul_fp8_block as triton_fp8_block
 
         HAS_TRITON = True
     except:
@@ -42,15 +40,15 @@ if is_cuda():
 HAS_CUTLASS = False
 if is_cuda():
     try:
-        import fbgemm_gpu.experimental.gen_ai
+        import mslk.gemm
 
         cutlass_fp8_block = torch.ops.llama_cpp.fp8_blockwise_matmul
         HAS_CUTLASS = True
     except:
         try:
-            import fbgemm_gpu.experimental.gen_ai
+            import mslk.gemm
 
-            cutlass_fp8_block = torch.ops.fbgemm.f8f8bf16_blockwise
+            cutlass_fp8_block = torch.ops.mslk.f8f8bf16_blockwise
             HAS_CUTLASS = True
         except:
             HAS_CUTLASS = False

--- a/tritonbench/operators/fp8_gemm_rowwise/operator.py
+++ b/tritonbench/operators/fp8_gemm_rowwise/operator.py
@@ -86,9 +86,7 @@ HAS_CUBLAS = False
 from tritonbench.utils.fp8_utils import get_fp8_constants
 
 try:
-    from fbgemm_gpu.experimental.gemm.triton_gemm.fp8_gemm import (
-        matmul_fp8_row as triton_fp8_row,
-    )
+    from mslk.gemm.triton.fp8_gemm import matmul_fp8_row as triton_fp8_row
 
     if not torch.version.hip:
         assert hasattr(
@@ -99,19 +97,19 @@ except (ImportError, AssertionError):
     HAS_TRITON = False
 
 try:
-    import fbgemm_gpu.experimental.gen_ai  # noqa: F401
+    import mslk.gemm  # noqa: F401
 
-    cutlass_or_ck_fp8_row = torch.ops.fbgemm.f8f8bf16_rowwise
+    cutlass_or_ck_fp8_row = torch.ops.mslk.f8f8bf16_rowwise
     # TODO: remove these b200 hacks.
     HAS_CUTLASS_OR_CK = is_hip() or (is_cuda() and not IS_BLACKWELL)
 except (ImportError, AttributeError, FileNotFoundError, OSError):
     HAS_CUTLASS_OR_CK = False
 
 try:
-    import fbgemm_gpu.experimental.gen_ai  # noqa: F401
+    import mslk.gemm  # noqa: F401
 
-    cublas_fp8_row = torch.ops.fbgemm.f8f8bf16_cublas
-    from fbgemm_gpu.experimental.gemm.triton_gemm.fp8_gemm import scale_fp8_row
+    cublas_fp8_row = torch.ops.mslk.f8f8bf16_cublas
+    from mslk.quantize.triton.fp8_quantize import scale_fp8_row
 
     # TODO: remove these b200 hacks.
     HAS_CUBLAS = is_cuda() and not IS_BLACKWELL

--- a/tritonbench/operators/fp8_gemm_rowwise_grouped/operator.py
+++ b/tritonbench/operators/fp8_gemm_rowwise_grouped/operator.py
@@ -162,10 +162,7 @@ from tritonbench.utils.fp8_utils import get_fp8_constants
 
 # Try to import Triton grouped GEMM module
 try:
-    from fbgemm_gpu.experimental.gemm.triton_gemm.grouped_gemm import (
-        grouped_gemm as grouped_gemm,
-        grouped_gemm_fp8_rowwise as grouped_gemm_fp8_rowwise,
-    )
+    from mslk.gemm.triton.grouped_gemm import grouped_gemm_fp8_rowwise
 
     # If import succeeds, set HAS_TRITON to True
     HAS_TRITON = True
@@ -175,10 +172,10 @@ except (ImportError, AssertionError):
 
 # Try to import Cutlass or CK module
 try:
-    import fbgemm_gpu.experimental.gen_ai  # noqa: F401
+    import mslk.gemm  # noqa: F401
 
     # Define the Cutlass or CK FP8 grouped MM operator
-    cutlass_or_ck_fp8_grouped_mm = torch.ops.fbgemm.f8f8bf16_rowwise_grouped_stacked
+    cutlass_or_ck_fp8_grouped_mm = torch.ops.mslk.f8f8bf16_rowwise_grouped_stacked
     # Set HAS_CUTLASS_OR_CK to True if import succeeds
     HAS_CUTLASS_OR_CK = True
 except (ImportError, AttributeError, OSError):


### PR DESCRIPTION
Summary: We are deprecating [FBGEMM GenAI](https://github.com/pytorch/FBGEMM/tree/main/fbgemm_gpu/experimental/gen_ai) in favor of [MSLK](https://github.com/meta-pytorch/MSLK). In this PR we update the tritonbench project to use the MSLK project instead of FBGEMM GPU GenAI.

Note there are 2 ops (mx4_to_fp32, fp32_to_mx4) from FBGEMM GPU that is used in Tritonbench, that was accidentally part of FBGEMM GenAI. For this reason, we leave the ability to install FBGEMM GPU (`--fbgemm`) so this kernel could be benchmarked still.

Differential Revision: D90124993
