### PR TITLE
rename ads_mkl quack to ads_mkl quack

### DIFF
--- a/tritonbench/operators/layer_norm/operator.py
+++ b/tritonbench/operators/layer_norm/operator.py
@@ -62,7 +62,7 @@ except ModuleNotFoundError:
     HAS_LIGER_KERNEL = False
 
 try:
-    from quack.quack_layernorm import layernorm as quack_layernorm
+    from ads_mkl.ops.cute_dsl.quack.quack_layernorm import layernorm as quack_layernorm
 
     HAS_QUACK_KERNEL = True
 except ModuleNotFoundError:


### PR DESCRIPTION
Summary:
* Move ads_mkl's quack to ads_mkl.ops.cute_dsl.quack.
* Flatten quack.quack to quack.

Reviewed By: santoshmo

Differential Revision: D90536604
