### PR TITLE
Turn off 2-CTA from tritonbench TLX matmul to 3.5+fb pin update landing

### DIFF
--- a/tritonbench/operators/gemm/tlx_matmul.py
+++ b/tritonbench/operators/gemm/tlx_matmul.py
@@ -27,7 +27,7 @@ def get_cuda_autotune_config():
             num_warps=4,
             num_stages=1,
             pre_hook=matmul_tma_set_block_size_hook,
-            ctas_per_cga=(2, 1, 1) if pairCTA else None,
+            # ctas_per_cga=(2, 1, 1) if pairCTA else None,
         )
         for BM in [128, 256]
         for BN in [128, 256, 512]
@@ -36,7 +36,8 @@ def get_cuda_autotune_config():
         for t in [1, 2, 3]
         for m in [1, 2]
         for subtile in [1, 2, 4, 8]
-        for pairCTA in [True, False]
+        # for pairCTA in [True, False]
+        for pairCTA in [False]
         for persistent in [True, False]
     ]
 


### PR DESCRIPTION
Summary:
to unblock landing 3.5+fb pin update stable-promo asap

We will need a few other patches such as D89389230 to make it pass but want to defer them after landing stable-promo

Created from CodeHub with https://fburl.com/edit-in-codehub

Reviewed By: agron911

Differential Revision: D90334458


