### PR TITLE
Correctly handle quotes in env

### DIFF
--- a/tritonbench/operators/fp8_gemm/fp8_gemm.py
+++ b/tritonbench/operators/fp8_gemm/fp8_gemm.py
@@ -249,9 +249,9 @@ class Operator(BenchmarkOperator):
 
     @register_benchmark(baseline=True)
     def torch_fp8_gemm(self, a, b, scale_a, scale_b):
-        assert not self.contains_blockwise_scaling or HAS_CUDA_129, (
-            "BlockWise scaling variants for scaled_gemm require CUDA 12.9+"
-        )
+        assert (
+            not self.contains_blockwise_scaling or HAS_CUDA_129
+        ), "BlockWise scaling variants for scaled_gemm require CUDA 12.9+"
 
         return lambda: torch._scaled_mm(
             a,

--- a/tritonbench/utils/run_utils.py
+++ b/tritonbench/utils/run_utils.py
@@ -2,6 +2,8 @@ import argparse
 import copy
 import logging
 import os
+import re
+import shlex
 import subprocess
 import sys
 import time
@@ -286,7 +288,9 @@ def _run(args: argparse.Namespace, extra_args: List[str]) -> BenchmarkOperatorRe
 
 
 def run_config(config_file: str, args: List[str]):
-    assert Path(config_file).exists(), f"Config file {config_file} must exist."
+    assert Path(config_file).exists(), (
+        f"Config file {config_file} must exist. Current working directory {os.getcwd()}"
+    )  # Fbcode only: need to run from fbsource root directory
     # Remove "TRITONBENCH_RUN_CONFIG" env
     if "TRITONBENCH_RUN_CONFIG" in os.environ:
         del os.environ["TRITONBENCH_RUN_CONFIG"]
@@ -298,9 +302,19 @@ def run_config(config_file: str, args: List[str]):
         op_args = benchmark_config["args"].split(" ") + args
         env_string = benchmark_config.get("envs", None)
         extra_envs = {}
+        forbidden_list = [";", "$", "&"]
         if env_string:
-            for env_part in env_string.split(" "):
-                key, val = env_part.split("=")
+            _ASSIGN_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+            if any(char in env_string for char in forbidden_list):
+                raise ValueError(
+                    f"Env string containing '{forbidden_list}' is not supported."
+                )
+            for env_part in shlex.split(env_string, posix=True):
+                if not _ASSIGN_RE.match(env_part):
+                    raise ValueError(
+                        f"Env string must be in the form of key=value, get {env_part}"
+                    )
+                key, val = env_part.split("=", 1)
                 extra_envs[key] = val
         disabled = benchmark_config.get("disabled", False)
         if disabled:


### PR DESCRIPTION
Summary:
Use `shlex.split` to correctly handle quote symbols in the `envs` field of TRITONBENCH_RUN_CONFIG.

Also, raise exceptions when `envs` include unsupported symbols like `$`, `&`, or `;`

Reviewed By: dshi7

Differential Revision: D91159114


