### PR TITLE
[AutoWS] [GEMM] Modify persistent GEMM configs based on support WS

### DIFF
--- a/tritonbench/operators/gemm/warp_spec_persistent_matmul.py
+++ b/tritonbench/operators/gemm/warp_spec_persistent_matmul.py
@@ -725,8 +725,6 @@ def blackwell_matmul_descriptor_persistent(a, b, warp_specialize: bool):
         c_stride,  #
         NUM_SMS=NUM_SMS,  #
         WARP_SPECIALIZE=warp_specialize,  #
-        # Note: This assumes blackwell.
-        FLATTEN=True,
         TRANSPOSE_A=transpose_a,
         TRANSPOSE_B=transpose_b,
     )


### PR DESCRIPTION
- Our AutoWS implementation doesn't work with num_warps=8 (blocked by layout issues, not clear to me that its critical).
- OAI's WS crashes with FLATTEN=False and WS. We get performance with FLATTEN=False and our WS path doesn't work yet with FLATTEN=True, but it doesn't crash and this is on my todo list to support.

I will be updating our WS to support the FLATTEN pattern.