### PR TITLE
Add CudaGraph support in gpu_events

### DIFF
--- a/tritonbench/operators/blackwell_attentions/operator.py
+++ b/tritonbench/operators/blackwell_attentions/operator.py
@@ -692,6 +692,9 @@ class Operator(BenchmarkOperator):
             base_info += f" {self.mode.value}"
         return base_info
 
-    def get_latency_scale(self, example_inputs):
+    def get_num_inputs_per_iter(self, example_inputs) -> int:
         assert len(example_inputs) % 3 == 0
         return len(example_inputs) // 3
+
+    def get_latency_scale(self, example_inputs):
+        return self.get_num_inputs_per_iter(example_inputs)

--- a/tritonbench/utils/cudagraph_utils.py
+++ b/tritonbench/utils/cudagraph_utils.py
@@ -1,0 +1,114 @@
+import threading
+from functools import partial
+from typing import Callable, Optional
+
+import torch
+from torch.profiler import profile, ProfilerActivity
+
+
+class CudaGraphConfig:
+    stream: Optional[torch.cuda.Stream] = None
+    graph: Optional[torch.cuda.CUDAGraph] = None
+    num_inputs_per_iter: int = -1
+    num_kernels_per_input: int = -1
+
+    @staticmethod
+    def generate(use_cuda_graphs: bool):
+        if use_cuda_graphs:
+            return CudaGraphConfig()
+        return None
+
+    def __init__(self):
+        if CudaGraphConfig.stream is None:
+            CudaGraphConfig.stream = torch.cuda.Stream()
+        if CudaGraphConfig.graph is None:
+            CudaGraphConfig.graph = torch.cuda.CUDAGraph()
+
+    def get_stream(self):
+        """
+        Get the stream for capturing the CUDA graph.
+        """
+        return CudaGraphConfig.stream
+
+    def get_graph(self):
+        """
+        Get the CUDA graph for capturing the CUDA graph.
+        """
+        return CudaGraphConfig.graph
+
+    def reset_graph(self):
+        """
+        Reset the CUDA graph for capturing the CUDA graph.
+        """
+        CudaGraphConfig.graph.reset()
+
+    def get_num_kernels(self, fn: Callable):
+        """
+        Estimate the number of GPU kernels executed in a function using PyTorch
+        profiler.
+        """
+
+        def trace_handler(prof, num_kernels_ptr, trace_event):
+            event_list = prof.events()
+            count = 0
+            for e in event_list:
+                if e.device_type == torch.autograd.DeviceType.CUDA:
+                    count += 1
+
+            if count == 0:
+                # If we do not see any CUDA events, we estimate the number of
+                # kernels from the number of cudaLaunchKernel events.
+                for e in event_list:
+                    if "cudaLaunchKernel" in e.name:
+                        count += 1
+
+            num_kernels_ptr[0] = count
+            # Signal the main thread that the trace handler is done
+            trace_event.set()
+
+        stream = self.get_stream()
+        num_kernels_ptr = [0]
+        trace_event = threading.Event()
+
+        with profile(
+            activities=[ProfilerActivity.CUDA],
+            on_trace_ready=partial(
+                trace_handler,
+                num_kernels_ptr=num_kernels_ptr,
+                trace_event=trace_event,
+            ),
+        ):
+            with torch.cuda.stream(stream):
+                fn()
+
+        torch.cuda.synchronize()
+        # Wait for the trace handler to finish
+        trace_event.wait()
+
+        num_kernels = num_kernels_ptr[0]
+        if num_kernels >= self.num_inputs_per_iter:
+            # Keep track of the number of kernels per input
+            num_kernels_per_input = num_kernels // self.num_inputs_per_iter
+            if CudaGraphConfig.num_kernels_per_input == -1:
+                CudaGraphConfig.num_kernels_per_input = num_kernels_per_input
+            else:
+                CudaGraphConfig.num_kernels_per_input += num_kernels_per_input
+                CudaGraphConfig.num_kernels_per_input //= 2
+                CudaGraphConfig.num_kernels_per_input = max(
+                    CudaGraphConfig.num_kernels_per_input, 1
+                )
+
+        # If the number of kernels is too low compared to the previous
+        # estimations (this can cause by a profiler failure), we estimate the
+        # number of kernels from the number of inputs and average number of
+        # kernels per input
+        return max(
+            num_kernels,
+            self.num_inputs_per_iter * CudaGraphConfig.num_kernels_per_input,
+        )
+
+
+class CudaGraphError(Exception):
+    def __init__(self, message):
+        self.message = message
+        super().__init__(message)

