### PR TITLE
[TritonBench] Add H100 hardware check

### DIFF
--- a/tritonbench/utils/env_utils.py
+++ b/tritonbench/utils/env_utils.py
@@ -93,6 +93,14 @@ def is_blackwell() -> bool:
 IS_BLACKWELL = is_blackwell()
 
 
+def is_h100() -> bool:
+    """Check if running on an NVIDIA H100 GPU."""
+    if not is_cuda():
+        return False
+    gpu_model = get_nvidia_gpu_model()
+    return "H100" in gpu_model
+
+
 def supports_tma():
     return is_cuda() and torch.cuda.get_device_capability()[0] >= 9
 


### PR DESCRIPTION
Summary: Currently the kernel only supports B200, we want to also add H100 configs that will be used in production models

Differential Revision: D90809206


