### PR TITLE
Fixing dynamic runner

### DIFF
--- a/tritonbench/utils/dynamic_runner.py
+++ b/tritonbench/utils/dynamic_runner.py
@@ -1,6 +1,10 @@
 from typing import Any, Callable, Dict, Generator, List, Optional
 
-from tritonbench.utils.triton_op import BenchmarkOperator, BenchmarkOperatorResult
+from tritonbench.utils.triton_op import (
+    BenchmarkOperator,
+    BenchmarkOperatorResult,
+    override_args,
+)
 
 
 def dynamic_run(
@@ -39,7 +43,8 @@ def dynamic_run(
         arg_list.append(key)
         arg_list.append(str(v))
 
-    op = BenchmarkOperator(extra_args=arg_list)
+    tb_args, extra_args = override_args(arg_list)
+    op = BenchmarkOperator(tb_args, extra_args)
 
     op.set_input_iter(input_iter)
 


### PR DESCRIPTION
Summary: Changes to triton_op.py in D91691767 require tb_args to be passed into BenchmarkOperator upon initialization which ultimately caused dynamic_runner to break.

Reviewed By: FindHao

Differential Revision: D91935887


