### PR TITLE
Correctly set env with torchrun

### DIFF
--- a/tritonbench/utils/env_utils.py
+++ b/tritonbench/utils/env_utils.py
@@ -17,6 +17,7 @@ import triton
 from tritonbench.utils.path_utils import REPO_PATH
 
 log = logging.getLogger(__name__)
+log.setLevel(logging.INFO)
 
 MAIN_RANDOM_SEED = 1337
 AVAILABLE_PRECISIONS = [
@@ -306,3 +307,14 @@ def get_logger(name, level: int = logging.INFO):
     logger = logging.getLogger(name)
     logger.setLevel(level)
     return logger
+
+
+def set_torchrun_env():
+    """Set the environment variables that are relevant to running TritonBench with torchrun (torch.distributed.run)."""
+    if "TORCHELASTIC_RUN_ID" in os.environ and "LOCAL_RANK" in os.environ:
+        os.environ["CUDA_VISIBLE_DEVICES"] = os.environ["LOCAL_RANK"]
+        torch.cuda.set_device(int(os.environ["LOCAL_RANK"]))
+        log.info(
+            f"[distributed] Found TORCHELASTIC_RUN_ID={os.environ['TORCHELASTIC_RUN_ID']} and LOCAL_RANK={os.environ['LOCAL_RANK']}. "
+            f"Set current device to: {torch.cuda.current_device()}"
+        )

--- a/tritonbench/utils/run_utils.py
+++ b/tritonbench/utils/run_utils.py
@@ -17,7 +17,7 @@ from tritonbench.operator_loader import get_op_loader_bench_cls_by_name, is_load
 from tritonbench.operators import load_opbench_by_name
 from tritonbench.operators_collection import list_operators_by_collection
 from tritonbench.utils.ab_test import compare_ab_results, run_ab_test
-from tritonbench.utils.env_utils import is_fbcode, is_hip
+from tritonbench.utils.env_utils import is_fbcode, is_hip, set_torchrun_env
 from tritonbench.utils.git_utils import get_branch, get_commit_time, get_current_hash
 from tritonbench.utils.gpu_utils import get_amd_device_name, gpu_lockdown
 from tritonbench.utils.list_operator_details import list_operator_details
@@ -145,6 +145,8 @@ def tritonbench_run(args: Optional[List[str]] = None):
     if config := os.environ.get("TRITONBENCH_RUN_CONFIG", None):
         run_config(config, args)
         return
+
+    set_torchrun_env()
 
     # Log the tool usage
     usage_report_logger(benchmark_name="tritonbench")


### PR DESCRIPTION
Summary:
When running TritonBench with `torchrun` (torch.distributed.run), each worker process inherits all GPUs as visible devices, causing every rank to default to GPU 0. This results in unstable benchmarking results, even with `--cudagraph`.

This diff adds a `set_torchrun_env()` function that detects a torchrun environment (via `TORCHELASTIC_RUN_ID` and `LOCAL_RANK` env vars) and pins each worker to its corresponding GPU by setting `CUDA_VISIBLE_DEVICES` to `LOCAL_RANK` and calling `torch.cuda.set_device()`. This is called early in `tritonbench_run()` before any operator loading or benchmarking begins.

Differential Revision: D93181880


