### PR TITLE
Add gpu_events latency measure mode

### DIFF
--- a/tritonbench/components/do_bench/common.py
+++ b/tritonbench/components/do_bench/common.py
@@ -1,0 +1,12 @@
+import torch
+
+
+def summarize_statistics(times, quantiles, return_mode):
+    if quantiles is not None:
+        ret = torch.quantile(times, torch.tensor(quantiles, dtype=torch.float)).tolist()
+        if len(ret) == 1:
+            ret = ret[0]
+        return ret
+    if return_mode == "all":
+        return times.tolist()
+    return getattr(torch, return_mode)(times).item()

--- a/tritonbench/components/do_bench/run.py
+++ b/tritonbench/components/do_bench/run.py
@@ -10,6 +10,9 @@ from torch._inductor.runtime.benchmarking import benchmarker
 from tritonbench.components.do_bench.entropy.entropy_criterion import EntropyCriterion
 from tritonbench.utils.constants import DEFAULT_N_REP, DEFAULT_N_WARMUP
 
+from .common import summarize_statistics
+from .gpu_events import do_bench_events
+
 from .power import do_bench_power
 
 NS_TO_MS = 1e-6
@@ -132,17 +135,6 @@ class Latency:
             self.times[i] /= scale
 
 
-def _summarize_statistics(times, quantiles, return_mode):
-    if quantiles is not None:
-        ret = torch.quantile(times, torch.tensor(quantiles, dtype=torch.float)).tolist()
-        if len(ret) == 1:
-            ret = ret[0]
-        return ret
-    if return_mode == "all":
-        return times.tolist()
-    return getattr(torch, return_mode)(times).item()
-
-
 def _do_bench_inductor(fn, warmup, rep, return_mode="all", grad_to_none=None):
     """Measure latency using inductor benchmarker.
 
@@ -177,7 +169,7 @@ def _do_bench_inductor(fn, warmup, rep, return_mode="all", grad_to_none=None):
         times_ms.append(ms_time)
 
     times = torch.tensor(times_ms, dtype=torch.float)
-    return _summarize_statistics(times, quantiles=None, return_mode=return_mode)
+    return summarize_statistics(times, quantiles=None, return_mode=return_mode)
 
 
 def _do_bench_cudagraph_with_cache_clear(
@@ -263,7 +255,7 @@ def _do_bench_cudagraph_with_cache_clear(
         all_kernel_times.append(kernel_time)
 
     times = torch.tensor(all_kernel_times, dtype=torch.float)
-    return _summarize_statistics(times, quantiles, return_mode)
+    return summarize_statistics(times, quantiles, return_mode)
 
 
 def _do_bench_profiler(
@@ -425,7 +417,7 @@ def _do_bench_profiler(
         torch.cuda.synchronize()
 
     times = torch.tensor(all_kernel_times, dtype=torch.float)
-    return _summarize_statistics(times, quantiles=None, return_mode=return_mode)
+    return summarize_statistics(times, quantiles=None, return_mode=return_mode)
 
 
 def _do_bench_cpu(
@@ -466,7 +458,7 @@ def _do_bench_cpu(
         t1 = time.time_ns()
         times_ms.append((t1 - t0) * NS_TO_MS)
     times = torch.tensor(times_ms, dtype=torch.float)
-    return _summarize_statistics(times, quantiles, return_mode)
+    return summarize_statistics(times, quantiles, return_mode)
 
 
 def _do_bench_entropy(
@@ -626,7 +618,7 @@ def _do_bench_entropy(
     benchmark_times = [s.elapsed_time(e) for s, e in zip(start_events, end_events)]
 
     times = torch.tensor(benchmark_times, dtype=torch.float)
-    return _summarize_statistics(times, quantiles, return_mode)
+    return summarize_statistics(times, quantiles, return_mode)
 
 
 def do_bench_wrapper(
@@ -711,6 +703,17 @@ def do_bench_wrapper(
                     use_cuda_graphs=use_cuda_graphs,
                 ),
                 remove_outliers=False,
+            )
+        elif latency_measure_mode == "gpu_events":
+            return Latency(
+                times=do_bench_events(
+                    fn,
+                    warmup=warmup,
+                    rep=rep,
+                    return_mode="all",
+                    grad_to_none=grad_to_none,
+                    skip_cache_clearing=skip_cache_clearing,
+                )
             )
         else:
             bench_fn = (

--- a/tritonbench/utils/parser.py
+++ b/tritonbench/utils/parser.py
@@ -260,7 +260,7 @@ def get_parser(args=None):
     parser.add_argument(
         "--latency-measure-mode",
         default="triton_do_bench",
-        choices=["triton_do_bench", "inductor_benchmarker", "profiler"],
+        choices=["triton_do_bench", "inductor_benchmarker", "profiler", "gpu_events"],
         help="Method to measure latency: triton_do_bench (default), inductor_benchmarker, profiler.",
     )
     parser.add_argument(


### PR DESCRIPTION
Summary:
Add the `gpu_events` option in `--latency-measure-mode` to enable
precise measurement of GPU kernel execution time using CUDA events.
This mode improves timing accuracy for small kernels by launching a
`block_stream_kernel` that holds the GPU stream until all kernels have
been dispatched, ensuring that timing does not include host dispatch
or scheduling overhead. Once dispatch is complete, the host signals
the GPU to proceed by running `unblock_stream_kernel`, allowing for
accurate kernel timing.

Note that there is a limit to the number of kernels that can be
dispatched per stream, so it is recommended to use
`CUDA_SCALE_LAUNCH_QUEUES=4x` to increase the stream capacity. The
number of benchmark iterations is automatically adjusted: if a timeout
occurs in `block_stream_kernel`, the iteration count is halved and
retried; if a timeout persists with only one iteration, the benchmark
fails. In case of repeated failures, it is advised to reduce the
number of kernels benchmarked per function in each iteration.

Differential Revision: D90559689


