### PR TITLE
Enable running custom benchmarks with TritonBench stable fbpkgs

### DIFF
--- a/benchmarks/compare_benchmarks/utils.py
+++ b/benchmarks/compare_benchmarks/utils.py
@@ -32,6 +32,7 @@ class BenchmarkConfig:
     """Configuration for a benchmark run."""
 
     custom_bench: str = None
+    gpu: str = None
     ops: List[str] = field(default_factory=lambda: DEFAULT_OPS.copy())
     metrics: List[str] = field(default_factory=lambda: DEFAULT_METRICS.copy())
     workloads: List[str] = field(default_factory=lambda: DEFAULT_WORKLOADS.copy())

--- a/run.py
+++ b/run.py
@@ -5,14 +5,31 @@ Note: make sure to `python install.py` first or otherwise make sure the benchmar
       has been installed. This script intentionally does not automate or enforce setup steps.
 """
 
+import importlib
+import sys
 from typing import List, Optional
 
 from tritonbench.utils.run_utils import tritonbench_run
 
 
 def run(args: Optional[List[str]] = None):
+    if args is None:
+        args = sys.argv[1:]
+
+    if "--launch" in args:
+        launch_idx = args.index("--launch")
+        if launch_idx + 1 >= len(args):
+            raise ValueError("--launch requires a module path argument")
+        launch_module = args[launch_idx + 1]
+        extra_args = args[:launch_idx] + args[launch_idx + 2:]
+        module = importlib.import_module(launch_module)
+        if not hasattr(module, "run"):
+            raise ValueError(f"Module {launch_module} has no 'run' function")
+        module.run(extra_args)
+        return
+
     tritonbench_run(args)
 
 
 if __name__ == "__main__":
-    tritonbench_run()
+    run()


### PR DESCRIPTION
Summary: Add dependencies and other required modifications in order to enable running `torchx` jobs with TritonBench `fbpkg`s on `compare_benchmarks`.

Reviewed By: xuzhao9

Differential Revision: D92554355


