### PR TITLE
modify pingpongAutoWS as a tuning knob

### DIFF
--- a/tritonbench/kernels/blackwell_triton_fused_attention_dp.py
+++ b/tritonbench/kernels/blackwell_triton_fused_attention_dp.py
@@ -302,7 +302,7 @@ if is_tile_enabled():
 else:
     # Helper to build config with optional minRegAutoWS/maxRegAutoWS
     def make_standard_config(
-        BM, BN, s, w, subtile, subtile_p, vectmul, add2reduce, maxreg
+        BM, BN, s, w, subtile, subtile_p, vectmul, add2reduce, maxreg, pingpong
     ):
         config_kwargs = {
             "BLOCK_M": BM,
@@ -324,13 +324,13 @@ else:
             extra_kwargs["maxRegAutoWS"] = maxreg
 
         if HAS_PINGPONG_AUTO_WS:
-            extra_kwargs["pingpongAutoWS"] = True
+            extra_kwargs["pingpongAutoWS"] = pingpong
 
         return triton.Config(config_kwargs, **extra_kwargs)
 
     configs = [
         make_standard_config(
-            BM, BN, s, w, subtile, subtile_p, vectmul, add2reduce, maxreg
+            BM, BN, s, w, subtile, subtile_p, vectmul, add2reduce, maxreg, pingpong
         )
         for BM in [256]
         for BN in [64, 128]
@@ -341,6 +341,7 @@ else:
         for vectmul in [1]
         for add2reduce in [False]
         for maxreg in [152, 192]
+        for pingpong in [True, False]
     ]
 
 


### PR DESCRIPTION
With updates in the autoWS pingpong pass, it'd be beneficial to have pingpong as a tuning knob for the kernel blackwell_triton_fused_attention_dp.py. 


Below are performance numbers with subtile_p and pingpong on/off. The command I used is 
```
TRITON_ALWAYS_COMPILE=1 TRITON_KERNEL_DUMP=1 TRITON_USE_META_WS=1 TRITON_DUMP_DIR=/tmp/triton_dumps TRITON_DUMP_PTXAS_LOG=1 CUDA_VISIBLE_DEVICES=4 bash ~/fbsource/fbcode/ads_mkl/benchmarks/denoise.sh python run.py --op blackwell_attentions --seq-len 8192 --batch 4 --n-heads 32 --d-head 128 --rep 3000 --sleep 1.0 --metrics tflops --simple-output --only triton_tutorial_flash_dp_persistent_blackwell --force
```
Performance numbers:
|  Batch, Heads, Heads_KV, SeqLen, SeqLen_KV, Dhead) == (4, 32, 32, 8192, 8192, 128)| ttgir | tflops |
| --- | --- | --- |
| subtile_p = False, pingpong = False   | [P2157155915](https://www.internalfb.com/phabricator/paste/view/P2157155915) | ~ 871 |
| subtile_p = False, pingpong = True   | [P2157157254](https://www.internalfb.com/phabricator/paste/view/P2157157254) | ~ 862 |
| subtile_p = True, pingpong = False   | [P2157158462](https://www.internalfb.com/phabricator/paste/view/P2157158462) | ~916 |
| subtile_p = True, pingpong = True   | [P2157159885](https://www.internalfb.com/phabricator/paste/view/P2157159885) | ~924 |

|  Batch, Heads, Heads_KV, SeqLen, SeqLen_KV, Dhead) == (4, 32, 32, 8192, 8192, 64)| ttgir | tflops |
| --- | --- | --- |
| subtile_p = False, pingpong = False   | [P2157149223](https://www.internalfb.com/phabricator/paste/view/P2157149223) | ~ 604 |
| subtile_p = False, pingpong = True   | [P2157150491](https://www.internalfb.com/phabricator/paste/view/P2157150491) | ~ 639 |
| subtile_p = True, pingpong = False   | [P2157152986](https://www.internalfb.com/phabricator/paste/view/P2157152986) | ~615 |
| subtile_p = True, pingpong = True   | [P2157154134](https://www.internalfb.com/phabricator/paste/view/P2157154134) | ~649 |
