### PR TITLE
Add --diode-model-config CLI arg for JSON ModelConfig

### DIFF
--- a/benchmarks/compare_benchmarks/run.py
+++ b/benchmarks/compare_benchmarks/run.py
@@ -66,6 +66,8 @@ def build_op_args(
                 str(config.diode_topk),
             ]
         )
+        if config.diode_model_config is not None:
+            args.extend(["--diode-model-config", config.diode_model_config])
 
     return args
 
@@ -357,6 +359,12 @@ def parse_args(args: List[str] = None) -> BenchmarkConfig:
         help="Diode model version to use. Default: recommended",
     )
     parser.add_argument(
+        "--diode-model-config",
+        type=str,
+        default=None,
+        help="JSON-serialized Diode ModelConfig. Overrides --diode-version.",
+    )
+    parser.add_argument(
         "--diode-topk",
         type=int,
         default=1,
@@ -391,6 +399,7 @@ def parse_args(args: List[str] = None) -> BenchmarkConfig:
             **base_configs,
             benchmark_map=benchmark_map,
             diode_version=args.diode_version,
+            diode_model_config=args.diode_model_config,
             diode_topk=args.diode_topk,
         )
 

--- a/benchmarks/compare_benchmarks/utils.py
+++ b/benchmarks/compare_benchmarks/utils.py
@@ -47,6 +47,7 @@ class DiodeBenchmarkConfig(BenchmarkConfig):
 
     custom_bench: str = "diode"
     diode_version: str = "recommended"
+    diode_model_config: Optional[str] = None
     diode_topk: int = 1
 
 

--- a/tritonbench/utils/diode_utils.py
+++ b/tritonbench/utils/diode_utils.py
@@ -1,5 +1,6 @@
 """Diode (ML model for pruning autotuning configs) utils for TritonBench operators."""
 
+import json
 import logging
 
 from torch._inductor.choices import InductorChoices
@@ -9,15 +10,60 @@ from tritonbench.utils.env_utils import is_fbcode
 if is_fbcode():  # Diode not available in OSS
     import diode.torch_diode.config as diode_config
     from diode.torch_diode.choices import DiodeInductorChoices
-    from diode.torch_diode.models.triton_gemm.model import GEMMModelV2, MODEL_CONFIGS
+    from diode.torch_diode.models.triton_gemm.encode_features import FeatureVersion
+    from diode.torch_diode.models.triton_gemm.model import (
+        GEMMModelV2,
+        MODEL_CONFIGS,
+        ModelConfig,
+    )
     from diode.torch_diode.registry import get_registry, register
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 
+def deserialize_model_config(json_str: str) -> "ModelConfig":
+    """Deserialize a JSON string into a ModelConfig instance.
+
+    Args:
+        json_str: JSON string representing a ModelConfig. The JSON should have
+            the following fields:
+            - model_name (str): Manifold model path
+            - n_hidden_layers (int): Number of hidden layers
+            - dropout_rate (float): Dropout rate
+            - template_op_pairs (list[list[str, str]]): Template/op pairs
+              (JSON arrays, converted to tuples)
+            - supported_devices (list[str] | null): Supported GPU devices
+            - feature_version (str): Feature version string (e.g. "v4")
+            - is_production (bool, optional): Production bucket flag. Default: True
+            - description (str, optional): Human-readable description. Default: ""
+
+    Returns:
+        A ModelConfig instance.
+
+    Raises:
+        json.JSONDecodeError: If the input is not valid JSON.
+        KeyError: If a required field is missing.
+        ValueError: If feature_version is not a valid FeatureVersion enum value.
+    """
+    data = json.loads(json_str)
+    return ModelConfig(
+        model_name=data["model_name"],
+        n_hidden_layers=data["n_hidden_layers"],
+        dropout_rate=data["dropout_rate"],
+        template_op_pairs=[tuple(pair) for pair in data["template_op_pairs"]],
+        supported_devices=data.get("supported_devices"),
+        feature_version=FeatureVersion(data["feature_version"]),
+        is_production=data.get("is_production", True),
+        description=data.get("description", ""),
+    )
+
+
 def setup_diode_model(
-    diode_version, topk: int = 1, expand_search_space: bool = True
+    diode_version: str,
+    topk: int = 1,
+    expand_search_space: bool = True,
+    model_config: "ModelConfig | None" = None,
 ) -> tuple[int, bool]:
     logger.info("[DIODE][TritonBench] Setup Diode model.")
 
