### PR TITLE
Gate power manager import behind a GPU check

### DIFF
--- a/tritonbench/components/power/__init__.py
+++ b/tritonbench/components/power/__init__.py
@@ -1,1 +1,7 @@
-from .power_manager import PowerManagerTask
+import torch
+
+# PowerManagerTask requires pynvml which is only available when NVIDIA GPU is present
+if torch.cuda.is_available():
+    from .power_manager import PowerManagerTask
+else:
+    PowerManagerTask = None

--- a/tritonbench/components/tasks/manager.py
+++ b/tritonbench/components/tasks/manager.py
@@ -37,8 +37,11 @@ class ManagerTask(TaskBase):
         import os
         import traceback
 
-        # required as this is in child process
-        from tritonbench.components.power.power_manager import PowerManager
+        import torch
+
+        # PowerManager requires pynvml which is only available when NVIDIA GPU is present
+        if torch.cuda.is_available():
+            from tritonbench.components.power.power_manager import PowerManager
 
         module = importlib.import_module(module_path, package=package)
         Ctor = getattr(module, class_name)

--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -1004,6 +1004,10 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
         """Benchmarking the operator and returning its metrics."""
         metrics: list[tuple[Any, dict[str, BenchmarkOperatorMetrics]]] = []
         if self.tb_args.power_chart:
+            if PowerManagerTask is None:
+                raise RuntimeError(
+                    "power_chart requires a CUDA-capable GPU with pynvml support"
+                )
             power_manager_task = PowerManagerTask.create(
                 self.benchmark_name,
                 _get_current_device_id(),


### PR DESCRIPTION
Summary: Report on the Triton slack that you can't use TritonBench without GPU software installed, which should be unnecessary if there is only the intention to benchmark GPU machines.

Differential Revision: D91147744


