### PR TITLE
Add --max-inputs-per-iter in blackwell_attentions

### DIFF
--- a/tritonbench/operators/blackwell_attentions/generate_inputs.py
+++ b/tritonbench/operators/blackwell_attentions/generate_inputs.py
@@ -15,7 +15,7 @@ def get_bytes(x):
 
 
 def _generated_qkv_inputs(
-    shape, dtype, device, gen_cache_size_inputs
+    shape, dtype, device, gen_cache_size_inputs, max_inputs_per_iter
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     requires_grad = True
 
@@ -48,6 +48,8 @@ def _generated_qkv_inputs(
         # Fix to 128 MB for now
         min_bytes = 128 * 1024 * 1024
         num_inputs = math.ceil(min_bytes / total_bytes)
+        if max_inputs_per_iter > 0:
+            num_inputs = min(num_inputs, max_inputs_per_iter)
         for _ in range(num_inputs - 1):
             inputs.append(q.clone().detach())
             inputs.append(k.clone().detach())
@@ -58,11 +60,7 @@ def _generated_qkv_inputs(
 
 # Config input tensors.
 # We can add more shapes, such as training, prefill, decoding, etc.
-
-
-def customized_inputs(
-    shape, num_inputs, dtype, device, gen_cache_size_inputs
-) -> Generator:
+def customized_inputs(shape, num_inputs, **kwargs) -> Generator:
     BATCH, H, N_HEADS_KV, SEQ_LEN, SEQ_LEN_KV, D_HEAD = shape
 
     SEQ_LEN_LOG2 = 7
@@ -72,17 +70,13 @@ def customized_inputs(
         if num_inputs is None:
             yield _generated_qkv_inputs(
                 (BATCH, H, N_HEADS_KV, SEQ_LEN, SEQ_LEN_KV, D_HEAD),
-                dtype=dtype,
-                device=device,
-                gen_cache_size_inputs=gen_cache_size_inputs,
+                **kwargs,
             )
         else:
             for _i in range(num_inputs):
                 yield _generated_qkv_inputs(
                     (BATCH, H, N_HEADS_KV, SEQ_LEN, SEQ_LEN, D_HEAD),
-                    dtype=dtype,
-                    device=device,
-                    gen_cache_size_inputs=gen_cache_size_inputs,
+                    **kwargs,
                 )
                 SEQ_LEN *= 2
         return
@@ -90,26 +84,22 @@ def customized_inputs(
         SEQ_LEN = 2**i
         yield _generated_qkv_inputs(
             (BATCH, H, H, SEQ_LEN, SEQ_LEN, D_HEAD),
-            dtype=dtype,
-            device=device,
-            gen_cache_size_inputs=gen_cache_size_inputs,
+            **kwargs,
         )
 
 
-def fa3_paper_inputs(dtype, device, gen_cache_size_inputs) -> Generator:
+def fa3_paper_inputs(**kwargs) -> Generator:
     D_HEAD = 128
     H = 2048 // D_HEAD
     for BATCH in [32, 16, 8, 4, 2, 1]:
         N_CTX = 16384 // BATCH
         yield _generated_qkv_inputs(
             shape=(BATCH, H, H, N_CTX, N_CTX, D_HEAD),
-            dtype=dtype,
-            device=device,
-            gen_cache_size_inputs=gen_cache_size_inputs,
+            **kwargs,
         )
 
 
-def sweep_inputs(dtype, device, gen_cache_size_inputs) -> Generator:
+def sweep_inputs(**kwargs) -> Generator:
     D = 128
     batch_sizes = [2**i for i in range(6)]
     num_heads = [1, 4, 8, 16]
@@ -119,7 +109,5 @@ def sweep_inputs(dtype, device, gen_cache_size_inputs) -> Generator:
             for S in seqlen:
                 yield _generated_qkv_inputs(
                     shape=(B, H, H, S, S, D),
-                    dtype=dtype,
-                    device=device,
-                    gen_cache_size_inputs=gen_cache_size_inputs,
+                    **kwargs,
                 )

--- a/tritonbench/operators/blackwell_attentions/operator.py
+++ b/tritonbench/operators/blackwell_attentions/operator.py
@@ -175,6 +175,12 @@ def parse_op_args(args: List[str]):
         action="store_true",
         help="Generate inputs as large as the GPU L2 cache size",
     )
+    parser.add_argument(
+        "--max-inputs-per-iter",
+        type=int,
+        default=0,
+        help="Max inputs per iteration. This is used when --gen-cache-size-inputs is on.",
+    )
     return parser.parse_args(args)
 
 
@@ -284,6 +290,7 @@ class Operator(BenchmarkOperator):
         self.sm_scale = args.sm_scale if args.sm_scale else 1.0 / math.sqrt(self.D_HEAD)
         self.deterministic = args.deterministic
         self.gen_cache_size_inputs = args.gen_cache_size_inputs
+        self.max_inputs_per_iter = args.max_inputs_per_iter
         self.optims = {}
 
     @register_benchmark()
@@ -602,6 +609,12 @@ class Operator(BenchmarkOperator):
         return fn
 
     def get_input_iter(self) -> Generator:
+        common_kwargs = {
+            "dtype": self.dtype,
+            "device": self.device,
+            "gen_cache_size_inputs": self.gen_cache_size_inputs,
+            "max_inputs_per_iter": self.max_inputs_per_iter,
+        }
         if self.input_types == "CUSTOMIZED_SHAPES":
             return customized_inputs(
                 shape=(
@@ -613,22 +626,12 @@ class Operator(BenchmarkOperator):
                     self.D_HEAD,
                 ),
                 num_inputs=self.tb_args.num_inputs,
-                dtype=self.dtype,
-                device=self.device,
-                gen_cache_size_inputs=self.gen_cache_size_inputs,
+                **common_kwargs,
             )
         elif self.input_types == "FA3_PAPER_SHAPES":
-            return fa3_paper_inputs(
-                dtype=self.dtype,
-                device=self.device,
-                gen_cache_size_inputs=self.gen_cache_size_inputs,
-            )
+            return fa3_paper_inputs(**common_kwargs)
         elif self.input_types == "SWEEP_SHAPES":
-            return sweep_inputs(
-                dtype=self.dtype,
-                device=self.device,
-                gen_cache_size_inputs=self.gen_cache_size_inputs,
-            )
+            return sweep_inputs(**common_kwargs)
         else:
             raise AssertionError(f"Unknown input type {self.input_types}")
 


### PR DESCRIPTION
Summary:
Add `--max-inputs-per-iter` to the `blackwell_attentions` benchmark to
control the number of inputs generated when using
`--gen-cache-size-inputs`.

Differential Revision: D90565773