@@ -27,9 +73,10 @@ def setup_diode_model(
     diode_config.topk = topk
     diode_config.expand_search_space = expand_search_space
 
-    gemm_diode_model: GEMMModelV2 = GEMMModelV2(
-        model_config=MODEL_CONFIGS[diode_version]
-    )
+    if model_config is None:
+        model_config = MODEL_CONFIGS[diode_version]
+
+    gemm_diode_model: GEMMModelV2 = GEMMModelV2(model_config=model_config)
     register(gemm_diode_model)
 
     V.set_choices_handler(DiodeInductorChoices())

--- a/tritonbench/utils/parser.py
+++ b/tritonbench/utils/parser.py
@@ -402,6 +402,16 @@ def get_parser(args=None):
             help="Version of diode to use. Default: recommended version in MODEL_CONFIGS (~/fbsource/fbcode/diode/torch_diode/models/triton_gemm/model.py)",
         )
         parser.add_argument(
+            "--diode-model-config",
+            type=str,
+            default=None,
+            help="JSON-serialized Diode ModelConfig. Advanced option that allows testing of Diode models "
+            "that are not registered in the Diode codebase. If provided, this takes precedence over "
+            '--diode-version. Example: \'{"model_name": "v5/my_test_model", "n_hidden_layers": 6, '
+            '"dropout_rate": 0.05, "template_op_pairs": [["triton::mm", "mm"], ["triton::bmm", "bmm"], ...], '
+            '"supported_devices": ["NVIDIA H100", ...], "feature_version": "v5", "is_production": false}\'',
+        )
+        parser.add_argument(
             "--diode-topk",
             type=int,
             default=1,

--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -39,7 +39,11 @@ from tritonbench.utils.constants import (
     DEFAULT_WARMUP,
 )
 from tritonbench.utils.cudagraph_utils import CudaGraphConfig, CudaGraphError
-from tritonbench.utils.diode_utils import setup_diode_model, teardown_diode_model
+from tritonbench.utils.diode_utils import (
+    deserialize_model_config,
+    setup_diode_model,
+    teardown_diode_model,
+)
 from tritonbench.utils.env_utils import (
     apply_precision,
     is_fbcode,
@@ -1157,9 +1161,15 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
                         else False
                     )
                     if "diode" in bm_name:
+                        diode_model_config = None
+                        if getattr(self.tb_args, "diode_model_config", None):
+                            diode_model_config = deserialize_model_config(
+                                self.tb_args.diode_model_config
+                            )
                         self.old_diode_configs = setup_diode_model(
                             self.tb_args.diode_version,
                             topk=self.tb_args.diode_topk,
+                            model_config=diode_model_config,
                         )
                     acc[bm_name] = self._do_bench(
                         input_id=input_id,


### PR DESCRIPTION
Summary:
Enables testing Diode models that are not yet registered in `MODEL_CONFIGS` by accepting a JSON-serialized `ModelConfig` directly via the CLI. This is motivated by the discussion on D92621277 — iterating on new model configs currently requires adding them to the registry, which is slow and pollutes the codebase. With `--diode-model-config`, researchers can prototype and benchmark new model configurations end-to-end without touching the Diode codebase.

When `--diode-model-config` is provided, the JSON is deserialized into a `ModelConfig` instance (with proper handling of JSON arrays → tuples, enum string → `FeatureVersion`, and optional field defaults) and takes precedence over the `--diode-version` lookup into `MODEL_CONFIGS`.

The new argument is propagated through all benchmark runner entry points (`benchmarks/fb/diode/run.py` and `benchmarks/compare_benchmarks/run.py`).

Reviewed By: jananisriram

Differential Revision: D92977001


