### PR TITLE
[ci][nightly] refresh pytorch when running the workflow

### DIFF
--- a/.ci/tritonbench/install.sh
+++ b/.ci/tritonbench/install.sh
@@ -5,10 +5,24 @@ if [ -z "${SETUP_SCRIPT:-}" ]; then
   exit 1
 fi
 
+# Parse arguments
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --refresh-pytorch) INSTALL_PYTORCH_NIGHTLY="1";  ;;
+        *) echo "Unknown parameter passed: $1"; usage ;;
+    esac
+    shift
+done
+
 . "${SETUP_SCRIPT}"
 
 tritonbench_dir=$(dirname "$(readlink -f "$0")")/../..
 cd ${tritonbench_dir}
+
+if [ -n "${INSTALL_PYTORCH_NIGHTLY}" ]; then
+  uv pip uninstall pytorch torchvision
+  python -m tools.cuda_utils --install-torch-nightly --cuda
+fi
 
 # Install Tritonbench and all its customized packages
 python install.py --all

--- a/.ci/tritonbench/setup-env.sh
+++ b/.ci/tritonbench/setup-env.sh
@@ -17,6 +17,7 @@ while [[ "$#" -gt 0 ]]; do
         --hip) USE_HIP="1"; ;;
         --triton-main) USE_TRITON_MAIN="1"; ;;
         --meta-triton) USE_META_TRITON="1"; ;;
+        --test-nvidia-driver) TEST_NVIDIA_DRIVER="1"; ;;
         *) echo "Unknown parameter passed: $1"; usage ;;
     esac
     shift
@@ -68,7 +69,9 @@ EOF
         cd -
     fi
     # Hack: install nvidia compute to get libcuda.so.1
-    sudo apt update && sudo apt-get install -y libnvidia-compute-580
+    if [ -n "${TEST_NVIDIA_DRIVER:-}" ]; then
+        sudo apt update && sudo apt-get install -y libnvidia-compute-580
+    fi
 elif [ -n "${USE_HIP:-}" ]; then
     python -m tools.cuda_utils --install-torch-nightly --hip
 else
@@ -78,7 +81,7 @@ fi
 
 bash .ci/tritonbench/install.sh
 
-if [ -n "${USE_CUDA:-}" ]; then
+if [ -n "${USE_CUDA:-}" && -n "${TEST_NVIDIA_DRIVER:-}" ]; then
     sudo apt-get purge -y '^libnvidia-'
     sudo apt-get purge -y '^nvidia-'
 fi

--- a/.github/workflows/_linux-benchmark-h100.yml
+++ b/.github/workflows/_linux-benchmark-h100.yml
@@ -80,6 +80,10 @@ jobs:
           # The max duration enforced by the server side
           role-duration-seconds: 18000
           aws-region: us-east-1
+      - name: Install PyTorch Nightly and TritonBench
+        run: |
+          set -eux
+          bash ./.ci/tritonbench/install.sh --refresh-pytorch
       - name: Compile Triton on Demand (Side A)
         if: ${{ inputs.side_a_triton && inputs.side_a_commit }}
         run: |

--- a/docker/tritonbench-nightly.dockerfile
+++ b/docker/tritonbench-nightly.dockerfile
@@ -34,7 +34,7 @@ RUN git clone --recurse-submodules -b "${TRITONBENCH_BRANCH}" --single-branch \
     https://github.com/meta-pytorch/tritonbench "${WORKSPACE_DIR}/tritonbench"
 
 # Install and setup env
-RUN cd ${WORKSPACE_DIR}/tritonbench && bash ./.ci/tritonbench/setup-env.sh --cuda --triton-main --meta-triton
+RUN cd ${WORKSPACE_DIR}/tritonbench && bash ./.ci/tritonbench/setup-env.sh --cuda --triton-main --meta-triton --test-nvidia-driver
 
 # Check the installed version of nightly if needed
 RUN cd ${WORKSPACE_DIR}/tritonbench && \


### PR DESCRIPTION
Users observed that h100 and amd workflows might be using different versions of pytorch.
This is because h100 is using the pytorch builtin the docker, and amd is using fresh pytorch nightly installation.

Unify the behaviour to always refresh the pytorch nightly and fbgemm_nightly builds.

Also, only install/uninstall cuda drivers when it is in the docker build. We don't need to touch cuda drivers when the runner comes with a GPU already.