### PR TITLE
Fixed gpu name access where no gpu available

### DIFF
--- a/tritonbench/utils/gpu_utils.py
+++ b/tritonbench/utils/gpu_utils.py
@@ -287,6 +287,19 @@ def get_amd_device_name() -> str:
     return AMD_DEVICE_NAME_MAPPING[(gcn_arch_major, gcn_arch_minor)]
 
 
+def get_gpu_device_name() -> str:
+    try:
+        import torch
+        from tritonbench.utils.env_utils import is_hip
+        from tritonbench.utils.gpu_utils import get_amd_device_name
+
+        if is_hip():
+            return get_amd_device_name()
+        return torch.cuda.get_device_name()
+    except Exception:
+        return "None"
+
+
 @triton.jit
 def sleep_amd(sleep_ns: tl.constexpr = 1000000):
     """

--- a/tritonbench/utils/parser.py
+++ b/tritonbench/utils/parser.py
@@ -10,8 +10,8 @@ from tritonbench.utils.constants import (
     DEFAULT_REP,
     DEFAULT_WARMUP,
 )
-from tritonbench.utils.env_utils import AVAILABLE_PRECISIONS, is_fbcode, is_hip
-from tritonbench.utils.gpu_utils import get_amd_device_name
+from tritonbench.utils.env_utils import AVAILABLE_PRECISIONS, is_fbcode
+from tritonbench.utils.gpu_utils import get_gpu_device_name
 
 
 def get_parser(args=None):
@@ -398,7 +398,7 @@ def get_parser(args=None):
         parser.add_argument(
             "--hardware",
             type=str,
-            default=get_amd_device_name() if is_hip() else torch.cuda.get_device_name(),
+            default=get_gpu_device_name(),
             help="Specify the hardware target (e.g., H100, B200, MI300) for Scuba logging.",
         )
         # Diode args (Diode not available in OSS)


### PR DESCRIPTION
Summary: This diff fixes a breakage introduced by D93003503 where a default hardware type value extarction caused error for tests with no gpu assigned

Differential Revision: D93624224


