### PR TITLE
Add conda on mast config

### DIFF
--- a/tritonbench/operators/fp8_gemm/persistent.py
+++ b/tritonbench/operators/fp8_gemm/persistent.py
@@ -21,7 +21,7 @@ if is_cuda():
             32 * 1024 * 1024, device="cuda", dtype=torch.uint8
         )
         cublas = nvidia.cublas.CublasLt(cublas_workspace)
-    except (ImportError, IOError, AttributeError):
+    except (ImportError, IOError, AttributeError, RuntimeError):
         pass
 
 

--- a/tritonbench/operators/gemm/persistent_matmul.py
+++ b/tritonbench/operators/gemm/persistent_matmul.py
@@ -11,14 +11,17 @@ from .triton_matmul_configs import get_full_amd_config_space, get_tileir_configs
 if not is_fbcode():
     import triton.tools.experimental_descriptor
 
-    if is_cuda():
-        from triton._C.libtriton import nvidia
+    try:
+        if is_cuda():
+            from triton._C.libtriton import nvidia
 
-        cublas_workspace = torch.empty(
-            32 * 1024 * 1024, device="cuda", dtype=torch.uint8
-        )
-        cublas = nvidia.cublas.CublasLt(cublas_workspace)
-    else:
+            cublas_workspace = torch.empty(
+                32 * 1024 * 1024, device="cuda", dtype=torch.uint8
+            )
+            cublas = nvidia.cublas.CublasLt(cublas_workspace)
+        else:
+            cublas = None
+    except RuntimeError:
         cublas = None
 
 

--- a/tritonbench/operators/gemm/stream_k.py
+++ b/tritonbench/operators/gemm/stream_k.py
@@ -17,14 +17,17 @@ from tritonbench.utils.env_utils import is_cuda, is_fbcode, is_hip_mi300
 from .triton_matmul_configs import get_full_amd_config_space
 
 if not is_fbcode():
-    if is_cuda():
-        from triton._C.libtriton import nvidia
+    try:
+        if is_cuda():
+            from triton._C.libtriton import nvidia
 
-        cublas_workspace = torch.empty(
-            32 * 1024 * 1024, device="cuda", dtype=torch.uint8
-        )
-        cublas = nvidia.cublas.CublasLt(cublas_workspace)
-    else:
+            cublas_workspace = torch.empty(
+                32 * 1024 * 1024, device="cuda", dtype=torch.uint8
+            )
+            cublas = nvidia.cublas.CublasLt(cublas_workspace)
+        else:
+            cublas = None
+    except RuntimeError:
         cublas = None
 
 


### PR DESCRIPTION
Summary:
Submit job that runs Conda on MAST.

Conda on MAST does not support customizing LD_LIBRARY_PATH (it will be overwritten by some other components), so cublas library path can't be set.

Differential Revision: D93285469


