### PR TITLE
[CI] change docker build cadence to weekly

### DIFF
--- a/.github/workflows/_linux-test-mi350.yml
+++ b/.github/workflows/_linux-test-mi350.yml
@@ -19,22 +19,37 @@ jobs:
       UV_VENV_DIR: "/workspace/uv_venvs"
       SETUP_SCRIPT: "/workspace/setup_instance.sh"
       CONDA_ENV: ${{ inputs.conda_env }}
+      DOCKER_IMAGE: "ghcr.io/meta-pytorch/tritonbench:rocm-latest"
       TRITON_HIP_USE_ASYNC_COPY: "0"
     steps:
       - name: Checkout Tritonbench
         uses: actions/checkout@v3
         with:
           submodules: recursive
-      - name: Install Tritonbench env
-        run: |
-          set -eux
-          if [[ "${CONDA_ENV}" == "meta-triton" ]]; then
-            CMD_SUFFIX=" --meta-triton"
-          elif [[ "${CONDA_ENV}" == "triton-main" ]]; then
-            CMD_SUFFIX=" --triton-main"
-          fi
-          bash ./.ci/tritonbench/setup-env.sh --hip ${CMD_SUFFIX}
+      - name: Pull docker image
+        uses: pytorch/test-infra/.github/actions/pull-docker-image@main
+        with:
+          docker-image: ${{ env.DOCKER_IMAGE }}
       - name: Test Tritonbench
         run: |
           set -eux
-          bash ./.ci/tritonbench/test-gpu.sh
+          GPU_FLAG="--device /dev/kfd --device /dev/dri --security-opt seccomp=unconfined --group-add video"
+
+          container_name=$(docker run \
+            ${GPU_FLAG:-} \
+            --env-file /etc/podinfo/gha-gpu-isolation-settings \
+            -e CONDA_ENV \
+            --ipc=host \
+            --tty \
+            --detach \
+            --shm-size=32g \
+            --cap-add=SYS_PTRACE \
+            -v "${GITHUB_WORKSPACE}:/tmp/workspace" \
+            -w /tmp/workspace \
+            "${DOCKER_IMAGE}"
+          )
+
+          docker exec -t -w /tmp/workspace "${container_name}" bash -c "
+            set -eux
+            bash ./.ci/tritonbench/test-gpu.sh
+          "

--- a/.github/workflows/docker-rocm.yaml
+++ b/.github/workflows/docker-rocm.yaml
@@ -1,9 +1,13 @@
 name: TritonBench Nightly ROCM Docker Build
 on:
+  schedule:
+    # Push the docker every weekend
+    - cron: '0 0 * * 6'
   pull_request:
     paths:
       - .github/workflows/docker-rocm.yaml
       - docker/tritonbench-rocm-nightly.dockerfile
+      - submodules/aiter
   workflow_dispatch:
     inputs:
       nightly_date:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,16 +1,14 @@
 name: TritonBench Nightly Docker Build
 on:
   schedule:
-    # Push the nightly docker daily at 3 PM UTC
-    - cron: '0 15 * * *'
+    # Push the docker every weekend
+    - cron: '0 0 * * 6'
   pull_request:
     paths:
       - .github/workflows/docker.yaml
       - docker/tritonbench-nightly.dockerfile
-      - submodules/FBGEMM
       - submodules/ThunderKittens
       - submodules/flash-attention
-      - submodules/aiter
       - install.py
       - tools/**
   workflow_dispatch:


### PR DESCRIPTION
Due to the common breakage of the pytorch trunk with mslk and fbgemm_gpu, we do the following:

- build docker every week instead of nightly, during the weekend
- during test, do not do a fresh install of the environment. Instead, rely on the last successful built docker image.

Note that the nightly build will still run on the latest pytorch/mslk/fbgemm_gpu nightly.