### PR TITLE
Add deterministic to OSS FA4

### DIFF
--- a/tritonbench/operators/blackwell_attentions/operator.py
+++ b/tritonbench/operators/blackwell_attentions/operator.py
@@ -72,20 +72,18 @@ except SystemError as e:
     print(f"SystemError resulted from importing FA4: {e.__class__.__name__}: {e}")
     traceback.print_exc()
 
-# [Optional] Vanilla Flash Attention v4
+# [Optional] OSS Flash Attention v4
 try:
-    from flash_attn.cute import flash_attn_func as upstream_fa4_flash_attn_func
+    from flash_attn.cute import flash_attn_func as oss_fa4_flash_attn_func
 
-    HAS_VANILLA_FA4 = True
+    HAS_OSS_FA4 = True
 except (ImportError, IOError, AttributeError):
-    HAS_VANILLA_FA4 = False
+    HAS_OSS_FA4 = False
 except SystemError as e:
-    HAS_VANILLA_FA4 = False
+    HAS_OSS_FA4 = False
     import traceback
 
-    print(
-        f"SystemError resulted from importing vanilla FA4: {e.__class__.__name__}: {e}"
-    )
+    print(f"SystemError resulted from importing OSS FA4: {e.__class__.__name__}: {e}")
     traceback.print_exc()
 
 from ..flash_attention.test_fmha_utils import permute_qkv
@@ -489,16 +487,15 @@ class Operator(BenchmarkOperator):
         )
         return preproc_permute, fn
 
-    @register_benchmark(
-        enabled=(IS_BLACKWELL and HAS_VANILLA_FA4), label="vanilla-FAv4"
-    )
+    @register_benchmark(enabled=(IS_BLACKWELL and HAS_OSS_FA4), label="OSS-FAv4")
     @multi_input_wrapper
-    def vanilla_fa4(self, *args) -> Tuple[Callable, Callable]:
+    def oss_fa4(self, *args) -> Tuple[Callable, Callable]:
         fn = partial(
-            upstream_fa4_flash_attn_func,
+            oss_fa4_flash_attn_func,
             softmax_scale=self.sm_scale,
             causal=self.causal,
             window_size=self.window_size if self.local else (None, None),
+            deterministic=self.deterministic,
         )
         return preproc_permute, fn
 


### PR DESCRIPTION
Summary: Add deterministic to OSS FA4 in blackwell_attentions and rename the op

Reviewed By: henrylhtsang

Differential Revision: D91845779


