### PR TITLE
Add Diode benchmark and shapes to fp8_gemm

### DIFF
--- a/tritonbench/data/loader.py
+++ b/tritonbench/data/loader.py
@@ -13,6 +13,7 @@ SUPPORTED_INPUT_OPS = [
     "bmm",
     "gemm",
     "jagged_dense_dense_sum",
+    "fp8_gemm",
 ]
 
 INPUT_CONFIG_DIR = Path(__file__).parent.joinpath("input_configs")


### PR DESCRIPTION
Summary: Add Diode benchmark to `fp8_gemm`. Add a new `scaled_mm` input loader json file to TritonBench (currently just a copy of `shapes_mm.json` with all `N % 16 != 0` and `K % 16 != 0` shapes removed).

Reviewed By: PaulZhang12

Differential Revision: D91814624


