### PR TITLE
String type conversion in tritonbench stat summarizer

### DIFF
--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -524,10 +524,16 @@ class BenchmarkOperatorResult:
                     )
                     if value is None:
                         continue
-                    if isinstance(value, (int, float)):
+                    numeric_value = value
+                    if isinstance(value, str):
+                        try:
+                            numeric_value = float(value)
+                        except (ValueError, TypeError):
+                            continue
+                    if isinstance(numeric_value, (int, float)):
                         agg_data[agg_metric_name] = agg_data.get(
                             agg_metric_name, []
-                        ) + [value]
+                        ) + [numeric_value]
         final_agg_data = {k: sum(v) / len(v) for k, v in agg_data.items()}
         userbenchmark_metrics_dict.update(final_agg_data)
 


### PR DESCRIPTION
Summary:
This diff adds logic to convert string to float in tritonbench stat summarizer

This is a stopgap solution for summarizer not considering metrics type that it does not expect, a more detailed refactor / addition to identify str() return call point would be a optimal solution

Differential Revision: D91525486


