### PR TITLE
Respect precision and mode when launching compile time subprocess

### DIFF
--- a/tritonbench/components/compile_time/trace.py
+++ b/tritonbench/components/compile_time/trace.py
@@ -1,6 +1,7 @@
 import os
 import random
 import string
+import time
 from datetime import datetime
 from functools import partial
 from typing import Callable, Dict, Optional
@@ -48,14 +49,12 @@ def do_compile_time_in_task(fn: Callable, cold_start: bool = False) -> float:
 
             nop_kernel[1,]()
         torch.cuda.synchronize()
-        start_event = torch.cuda.Event(enable_timing=True)
-        end_event = torch.cuda.Event(enable_timing=True)
-        start_event.record()
+        start_time = time.perf_counter()
         fn()
-        end_event.record()
-        torch.cuda.synchronize()  # Wait for the events to be recorded!
-    latency_with_compile = start_event.elapsed_time(end_event)
-    return latency_with_compile
+        torch.cuda.synchronize()
+        end_time = time.perf_counter()
+    walltime_with_compile = (end_time - start_time) * 1e3
+    return walltime_with_compile
 
 
 def do_compile_kineto_trace_in_task(

--- a/tritonbench/utils/env_utils.py
+++ b/tritonbench/utils/env_utils.py
@@ -245,7 +245,9 @@ def fresh_triton_cache():
 
     with tempfile.TemporaryDirectory() as tmpdir:
         old = os.environ.get("TRITON_CACHE_DIR", None)
+        old_helion_cache = os.environ.get("HELION_CACHE_DIR", None)
         os.environ["TRITON_CACHE_DIR"] = tmpdir
+        os.environ["HELION_CACHE_DIR"] = tmpdir
         old_cache_manager = os.environ.get("TRITON_CACHE_MANAGER", None)
         os.environ.pop("TRITON_CACHE_MANAGER", None)
         yield
@@ -253,6 +255,10 @@ def fresh_triton_cache():
             os.environ["TRITON_CACHE_DIR"] = old
         else:
             del os.environ["TRITON_CACHE_DIR"]
+        if old_helion_cache:
+            os.environ["HELION_CACHE_DIR"] = old_helion_cache
+        else:
+            del os.environ["HELION_CACHE_DIR"]
         if old_cache_manager:
             os.environ["TRITON_CACHE_MANAGER"] = old_cache_manager
 


### PR DESCRIPTION
Summary: Because compile time is CPU bounded, we should use walltime instead of GPU events to measure the compile time.

Fixes compile_time metric on Helion kernels

Differential Revision: D90411924


