### PR TITLE
Import TLX tutorial kernels of Blackwell GEMM in Tritonbench

### DIFF
--- a/tritonbench/operators/gemm/operator.py
+++ b/tritonbench/operators/gemm/operator.py
@@ -21,8 +21,32 @@ from tritonbench.operators.gemm.warp_spec_persistent_matmul import (
 from tritonbench.utils.triton_utils import has_tlx
 
 if has_tlx():
+    from triton.language.extra.tlx.tutorials.blackwell_gemm_2cta import (
+        matmul as _tlx_matmul_2cta,
+    )
+    from triton.language.extra.tlx.tutorials.blackwell_gemm_clc import (
+        matmul as _tlx_matmul_clc,
+    )
+    from triton.language.extra.tlx.tutorials.blackwell_gemm_pipelined import (
+        matmul as _tlx_matmul_pipelined,
+    )
+    from triton.language.extra.tlx.tutorials.blackwell_gemm_ws import (
+        matmul as _tlx_matmul_ws,
+    )
     from tritonbench.operators.gemm.tlx_matmul import tlx_matmul as _tlx_matmul
 else:
+
+    def _tlx_matmul_clc(*args, **kwargs):
+        raise RuntimeError("TLX not available in this Triton version")
+
+    def _tlx_matmul_pipelined(*args, **kwargs):
+        raise RuntimeError("TLX not available in this Triton version")
+
+    def _tlx_matmul_clc(*args, **kwargs):
+        raise RuntimeError("TLX not available in this Triton version")
+
+    def _tlx_matmul_pipelined(*args, **kwargs):
+        raise RuntimeError("TLX not available in this Triton version")
 
     def _tlx_matmul(*args, **kwargs):
         raise RuntimeError("TLX not available in this Triton version")
@@ -562,6 +586,46 @@ class Operator(BenchmarkOperator):
                 return lambda: _tlx_matmul(a, b) + bias
             else:
                 return lambda: _tlx_matmul(a, b)
+
+        @register_benchmark(enabled=has_tlx())
+        def tlx_matmul_ws(self, a, b, bias) -> Callable:
+            # TLX matmul requires contiguous inputs with 16-byte aligned strides
+            a_contig = a.contiguous()
+            b_contig = b.contiguous()
+            if bias is not None:
+                return lambda: _tlx_matmul_ws(a_contig, b_contig) + bias
+            else:
+                return lambda: _tlx_matmul_ws(a_contig, b_contig)
+
+        @register_benchmark(enabled=has_tlx())
+        def tlx_matmul_clc(self, a, b, bias) -> Callable:
+            # TLX matmul requires contiguous inputs with 16-byte aligned strides
+            a_contig = a.contiguous()
+            b_contig = b.contiguous()
+            if bias is not None:
+                return lambda: _tlx_matmul_clc(a_contig, b_contig) + bias
+            else:
+                return lambda: _tlx_matmul_clc(a_contig, b_contig)
+
+        @register_benchmark(enabled=has_tlx())
+        def tlx_matmul_pipelined(self, a, b, bias) -> Callable:
+            # TLX matmul requires contiguous inputs with 16-byte aligned strides
+            a_contig = a.contiguous()
+            b_contig = b.contiguous()
+            if bias is not None:
+                return lambda: _tlx_matmul_pipelined(a_contig, b_contig) + bias
+            else:
+                return lambda: _tlx_matmul_pipelined(a_contig, b_contig)
+
+        @register_benchmark(enabled=has_tlx())
+        def tlx_matmul_2cta(self, a, b, bias) -> Callable:
+            # TLX matmul requires contiguous inputs with 16-byte aligned strides
+            a_contig = a.contiguous()
+            b_contig = b.contiguous()
+            if bias is not None:
+                return lambda: _tlx_matmul_2cta(a_contig, b_contig) + bias
+            else:
+                return lambda: _tlx_matmul_2cta(a_contig, b_contig)
 
         @register_benchmark(enabled=HAS_TILELANG and is_cu130())
         def tilelang_blackwell_matmul(self, a, b, bias) -> Callable:


### PR DESCRIPTION
Summary:
Unify the fragmented perf measurement of TLX kernels between fbtriton and tritonbench.

Previous D91444440 is abandoned and replaced with D91641412, D91758858 and this diff.

Differential Revision: D91760420


