### PR TITLE
Add wildcard matching support to --input-loader flag

### DIFF
--- a/docs/data.md
+++ b/docs/data.md
@@ -7,7 +7,7 @@ In TritonBench, users can customize the input data to run. Here is an overview o
 | `--input-id`          | Input ID to run, starting from 0.      Default is 0.                                                                                                                                                                 |
 | `--num-inputs`        | Number of inputs to run. By default, run all available inputs.                                                                                                                                                       |
 | `--input-sample-mode` | Input sampling mode. 'first-k' (default) uses the first k inputs starting from `--input-id`.  "'equally-spaced-k' selects k equally spaced inputs from the entire input range, where k is specified by --num-inputs. |
-| `--input-loader`      | Specify a json file to load inputs from the input json file.                                                                                                                                                         |
+| `--input-loader`      | Specify a json file (or wildcard pattern) to load inputs from input json file(s).                                                                                                                                    |
 
 
 ## Input Data Collection
@@ -15,3 +15,48 @@ In TritonBench, users can customize the input data to run. Here is an overview o
 We keep a set of input data in the [data/input_configs](https://github.com/meta-pytorch/tritonbench/tree/main/tritonbench/data/input_configs) directory.
 The input data is organized by model names and is in json format. User can specify the input config by `--input-loader <path-to-input-json>`.
 TritonBench will generate synthetic inputs based on the input config.
+
+### Wildcard Matching
+
+The `--input-loader` flag supports wildcard patterns to load and merge multiple input config files at once. This is useful when you want to benchmark across multiple input configurations.
+
+**Supported wildcards:** `*`, `?`, `[`, `]`
+
+#### Examples
+
+**Single file (standard usage):**
+```bash
+--input-loader path/to/input_configs/fb/ads_omnifm_v4/domain_experts_gemm.json
+```
+
+**Wildcard matching multiple files:**
+```bash
+# Load all gemm input configs from a directory
+--input-loader 'path/to/input_configs/fb/ads_omnifm_v4/*_gemm.json'
+```
+
+#### Behavior
+
+When multiple files match a wildcard pattern:
+
+1. **Preload**: All matching JSON files are loaded
+2. **Validation**: All files must have the same `tritonbench_ops` in their metadata. If files have different ops (e.g., mixing `gemm` and `addmm` configs), the job will terminate with an error
+3. **Merge & Dedupe**: Inputs from all files are merged, with duplicate inputs (based on the `inputs` field) removed
+
+#### Example Output
+
+```
+[input-loader] Merged 15 input config files with 221 total unique inputs
+```
+
+#### Error Case
+
+If you try to merge files with different `tritonbench_ops`, you will see an error like:
+
+```
+RuntimeError: All input config files must have the same tritonbench_ops, but found different ops:
+  - path/to/file1_addmm.json: ('addmm',)
+  - path/to/file2_gemm.json: ('gemm',)
+```
+
+To fix this, make your wildcard pattern more specific (e.g., use `*_gemm.json` instead of `*.json`).

--- a/tritonbench/data/loader.py
+++ b/tritonbench/data/loader.py
@@ -1,8 +1,9 @@
+import glob as glob_module
 import importlib
 import json
 import os
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, List, Optional, Tuple
 
 from tritonbench.utils.env_utils import is_fbcode
 
@@ -36,6 +37,111 @@ def get_input_config_path(input_config_short_path: str):
     return input_file_path
 
 
+def expand_input_config_paths(input_pattern: str) -> List[Path]:
+    """
+    Expand a path pattern (potentially with wildcards) to a list of actual file paths.
+    Supports wildcards like *, ?, etc.
+    """
+    has_wildcard = any(c in input_pattern for c in ["*", "?", "[", "]"])
+
+    if not has_wildcard:
+        return [get_input_config_path(input_pattern)]
+
+    matches = list(glob_module.glob(input_pattern))
+    if matches:
+        return [Path(m) for m in sorted(matches)]
+
+    config_pattern = str(INPUT_CONFIG_DIR / input_pattern)
+    matches = list(glob_module.glob(config_pattern))
+    if matches:
+        return [Path(m) for m in sorted(matches)]
+
+    if INTERNAL_INPUT_CONFIG_DIR:
+        internal_pattern = str(INTERNAL_INPUT_CONFIG_DIR / input_pattern)
+        matches = list(glob_module.glob(internal_pattern))
+        if matches:
+            return [Path(m) for m in sorted(matches)]
+
+    raise RuntimeError(f"No input files found matching pattern: {input_pattern}")
+
+
+def load_and_merge_input_configs(
+    file_paths: List[Path],
+) -> Tuple[dict, Optional[str]]:
+    """
+    Load and merge multiple input config JSON files.
+    Validates that all files have the same tritonbench_ops.
+    Returns merged config and the common loader type.
+    """
+    if len(file_paths) == 1:
+        with open(file_paths[0], "r") as f:
+            config = json.load(f)
+        loader = None
+        if "metadata" in config and "tritonbench_loader" in config["metadata"]:
+            loader = config["metadata"]["tritonbench_loader"]
+        return config, loader
+
+    configs = []
+    ops_sets = []
+    loaders = []
+
+    for path in file_paths:
+        with open(path, "r") as f:
+            config = json.load(f)
+        configs.append((path, config))
+
+        if "metadata" in config and "tritonbench_ops" in config["metadata"]:
+            ops = tuple(sorted(config["metadata"]["tritonbench_ops"]))
+        else:
+            ops = tuple(sorted(k for k in config.keys() if k != "metadata"))
+        ops_sets.append(ops)
+
+        if "metadata" in config and "tritonbench_loader" in config["metadata"]:
+            loaders.append(config["metadata"]["tritonbench_loader"])
+
+    unique_ops = set(ops_sets)
+    if len(unique_ops) > 1:
+        error_details = "\n".join(
+            f"  - {path}: {ops}" for path, ops in zip(file_paths, ops_sets)
+        )
+        raise RuntimeError(
+            f"All input config files must have the same tritonbench_ops, but found different ops:\n{error_details}"
+        )
+
+    unique_loaders = set(loaders)
+    if len(unique_loaders) > 1:
+        raise RuntimeError(
+            f"All input config files must use the same tritonbench_loader, but found: {unique_loaders}"
+        )
+
+    common_loader = loaders[0] if loaders else None
+
+    merged_config = {}
+    _, first_config = configs[0]
+    if "metadata" in first_config:
+        merged_config["metadata"] = first_config["metadata"].copy()
+
+    for _, config in configs:
+        for key, inputs_list in config.items():
+            if key == "metadata":
+                continue
+            if key not in merged_config:
+                merged_config[key] = []
+
+            existing_inputs = {inp["inputs"] for inp in merged_config[key]}
+            for inp in inputs_list:
+                if inp["inputs"] not in existing_inputs:
+                    merged_config[key].append(inp)
+                    existing_inputs.add(inp["inputs"])
+
+    total_inputs = sum(len(v) for k, v in merged_config.items() if k != "metadata")
+    print(
+        f"[input-loader] Merged {len(file_paths)} input config files with {total_inputs} total unique inputs"
+    )
+
+    return merged_config, common_loader
+
+
 def get_input_loader(
     tritonbench_op: Any, input: Optional[str] = None, loader="builtin"
 ):
@@ -49,27 +155,23 @@ def get_input_loader(
     if hasattr(tritonbench_op, "aten_op_name"):
         loader = "aten"
     if loader == "jagged":
-        # default config for all jagged inputs
         input = "durin_20250402/jagged_dense_dense_sum.json" if not input else input
-    input_file_path = get_input_config_path(input)
 
-    with open(input_file_path, "r") as f:
-        input_config = json.load(f)
+    input_file_paths = expand_input_config_paths(input)
+    input_config, config_loader = load_and_merge_input_configs(input_file_paths)
 
-    # Sanity checks
-    if "metadata" in input_config and "tritonbench_loader" in input_config["metadata"]:
-        loader = input_config["metadata"]["tritonbench_loader"]
+    if config_loader:
+        loader = config_loader
+
     if loader == "builtin":
         assert (
             hasattr(tritonbench_op, "aten_op_name") or op_name in SUPPORTED_INPUT_OPS
         ), f"Unsupported op by builtin loader: {op_name}. "
 
-    # Load jagged inputs
     if loader == "jagged" and is_fbcode():
         from .input_loaders.fb.jagged import InputLoader
 
         return InputLoader(tritonbench_op, input_config).get_input_iter()
-    # Load operator warehouse inputs
     elif loader == "operator_warehouse" and is_fbcode():
         from .input_loaders.fb.operator_warehouse import (
             get_input_iter as get_input_iter_ow,
@@ -80,11 +182,9 @@ def get_input_loader(
     op_module = ".".join(tritonbench_op.__module__.split(".")[:-1])
     generator_module = importlib.import_module(op_module)
     input_loader_cls = generator_module.InputLoader
-    # Load aten inputs
     if loader == "aten":
         operator_inputs_loader = input_loader_cls(op_name, input_config)
         return operator_inputs_loader.get_input_iter()
-    # Load builtin inputs
     elif loader == "builtin":
         input_loader = input_loader_cls(tritonbench_op, input_config)
         return input_loader.get_input_iter()


### PR DESCRIPTION
Summary:
When benchmarking across multiple input configurations (e.g., different model layers), users previously had to run separate benchmark commands for each JSON file. This change enables loading multiple input config files at once using wildcard patterns like `*_gemm.json`.

The implementation:
- Expands wildcard patterns using Python's glob module
- Validates that all matched files have the same `tritonbench_ops` (errors out with clear message if not)
- Merges and deduplicates inputs across files before running

This simplifies workflows where users want to benchmark a kernel across all related input configurations in a directory.

Differential Revision: D93774424


