### PR TITLE
Revert https://github.com/meta-pytorch/tritonbench/pull/752

### DIFF
--- a/tritonbench/operators/gemm/operator.py
+++ b/tritonbench/operators/gemm/operator.py
@@ -544,12 +544,7 @@ class Operator(BenchmarkOperator):
             compiled_artifact = kernel.compile(args)
 
             def out():
-                kernel.run(
-                    args,
-                    compiled_artifact,
-                    stream=torch.cuda.current_stream(),
-                    assume_supported_args=True,
-                )
+                kernel.run(args, compiled_artifact, assume_supported_args=True)
                 return c
 
             return out
@@ -567,12 +562,7 @@ class Operator(BenchmarkOperator):
             kernel, compiled_artifact = get_best_cutlass_api_kernel(args)
 
             def out():
-                kernel.run(
-                    args,
-                    compiled_artifact,
-                    stream=torch.cuda.current_stream(),
-                    assume_supported_args=True,
-                )
+                kernel.run(args, compiled_artifact, assume_supported_args=True)
                 return c
 
             return out


### PR DESCRIPTION
Summary:
https://github.com/meta-pytorch/tritonbench/pull/752 can't be merged because of merge conflict: https://www.internalfb.com/sandcastle/workflow/292733975791769309/artifact/actionlog.292733975995928419.stdout.1?selectedLines=3702-3702-10-19

Try reverting this so that the PR can be imported as Diff

Reviewed By: NikhilAPatel

Differential Revision: D90271271


