### PR TITLE
enable force_async to p0@v in TLX blackwell attention kernel

### DIFF
--- a/tritonbench/kernels/tlx_attention_ws_pipelined.py
+++ b/tritonbench/kernels/tlx_attention_ws_pipelined.py
@@ -694,6 +694,7 @@ def _attn_fwd_ws(
                 kv_tiles[v_bufIdx],
                 acc_tiles[0],
                 use_acc=False,
+                force_async=True,
             )
 
             acc1_init = False
@@ -751,6 +752,7 @@ def _attn_fwd_ws(
                     kv_tiles[v_bufIdx],
                     acc_tiles[0],
                     use_acc=True,
+                    force_async=True,
                 )
 
             tlx.tcgen05_commit(acc_empties[0])
@@ -1323,6 +1325,7 @@ def _attn_fwd_ws_persistent(
                         kv_slice,
                         acc_tiles[0],
                         use_acc=slice_id > 0,
+                        force_async=True,
                     )
 
                 acc1_init = False
@@ -1414,6 +1417,7 @@ def _attn_fwd_ws_persistent(
                             kv_slice,
                             acc_tiles[0],
                             use_acc=True,
+                            force_async=True,
                         )
 
                 tlx.tcgen05_commit(q_empties[q_bufIdx])


### PR DESCRIPTION
Summary: Enables asyncronous execution of back-to-back tl.async_dot for p0@v in TLX blackwell attention kernel, which was by default executed in sequential. This enhances kernel performance.

Reviewed By: htyu

Differential Revision: D91748087


