### PR TITLE
Backport fbtriton '[TLX] Omit CLC stage numbers from APIs (#833)'

### DIFF
--- a/tritonbench/operators/gemm/tlx_matmul.py
+++ b/tritonbench/operators/gemm/tlx_matmul.py
@@ -485,7 +485,7 @@ def matmul_kernel_tma_ws_blackwell(
 
     if CLUSTER_LAUNCH_CONTROL:
         # Dynamic tiling setup with CLC
-        clc_context = tlx.clc_create_context(1, 6 if PAIR_CTA else 3)
+        clc_context = tlx.clc_create_context(6 if PAIR_CTA else 3)
 
     with tlx.async_tasks():
         with tlx.async_task("default"):  # epilogue consumer
@@ -505,7 +505,7 @@ def matmul_kernel_tma_ws_blackwell(
             while tile_id != -1:
                 if CLUSTER_LAUNCH_CONTROL:
                     tlx.clc_producer(
-                        clc_context, 0, clc_phase_producer, multi_ctas=PAIR_CTA
+                        clc_context, clc_phase_producer, multi_ctas=PAIR_CTA
                     )
                     clc_phase_producer ^= 1
 
@@ -533,7 +533,7 @@ def matmul_kernel_tma_ws_blackwell(
 
                 if CLUSTER_LAUNCH_CONTROL:
                     tile_id = tlx.clc_consumer(
-                        clc_context, 0, clc_phase_consumer, multi_ctas=PAIR_CTA
+                        clc_context, clc_phase_consumer, multi_ctas=PAIR_CTA
                     )
                     clc_phase_consumer ^= 1
                 else:
@@ -579,7 +579,7 @@ def matmul_kernel_tma_ws_blackwell(
 
                 if CLUSTER_LAUNCH_CONTROL:
                     tile_id = tlx.clc_consumer(
-                        clc_context, 0, clc_phase_consumer, multi_ctas=PAIR_CTA
+                        clc_context, clc_phase_consumer, multi_ctas=PAIR_CTA
                     )
                     clc_phase_consumer ^= 1
                 else:
@@ -621,7 +621,7 @@ def matmul_kernel_tma_ws_blackwell(
                 )
                 if CLUSTER_LAUNCH_CONTROL:
                     tile_id = tlx.clc_consumer(
-                        clc_context, 0, clc_phase_consumer, multi_ctas=PAIR_CTA
+                        clc_context, clc_phase_consumer, multi_ctas=PAIR_CTA
                     )
                     clc_phase_consumer ^= 1
                 else:


### PR DESCRIPTION
Summary:
This is a backport of an upstream PR: https://github.com/facebookexperimental/triton/pull/833

NOTE: this diff also changes all the existing CLC use cases in fbsource

Upstream commit message:
```
> [TLX] Omit CLC stage numbers from APIs (#833)

> Summary:
> Originally we added num_clc_stages to support pipelining the async workload stealing.
> However we realize this setting is rarely needed so we are omitting this setting in API to further simplify users kernels using CLC.

> Pull Request resolved: https://github.com/facebookexperimental/triton/pull/833

> Test Plan:
> `pytest python/test/unit/language/test_tlx.py::test_cluster_launch_control`
> `TLX_GEMM_VERSION=ws pytest third_party/tlx/tutorials/correctness_test.py`
> `TLX_GEMM_VERSION=clc pytest third_party/tlx/tutorials/correctness_test.py`

> Reviewed By: htyu

> Differential Revision: D92216850

> Pulled By: dshi7

> fbshipit-source-id: 22f1a9fb1203e5d47af35d34f53d469b99902516
```

***Do not remove the following line from this commit***
Reactor FBTriton Backport Revision: 48acf32f337952c4aded7c87332b747f23e1eb0b
---

This diff was generated by running:
```
buck run fbcode//triton/tools/reactor:reactor -- backport --version stable --fbtriton --pr 833
```

Differential Revision: D92276508