--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -38,6 +38,7 @@ from tritonbench.utils.constants import (
     DEFAULT_SLEEP,
     DEFAULT_WARMUP,
 )
+from tritonbench.utils.cudagraph_utils import CudaGraphConfig, CudaGraphError
 from tritonbench.utils.diode_utils import setup_diode_model, teardown_diode_model
 from tritonbench.utils.env_utils import (
     apply_precision,
@@ -815,6 +816,7 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
             None  # Updated in _reduce_benchmarks if running the Diode benchmark
         )
         self.old_allow_tf32 = set_allow_tf32(self.tb_args.allow_tf32)
+        self.cudagraph_config = CudaGraphConfig.generate(self.use_cuda_graphs)
 
     # Run the post initialization
     def __post__init__(self):
@@ -1230,6 +1232,9 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
 
     def get_x_val(self, example_inputs) -> Any:
         return self._cur_input_id
+
+    def get_cudagraph_stream(self):
+        return self.cudagraph_config.get_stream()
 
     def get_bwd_fn(self, fwd_fn: Callable) -> Callable:
         # Extract tensors that require gradients from example_inputs
@@ -1742,6 +1747,10 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
             if {"latency", "tflops", "gbps", "speedup", "compile_time"} & set(
                 self.required_metrics
             ):
+                if self.cudagraph_config is not None:
+                    self.cudagraph_config.num_inputs_per_iter = (
+                        self.get_num_inputs_per_iter(self.example_inputs)
+                    )
                 metrics.latency = do_bench_wrapper(
                     fn,
                     warmup,
@@ -1762,8 +1771,10 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
                     entropy_max_samples=getattr(
                         self.tb_args, "entropy_max_samples", 10000
                     ),
+                    cudagraph_config=self.cudagraph_config,
                 )
-                metrics.latency.scale(self.get_latency_scale(self.example_inputs))
+                if metrics.latency is not None:
+                    metrics.latency.scale(self.get_latency_scale(self.example_inputs))
             if {
                 "gpu_peak_mem",
                 "gpu_mem_footprint_compression_ratio",
@@ -2020,6 +2031,8 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
             metrics.error_msg = "CUDA OOM"
         except NotImplementedError as e:
             metrics.error_msg = str(e)
+        except CudaGraphError:
+            metrics.error_msg = "CudaGraph error"
         except Exception as e:
             if not self.tb_args.keep_going:
                 raise
@@ -2481,5 +2494,10 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
         operator_name = cls.name
         return BASELINE_BENCHMARKS.get(operator_name, None)
 
-    def get_latency_scale(self, example_inputs):
+    @classmethod
+    def get_num_inputs_per_iter(cls, example_inputs):
+        return 1
+
+    @classmethod
+    def get_latency_scale(cls, example_inputs):
         return 1


### PR DESCRIPTION
Summary:
This diff adds CudaGraph support in the gpu_events mode with the      
following limitations:                                                
                                                                      
- When capturing a graph, `gpu_eventsw obtains a CUDA stream from     
wCudaGraphConfigw. This stream should be used when executing any      
dependencies of the kernels to benchmark, to ensure that all          
dependencies are on the same stream. For example, if the function to  
benchmark is a backward operator, the forward operator must be        
executed on the same stream; otherwise, it will fail.                 
                                                                      
- The benchmark can capture a maximum of 2048 kernels in a graph to   
prevent a hang.  Thus, the benchmark will not capture every           
benchmarking iteration (i.e., `n_repeat`) in a graph if the total     
number of kernels is larger than the maximum limit. Instead, it will  
capture only `n_cudagraph_repeat` iterations, where                   
`n_cudagraph_repeat = max(max_num_kernels // num_kernels, 1)`, and    
replay the graph `n_replay` times to reach the expected repetition    
count, where `n_replay = max(n_repeat // n_cudagraph_repeat, 1)`.

Differential Revision: D91290274


