### PR TITLE
Add Diode topk to argument parsing

### DIFF
--- a/tritonbench/utils/parser.py
+++ b/tritonbench/utils/parser.py
@@ -389,12 +389,19 @@ def get_parser(args=None):
             type=str,
             help="Set what version of Triton we are using for logging purposes.",
         )
+        # Diode args (Diode not available in OSS)
         parser.add_argument(
             "--diode-version",
             type=str,
             default="v4",
             help="Version of diode to use. Default: v4",
-        )  # Diode not available in OSS
+        )
+        parser.add_argument(
+            "--diode-topk",
+            type=int,
+            default=1,
+            help="Top K kernels to return for Diode. Default: 1",
+        )
 
     args, extra_args = parser.parse_known_args(args)
     if args.op and args.ci:

--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -1138,7 +1138,8 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
                     )
                     if "diode" in bm_name:
                         self.old_diode_configs = setup_diode_model(
-                            self.tb_args.diode_version
+                            self.tb_args.diode_version,
+                            topk=self.tb_args.diode_topk,
                         )
                     acc[bm_name] = self._do_bench(
                         input_id=input_id,


### PR DESCRIPTION
Summary: Add `topk` to argument parsing, making it easier to tune Diode's `topk` parameter. We find that `topk=3` leads to much faster runtime for many shapes.

Differential Revision: D90355473


