### PR TITLE
[ci] Fix gemm TMA API upgrade

### DIFF
--- a/tritonbench/operators/gemm/operator.py
+++ b/tritonbench/operators/gemm/operator.py
@@ -338,9 +338,8 @@ class Operator(BenchmarkOperator):
         else:
             return lambda: matmul_tma_persistent(a, b)
 
-    @register_benchmark(
-        enabled=not is_fbcode() and HAS_PERSISTENT and supports_tma(), fwd_only=True
-    )
+    # TODO fix cached TMA backend
+    @register_benchmark(enabled=False, fwd_only=True)
     def triton_tma_persistent_cached_matmul(self, a, b, bias) -> Callable:
         b = b.T.contiguous()
         if bias is not None:

--- a/tritonbench/operators/gemm/persistent_matmul.py
+++ b/tritonbench/operators/gemm/persistent_matmul.py
@@ -4,9 +4,12 @@ from functools import lru_cache
 import torch
 import triton
 import triton.language as tl
+from tritonbench.kernels.triton_fused_attention import TensorDescriptor
 from tritonbench.utils.env_utils import is_cuda, is_fbcode, is_tile_enabled
 
+from ...kernels.triton_fused_attention import _maybe_make_tensor_desc
 from .triton_matmul_configs import get_full_amd_config_space, get_tileir_configs
+
 
 if not is_fbcode():
     import triton.tools.experimental_descriptor
@@ -252,11 +255,61 @@ def matmul_persistent(a, b):
     return c
 
 
