### PR TITLE
[bisect] add preflight check to bisect

### DIFF
--- a/.ci/bisect/run.sh
+++ b/.ci/bisect/run.sh
@@ -91,13 +91,19 @@ install_triton "${TRITON_SRC_DIR}"
 cd "${TRITONBENCH_DIR}"
 # allow the regression detector to exit with error code
 set +e
-python ./.ci/bisect/regression_detector.py
-# if no regression, exit early and report error: this shouldn't happen
-if [ $? -eq 0 ]; then
-    echo "ERROR: Regression not detected on bad commit"
-    exit 1
-fi
+BASELINE_LOG="${BASELINE_LOG}" python ./.ci/bisect/regression_detector.py
+PREFLIGHT_RC=$?
 set -e
+# if no regression, exit early and report error: this shouldn't happen
+if [ ${PREFLIGHT_RC} -eq 0 ]; then
+    echo "ERROR: No regression detected on bad commit (${BAD_COMMIT}) relative to good commit (${GOOD_COMMIT})."
+    echo "The regression detector exited with 0, meaning the bad commit behaves the same as the good commit."
+    echo "Please verify that your good_commit and bad_commit are correct, or adjust the REGRESSION_THRESHOLD (currently ${REGRESSION_THRESHOLD}%)."
+    exit 1
+elif [ ${PREFLIGHT_RC} -ne 1 ] && [ ${FUNCTIONAL} -ne 1 ]; then
+    echo "WARNING: Pre-flight regression check exited with unexpected code ${PREFLIGHT_RC}."
+    echo "This may indicate a build or environment issue. Proceeding with bisect anyway."
+fi
 
 # kick off the bisect!
 BASELINE_LOG="${BASELINE_LOG}" PER_COMMIT_LOG=1 USE_UV=1 CONDA_DIR="${WORKSPACE_DIR}/uv_venvs/${CONDA_ENV}" \


### PR DESCRIPTION
Before this PR, if there is no regression between good and bad diffs, the bisect is still successful.

Add pre-flight check to error out if there is no regression detected.


Test bisect:

command line:  python run.py --op ragged_attention --metrics tflops --simple-output
repo: triton-main
good commit: 3c995fc5d50fb025948b550f788cc7bdf0254829
bad commit: 27bd20aa3270164d8f0983df9aa76967a575ec4c
test run (expected fail): https://github.com/meta-pytorch/tritonbench/actions/runs/21970212633


command line:  python run.py --op ragged_attention --metrics tflops --simple-output
repo: meta-triton
good commit: f7b1febc50e4a3f828e26b0a31bb5249b402b9ba
bad commit: 3bde25574791cb1f61b22bb616542caf90357eed
test run (expected success): https://github.com/meta-pytorch/tritonbench/actions/runs/21973364610