### PR TITLE
[amd] Revert rocm to 7.0

### DIFF
--- a/tools/cuda_utils.py
+++ b/tools/cuda_utils.py
@@ -9,7 +9,7 @@ from .torch_utils import install_pytorch_nightly
 
 # defines the default CUDA version to compile against
 DEFAULT_CUDA_VERSION = "12.8"
-DEFAULT_HIP_VERSION = "7.1"
+DEFAULT_HIP_VERSION = "7.0"
 
 # the key is the value of `torch.version.cuda`
 CUDA_VERSION_MAP = {
@@ -25,8 +25,8 @@ CUDA_VERSION_MAP = {
 
 # the key is the value of `torch.version.hip`
 HIP_VERSION_MAP = {
-    "7.1": {
-        "pytorch_url": "rocm7.1",
+    "7.0": {
+        "pytorch_url": "rocm7.0",
     }
 }
 


### PR DESCRIPTION
Unfortunately, rocm 7.1 has many issues in our CI: https://github.com/meta-pytorch/tritonbench/actions/runs/22454074334/job/65030446172

Need to revert it to rocm 7.0, which will pin us to pytorch 20260206 nightly on AMD.

Test plan:

https://github.com/meta-pytorch/tritonbench/actions/runs/22458049144