+def matmul_tma_persistent_get_configs(pre_hook=None):
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": BM,
+                "BLOCK_SIZE_N": BN,
+                "BLOCK_SIZE_K": BK,
+                "GROUP_SIZE_M": 8,
+                "EPILOGUE_SUBTILE": SUBTILE,
+            },
+            num_stages=s,
+            num_warps=w,
+            pre_hook=pre_hook,
+        )  #
+        for BM in [128]  #
+        for BN in [128, 256]  #
+        for BK in [64, 128]  #
+        for s in ([2, 3, 4])  #
+        for w in [4, 8]  #
+        for SUBTILE in [True, False]  #
+    ]
+
+
+def matmul_tma_set_block_size_hook(nargs):
+    EPILOGUE_SUBTILE = nargs.get("EPILOGUE_SUBTILE", False)
+    BLOCK_M = nargs["BLOCK_SIZE_M"]
+    BLOCK_N = nargs["BLOCK_SIZE_N"]
+    BLOCK_K = nargs["BLOCK_SIZE_K"]
+    nargs["a_desc"].block_shape = [BLOCK_M, BLOCK_K]
+    nargs["b_desc"].block_shape = [BLOCK_N, BLOCK_K]
+    if EPILOGUE_SUBTILE:
+        nargs["c_desc"].block_shape = [BLOCK_M, BLOCK_N // 2]
+    else:
+        nargs["c_desc"].block_shape = [BLOCK_M, BLOCK_N]
+
+
+@triton.jit
+def _compute_pid(tile_id, num_pid_in_group, num_pid_m, GROUP_SIZE_M, NUM_SMS):
+    group_id = tile_id // num_pid_in_group
+    first_pid_m = group_id * GROUP_SIZE_M
+    group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+    pid_m = first_pid_m + (tile_id % group_size_m)
+    pid_n = (tile_id % num_pid_in_group) // group_size_m
+    return pid_m, pid_n
+
+
+@triton.autotune(
+    configs=matmul_tma_persistent_get_configs(pre_hook=matmul_tma_set_block_size_hook),
+    key=["M", "N", "K", "WARP_SPECIALIZE"],
+)
 @triton.jit(launch_metadata=_matmul_launch_metadata)
 def matmul_kernel_tma_persistent(
-    a_desc_ptr,
-    b_desc_ptr,
-    c_desc_ptr,  #
+    a_desc,
+    b_desc,
+    c_desc,  #
     M,
     N,
     K,  #
@@ -265,8 +318,10 @@ def matmul_kernel_tma_persistent(
     BLOCK_SIZE_K: tl.constexpr,  #
     GROUP_SIZE_M: tl.constexpr,  #
     FP8_OUTPUT: tl.constexpr,  #
-    NUM_SMS: tl.constexpr,
-):  #
+    EPILOGUE_SUBTILE: tl.constexpr,  #
+    NUM_SMS: tl.constexpr,  #
+    WARP_SPECIALIZE: tl.constexpr,  #
+):
     dtype = tl.float8e4nv if FP8_OUTPUT else tl.float16
     start_pid = tl.program_id(axis=0)
     num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
@@ -274,81 +329,53 @@ def matmul_kernel_tma_persistent(
     k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
     num_tiles = num_pid_m * num_pid_n
 
-    tiles_per_SM = num_tiles // NUM_SMS
-    if start_pid < num_tiles % NUM_SMS:
-        tiles_per_SM += 1
-
-    tile_id = start_pid - NUM_SMS
-    ki = -1
-
-    pid_m = 0
-    pid_n = 0
-    offs_am = 0
-    offs_bn = 0
-
+    tile_id_c = start_pid - NUM_SMS
     num_pid_in_group = GROUP_SIZE_M * num_pid_n
 
-    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
-
-    for _ in range(0, k_tiles * tiles_per_SM):
-        ki = tl.where(ki == k_tiles - 1, 0, ki + 1)
-        if ki == 0:
-            tile_id += NUM_SMS
-            group_id = tile_id // num_pid_in_group
-            first_pid_m = group_id * GROUP_SIZE_M
-            group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
-            pid_m = first_pid_m + (tile_id % group_size_m)
-            pid_n = (tile_id % num_pid_in_group) // group_size_m
-
-            offs_am = pid_m * BLOCK_SIZE_M
-            offs_bn = pid_n * BLOCK_SIZE_N
-
-        offs_k = ki * BLOCK_SIZE_K
-
-        a = tl._experimental_descriptor_load(
-            a_desc_ptr, [offs_am, offs_k], [BLOCK_SIZE_M, BLOCK_SIZE_K], dtype
+    # Enable warp specialization to leverage async warp scheduling in the GPU.
+    # FIXME: This only works on Blackwell right now. On older GPUs, this will
+    # use software pipelining.
+    for tile_id in tl.range(
+        start_pid, num_tiles, NUM_SMS, flatten=True, warp_specialize=WARP_SPECIALIZE
+    ):
+        pid_m, pid_n = _compute_pid(
+            tile_id, num_pid_in_group, num_pid_m, GROUP_SIZE_M, NUM_SMS
         )
-        b = tl._experimental_descriptor_load(
-            b_desc_ptr, [offs_bn, offs_k], [BLOCK_SIZE_N, BLOCK_SIZE_K], dtype
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m, pid_n = _compute_pid(
+            tile_id_c, num_pid_in_group, num_pid_m, GROUP_SIZE_M, NUM_SMS
         )
-        accumulator = tl.dot(a, b.T, accumulator)
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
 
-        if ki == k_tiles - 1:
-            c = accumulator.to(dtype)
+        # Epilogue subtiling is a technique to break our computation and stores into multiple pieces
+        # By subtiling we can reduce shared memory consumption by the epilogue and instead use that
+        # memory to increase our stage count.
+        # In this case we partition the accumulator into 2 BLOCK_SIZE_M x BLOCK_SIZE_N // 2 tensors
+        if EPILOGUE_SUBTILE:
+            acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+            acc = tl.permute(acc, (0, 2, 1))
+            acc0, acc1 = tl.split(acc)
+            c0 = acc0.to(dtype)
+            c_desc.store([offs_am_c, offs_bn_c], c0)
+            c1 = acc1.to(dtype)
+            c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+        else:
+            accumulator = accumulator.to(dtype)
+            c_desc.store([offs_am_c, offs_bn_c], accumulator)
 
-            tl._experimental_descriptor_store(c_desc_ptr, c, [offs_am, offs_bn])
-            accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
 
-
-def matmul_tma_persistent(a, b):
-    # Autotuner does not work with TMA. Use manual config.
-    configs = {
-        torch.float8_e4m3fn: {
-            "BLOCK_SIZE_M": 128,
-            "BLOCK_SIZE_N": 256,
-            "BLOCK_SIZE_K": 128,
-            "GROUP_SIZE_M": 8,
-            "num_stages": 4,
-            "num_warps": 8,
-        },
-        torch.float16: {
-            "BLOCK_SIZE_M": 128,
-            "BLOCK_SIZE_N": 256,
-            "BLOCK_SIZE_K": 64,
-            "GROUP_SIZE_M": 8,
-            "num_stages": 3,
-            "num_warps": 8,
-        },
-        torch.bfloat16: {
-            "BLOCK_SIZE_M": 128,
-            "BLOCK_SIZE_N": 256,
-            "BLOCK_SIZE_K": 64,
-            "GROUP_SIZE_M": 8,
-            "num_stages": 3,
-            "num_warps": 8,
-        },
-    }
-
+def matmul_tma_persistent(a, b, warp_specialize: bool = False):
     # Check constraints.
     assert a.shape[1] == b.shape[1], "Incompatible dimensions"  # b is transposed
     assert a.dtype == b.dtype, "Incompatible dtypes"
@@ -358,53 +385,36 @@ def matmul_tma_persistent(a, b):
     dtype = a.dtype
 
     c = torch.empty((M, N), device=a.device, dtype=dtype)
-    desc_a = triton.tools.experimental_descriptor.create_2d_tma_descriptor(
-        a.data_ptr(),
-        M,
-        K,
-        configs[dtype]["BLOCK_SIZE_M"],
-        configs[dtype]["BLOCK_SIZE_K"],
-        a.element_size(),
-    )
-    desc_b = triton.tools.experimental_descriptor.create_2d_tma_descriptor(
-        b.data_ptr(),
-        N,
-        K,
-        configs[dtype]["BLOCK_SIZE_N"],
-        configs[dtype]["BLOCK_SIZE_K"],
-        b.element_size(),
-    )
-    desc_c = triton.tools.experimental_descriptor.create_2d_tma_descriptor(
-        c.data_ptr(),
-        M,
-        N,
-        configs[dtype]["BLOCK_SIZE_M"],
-        configs[dtype]["BLOCK_SIZE_N"],
-        c.element_size(),
-    )
+
     NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
 
-    grid = lambda META: (
-        min(
-            NUM_SMS,
-            triton.cdiv(M, META["BLOCK_SIZE_M"]) * triton.cdiv(N, META["BLOCK_SIZE_N"]),
-        ),
-    )
+    # A dummy block value that will be overwritten when we have the real block size
+    dummy_block = [1, 1]
+    a_desc = TensorDescriptor.from_tensor(a, dummy_block)
+    b_desc = TensorDescriptor.from_tensor(b, dummy_block)
+    c_desc = TensorDescriptor.from_tensor(c, dummy_block)
+
+    def grid(META):
+        nonlocal a_desc, b_desc, c_desc
+        BLOCK_M = META["BLOCK_SIZE_M"]
+        BLOCK_N = META["BLOCK_SIZE_N"]
+        return (
+            min(
+                NUM_SMS,
+                triton.cdiv(M, BLOCK_M) * triton.cdiv(N, BLOCK_N),
+            ),
+        )
+
     matmul_kernel_tma_persistent[grid](
-        desc_a,
-        desc_b,
-        desc_c,  #
+        a_desc,
+        b_desc,
+        c_desc,  #
         M,
         N,
         K,  #
-        BLOCK_SIZE_M=configs[dtype]["BLOCK_SIZE_M"],  #
-        BLOCK_SIZE_N=configs[dtype]["BLOCK_SIZE_N"],  #
-        BLOCK_SIZE_K=configs[dtype]["BLOCK_SIZE_K"],  #
-        GROUP_SIZE_M=configs[dtype]["GROUP_SIZE_M"],  #
         FP8_OUTPUT=dtype == torch.float8_e4m3fn,  #
         NUM_SMS=NUM_SMS,  #
-        num_stages=configs[dtype]["num_stages"],  #
-        num_warps=configs[dtype]["num_warps"],  #
+        WARP_SPECIALIZE=warp_specialize,  #
     )
     return c
 


### PR DESCRIPTION
Test Plan:

Before:

```
$ python run.py --op gemm --only triton_tma_persistent_matmul --force
          (M, N, K)    triton_tma_persistent_matmul-latency    triton_tma_persistent_matmul-speedup    triton_tma_persistent_matmul-tflops
-------------------  --------------------------------------  --------------------------------------  -------------------------------------
 (8192, 8192, 4096)                       0.825600 (±0.36%)                                                                        665.886
 (8192, 8192, 8192)                       1.632256 (±0.25%)                                                                        673.615
(8192, 8192, 16384)                       3.192960 (±0.13%)                                                                        688.71
            average                      1.8836053609848022                                                                        676.07
```

After:
```
$ python run.py --op gemm --only triton_tma_persistent_matmul
          (M, N, K)    triton_tma_persistent_matmul-latency    triton_tma_persistent_matmul-speedup    triton_tma_persistent_matmul-tflops
-------------------  --------------------------------------  --------------------------------------  -------------------------------------
 (8192, 8192, 4096)                       0.694144 (±9.88%)                                                                        791.991
 (8192, 8192, 8192)                       1.545184 (±0.99%)                                                                        711.573
(8192, 8192, 16384)                       2.930656 (±6.25%)                                                                        750.352
            average                      1.7233279943466187                                                                        751.305
```