### PR TITLE
Logging tritonbench zgpu results to scuba

### DIFF
--- a/tritonbench/utils/parser.py
+++ b/tritonbench/utils/parser.py
@@ -10,7 +10,8 @@ from tritonbench.utils.constants import (
     DEFAULT_REP,
     DEFAULT_WARMUP,
 )
-from tritonbench.utils.env_utils import AVAILABLE_PRECISIONS, is_fbcode
+from tritonbench.utils.env_utils import AVAILABLE_PRECISIONS, is_fbcode, is_hip
+from tritonbench.utils.gpu_utils import get_amd_device_name
 
 
 def get_parser(args=None):
@@ -393,6 +394,12 @@ def get_parser(args=None):
             default="stable",
             type=str,
             help="Set what version of Triton we are using for logging purposes.",
+        )
+        parser.add_argument(
+            "--hardware",
+            type=str,
+            default=get_amd_device_name() if is_hip() else torch.cuda.get_device_name(),
+            help="Specify the hardware target (e.g., H100, B200, MI300) for Scuba logging.",
         )
         # Diode args (Diode not available in OSS)
         parser.add_argument(


### PR DESCRIPTION
Summary: This diff introduces a new run_id to allow for tritonbench to be added to scuba and easily queriable

Differential Revision: D93003503


