### PR TITLE
Fix perf issues for FA w/ subtiling p

### DIFF
--- a/tritonbench/kernels/blackwell_triton_fused_attention_dp.py
+++ b/tritonbench/kernels/blackwell_triton_fused_attention_dp.py
@@ -103,7 +103,9 @@ def _attn_fwd_subtile(
         qk0, qk1 = qk.reshape([PM, 2, PN // 2]).permute(0, 2, 1).split()
 
         p0 = tl.math.exp2(qk0)
+        p0_bf16 = p0.to(dtype)
         p1 = tl.math.exp2(qk1)
+        p1_bf16 = p1.to(dtype)
 
         p = tl.join(p0, p1).permute(0, 2, 1).reshape([PM, PN])
     else:
@@ -141,7 +143,10 @@ def _attn_fwd_subtile(
     # We can potentially move these to be before updating l_ij, so the dot
     # is not blocked.
     # prepare p and v for the dot
-    p_bf16 = p.to(dtype)
+    if not SUBTILING_P:
+        p_bf16 = p.to(dtype)
+    else:
+        p_bf16 = tl.join(p0_bf16, p1_bf16).permute(0, 2, 1).reshape([PM, PN])
     # note that this non transposed v for FP8 is only supported on Blackwell
     acc = tl.dot(p_bf16, v, acc)
     if not FADD2_REDUCE:
@@ -332,7 +337,7 @@ else:
         for s in NUM_STAGES_OPTIONS
         for w in [4]
         for subtile in [True]
-        for subtile_p in [False]
+        for subtile_p in [True, False]
         for vectmul in [1]
         for add2reduce in [False]
         for maxreg in [152, 192]


### PR DESCRIPTION
Previously with subtiling_p enabled, FA tutorial kernel of shape (4, 32, 32, 8192, 8192, 128) has perf drop from ~890 tflops to ~650 tflops.

This is because joining `p0_bf16` and `p1_bf16` introduces the long liveness of both `p_bf16` and `p` in the softmax partition, which increases register pressure (64 -> 312 bytes spill stores, 124 -> 364 bytes spill loads). 

Delaying the `p0_bf16` and `p1_bf16` joining in the source code unleashes the benefit of subtiling `p` and increases the perf to ~931 tflops. With subtiling p, the register pressure reduces (64 -> 12 bytes spill stores, 124 -> 40 bytes spill loads). 

Now since subtiling `p` shows perf win compared to the origin version (~890 tflops), we should enable autotune of this knob.

Results:
```
# Before this PR 
  (Batch, Heads, Heads_KV, SeqLen, SeqLen_KV, Dhead)    triton_tutorial_flash_dp_persistent_blackwell-tflops
----------------------------------------------------  ------------------------------------------------------
                    (4, 32, 32, 8192, 8192, 128) fwd                                                 894.971
                                   894.9713080118753
# Before this PR w/ subtiling_p
  (Batch, Heads, Heads_KV, SeqLen, SeqLen_KV, Dhead)    triton_tutorial_flash_dp_persistent_blackwell-tflops
----------------------------------------------------  ------------------------------------------------------
                    (4, 32, 32, 8192, 8192, 128) fwd                                                 654.799
                                   654.7986067440738
# After this PR w/ subtiling_p
  (Batch, Heads, Heads_KV, SeqLen, SeqLen_KV, Dhead)    triton_tutorial_flash_dp_persistent_blackwell-tflops
----------------------------------------------------  ------------------------------------------------------
                    (4, 32, 32, 8192, 8192, 128) fwd                                                 931.865
                                   931.8653404181855
```
Command to run:
```
TRITON_ALWAYS_COMPILE=1 TRITON_KERNEL_DUMP=1 TRITON_USE_META_WS=1 TRITON_DUMP_DIR=/tmp/triton_dumps TRITON_DUMP_PTXAS_LOG=1 CUDA_VISIBLE_DEVICES=5 bash ~/fbsource/fbcode/ads_mkl/benchmarks/denoise.sh python run.py --op blackwell_attentions --seq-len 8192 --batch 4 --n-heads 32 --d-head 128 --rep 3000 --sleep 1.0 --metrics tflops --simple-output --only triton_tutorial_flash_dp_persistent_blackwell --force
```