### PR TITLE
Modify input loader to make "count" optional

### DIFF
--- a/tritonbench/operator_loader/aten/input_loader.py
+++ b/tritonbench/operator_loader/aten/input_loader.py
@@ -170,7 +170,7 @@ class OperatorInputLoader:
                 continue
             op_inps = Counter()
             for inputs in input_config[operator]:
-                cnt = inputs["count"]
+                cnt = inputs["count"] if "count" in inputs else 1
                 inps = inputs["inputs"]
                 op_inps[inps] += cnt
             self.operator_db[operator] = op_inps


### PR DESCRIPTION
Summary: Make `count` field in input loader optional. If not present, assume 1.

Reviewed By: xuzhao9

Differential Revision: D92465945


