### PR TITLE
Default Diode version to recommended model config

### DIFF
--- a/tritonbench/utils/parser.py
+++ b/tritonbench/utils/parser.py
@@ -393,8 +393,8 @@ def get_parser(args=None):
         parser.add_argument(
             "--diode-version",
             type=str,
-            default="v4",
-            help="Version of diode to use. Default: v4",
+            default="recommended",
+            help="Version of diode to use. Default: recommended version in MODEL_CONFIGS (~/fbsource/fbcode/diode/torch_diode/models/triton_gemm/model.py)",
         )
         parser.add_argument(
             "--diode-topk",


### PR DESCRIPTION
Summary: Set default Diode version in TritonBench to the recommended model config in `~/fbsource/fbcode/diode/torch_diode/models/triton_gemm/model.py`.

Reviewed By: xuzhao9

Differential Revision: D91059838


