### PR TITLE
Fix for illegal memory access which is causing a hang on AMD GPUs.

### DIFF
--- a/tritonbench/operators/gemm/partition_k.py
+++ b/tritonbench/operators/gemm/partition_k.py
@@ -192,7 +192,6 @@ def _reduce(
     BLOCK_SIZE_N: tl.constexpr,
 ):
     pid = tl.program_id(0)
-    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
     num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
     pid_m = pid // num_pid_n
     pid_n = pid % num_pid_n


### PR DESCRIPTION
This commit fixes the correctness and prevents illegal access due to integer overflow in pointer offsets when running the partitionk kernel with non-square kernels shapes.
This kernel currently hangs on AMD MI series GPUs due to an invalid memory access.