### PR TITLE
Modify is_blackwell in case nvidia-smi isn't available

### DIFF
--- a/tritonbench/operators/blackwell_attentions/operator.py
+++ b/tritonbench/operators/blackwell_attentions/operator.py
@@ -16,7 +16,6 @@ import torch
 from torch.nn.attention import sdpa_kernel, SDPBackend
 from torch.nn.functional import scaled_dot_product_attention as sdpa
 from tritonbench.kernels.attention_utils import SUPPORT_GLUON
-from tritonbench.kernels.blackwell_attention_utils import is_blackwell
 
 try:
     from tritonbench.kernels.blackwell_triton_fused_attention import (

--- a/tritonbench/utils/env_utils.py
+++ b/tritonbench/utils/env_utils.py
@@ -87,7 +87,9 @@ def is_blackwell() -> bool:
     if not is_cuda():
         return False
     gpu_model = get_nvidia_gpu_model()
-    return "B200" in gpu_model or "B300" in gpu_model
+    if gpu_model:
+        return "B200" in gpu_model or "B300" in gpu_model
+    return torch.cuda.get_device_capability()[0] == 10
 
 
 IS_BLACKWELL = is_blackwell()


### PR DESCRIPTION
Summary: In some cases, we don't have nvidia-smi. So fall back to torch get_device_capability in those cases.

Differential Revision: D90910490


