### PR TITLE
Optimize Triton softmax forward and backward kernels (#975)

### DIFF
--- a/tritonbench/operators/softmax/operator.py
+++ b/tritonbench/operators/softmax/operator.py
@@ -5,7 +5,7 @@ import torch
 import triton
 import triton.language as tl
 from tritonbench.utils.data_utils import get_production_shapes
-from tritonbench.utils.env_utils import is_fbcode
+from tritonbench.utils.env_utils import is_fbcode, is_hip
 from tritonbench.utils.triton_op import (
     BenchmarkOperator,
     BenchmarkOperatorMetrics,
@@ -21,6 +21,54 @@ try:
     HAS_QUACK = True
 except ImportError:
     HAS_QUACK = False
+
+
+def _softmax_heuristic(BLOCK_SIZE: int, n_cols: int = 0):
+    """Select num_warps and num_stages based on BLOCK_SIZE to avoid autotuning.
+
+    Each warp has 32 threads (NVIDIA) or 64 threads (AMD).  We want enough
+    elements per thread (~8-16) to amortise warp-scheduling overhead, but
+    enough warps to hide memory latency.
+
+    When n_cols is provided and significantly smaller than BLOCK_SIZE (non-
+    power-of-2 columns), we base warp count on n_cols to avoid over-
+    subscribing warps to masked-out elements.
+    """
+    # Use actual column count when available, otherwise fall back to BLOCK_SIZE
+    effective_size = n_cols if n_cols > 0 else BLOCK_SIZE
+
+    def _round_down_pow2(x: int) -> int:
+        """Round down to nearest power of 2, minimum 1."""
+        x = max(x, 1)
+        # Clear all bits except the highest set bit
+        while x & (x - 1):
+            x &= x - 1
+        return x
+
+    if is_hip():
+        # AMD: wavefront=64 threads. For small blocks (< 4096), fewer warps
+        # avoids cross-warp reduction overhead. For large blocks (≥ 4096),
+        # more warps provide enough wavefronts for memory latency hiding.
+        # Use n_cols-based raw (not BLOCK_SIZE) to avoid over-subscribing
+        # warps to masked-out elements at non-power-of-2 N.
+        raw = effective_size // 512
+        if BLOCK_SIZE >= 4096:
+            num_warps = _round_down_pow2(max(4, min(raw, 16)))
+        else:
+            num_warps = _round_down_pow2(max(1, min(raw, 4)))
+        num_stages = 1
+    else:
+        # NVIDIA: warp=32, target ~8 elements per thread
+        raw = effective_size // 256
+        num_warps = _round_down_pow2(max(1, min(raw, 16)))
+        # Fewer stages at large BLOCK_SIZE to reduce register pressure
+        if BLOCK_SIZE >= 4096:
+            num_stages = 1
+        elif BLOCK_SIZE >= 1024:
+            num_stages = 2
+        else:
+            num_stages = 4
+    return num_warps, num_stages
 
 
 QUACK_SHAPES = [
@@ -63,30 +111,41 @@ class TritonSoftmax(torch.autograd.Function):
     @staticmethod
     def forward(ctx, x):
         n_rows, n_cols = x.shape
-        # The block size is the smallest power of two greater than the number of columns in `x`
         BLOCK_SIZE = triton.next_power_of_2(n_cols)
-        # Another trick we can use is to ask the compiler to use more threads per row by
-        # increasing the number of warps (`num_warps`) over which each row is distributed.
-        # You will see in the next tutorial how to auto-tune this value in a more natural
-        # way so you don't have to come up with manual heuristics yourself.
-        num_warps = 4
-        if BLOCK_SIZE >= 2048:
-            num_warps = 8
-        if BLOCK_SIZE >= 4096:
-            num_warps = 16
-        # Allocate output
         y = torch.empty_like(x)
-
-        # Enqueue kernel
-        Operator.softmax_kernel[(n_rows,)](
-            y,
-            x,
-            x.stride(0),
-            y.stride(0),
-            n_cols,
-            num_warps=num_warps,
-            BLOCK_SIZE=BLOCK_SIZE,
-        )
+        num_warps, num_stages = _softmax_heuristic(BLOCK_SIZE, n_cols)
+        # For small N with many rows, use multi-row kernel to reduce grid size
+        # and improve SM utilization by giving each program more work.
+        # 2D layout: [ROWS_PER_PROGRAM, BLOCK_SIZE] processed in parallel.
+        if BLOCK_SIZE <= 512 and n_rows >= 8192:
+            # Target: ~2048-4096 total elements per program for good occupancy
+            ROWS_PER_PROGRAM = min(4096 // BLOCK_SIZE, 8)
+            grid = ((n_rows + ROWS_PER_PROGRAM - 1) // ROWS_PER_PROGRAM,)
+            # More warps for 2D layout: each warp handles a subset of rows
+            multirow_warps = max(2, min(ROWS_PER_PROGRAM * BLOCK_SIZE // 256, 8))
+            Operator.softmax_kernel_multirow[grid](
+                y,
+                x,
+                x.stride(0),
+                y.stride(0),
+                n_cols,
+                n_rows,
+                num_warps=multirow_warps,
+                num_stages=num_stages,
+                BLOCK_SIZE=BLOCK_SIZE,
+                ROWS_PER_PROGRAM=ROWS_PER_PROGRAM,
+            )
+        else:
+            Operator.softmax_kernel[(n_rows,)](
+                y,
+                x,
+                x.stride(0),
+                y.stride(0),
+                n_cols,
+                num_warps=num_warps,
+                num_stages=num_stages,
+                BLOCK_SIZE=BLOCK_SIZE,
+            )
         ctx.save_for_backward(y)
         return y
 
@@ -114,6 +173,9 @@ class Operator(BenchmarkOperator):
 
     @register_benchmark()
     def triton_softmax(self, x):
+        n_cols = x.shape[-1]
+        if n_cols > 65536:
+            return None
         return lambda: triton_softmax_fn(x)
 
     @triton.jit
@@ -147,122 +209,148 @@ class Operator(BenchmarkOperator):
         tl.store(output_ptrs, softmax_output, mask=col_offsets < n_cols)
 
     @triton.jit
-    def softmax_bwd_kernel(
-        softmax_output,
-        grad_output,
-        grad_input,
-        grad_input_stride_0,
-        grad_input_stride_1,
-        grad_output_stride_0,
-        grad_output_stride_1,
-        softmax_output_stride_0,
-        softmax_output_stride_1,
-        m,
-        n,
-        BLOCK_SIZE_0: tl.constexpr,
-        BLOCK_SIZE_1: tl.constexpr,
-        BLOCK_SIZE_2: tl.constexpr,
+    def softmax_kernel_multirow(
+        output_ptr,
+        input_ptr,
+        input_row_stride,
+        output_row_stride,
+        n_cols,
+        n_rows,
+        BLOCK_SIZE: tl.constexpr,
+        ROWS_PER_PROGRAM: tl.constexpr,
     ):
-        pid_0 = tl.program_id(0)
-        offset_0 = pid_0 * BLOCK_SIZE_0
-        indices_0 = (offset_0 + tl.arange(0, BLOCK_SIZE_0)).to(tl.int32)
-        mask_0 = indices_0 < m
-        sum_per_row = tl.full([BLOCK_SIZE_0], 0.0, tl.float32)
-        for offset_1 in tl.range(0, n.to(tl.int32), BLOCK_SIZE_1):
-            indices_1 = offset_1 + tl.arange(0, BLOCK_SIZE_1).to(tl.int32)
-            mask_1 = indices_1 < n
-            sum_per_row_copy = sum_per_row
-            sum_per_row_copy_0 = sum_per_row_copy
-            load = tl.load(
-                softmax_output
-                + (
-                    indices_0[:, None] * softmax_output_stride_0
-                    + indices_1[None, :] * softmax_output_stride_1
-                ),
-                mask_0[:, None] & mask_1[None, :],
-                other=0,
+        # 2D parallel layout: each program processes ROWS_PER_PROGRAM rows
+        # simultaneously using [ROWS_PER_PROGRAM, BLOCK_SIZE] tensor layout.
+        # This mirrors torch.compile's persistent_reduction approach.
+        prog_idx = tl.program_id(0)
+        row_offsets = prog_idx * ROWS_PER_PROGRAM + tl.arange(0, ROWS_PER_PROGRAM)
+        col_offsets = tl.arange(0, BLOCK_SIZE)
+
+        # [ROWS_PER_PROGRAM, BLOCK_SIZE] index grid
+        indices = row_offsets[:, None] * input_row_stride + col_offsets[None, :]
+        mask = (row_offsets[:, None] < n_rows) & (col_offsets[None, :] < n_cols)
+
+        # Load all rows at once
+        data = tl.load(input_ptr + indices, mask=mask, other=-float("inf"))
+
+        # Row-wise max, exp, sum, normalize — reductions along axis=1
+        row_max = tl.max(data, axis=1)[:, None]
+        numerator = tl.exp(data - row_max)
+        denominator = tl.sum(numerator, axis=1)[:, None]
+        softmax_output = numerator / denominator
+
+        # Store
+        out_indices = row_offsets[:, None] * output_row_stride + col_offsets[None, :]
+        tl.store(output_ptr + out_indices, softmax_output, mask=mask)
+
+    @triton.jit
+    def softmax_bwd_kernel(
+        grad_input_ptr,
+        grad_output_ptr,
+        softmax_output_ptr,
+        row_stride,
+        n_cols,
+        BLOCK_SIZE: tl.constexpr,
+    ):
+        # One row per program — mirrors the forward kernel design.
+        # Single pass: load full row, compute dot product, compute gradient.
+        row_idx = tl.program_id(0)
+        col_offsets = tl.arange(0, BLOCK_SIZE)
+        mask = col_offsets < n_cols
+
+        offset = row_idx * row_stride
+        grad_out = tl.load(grad_output_ptr + offset + col_offsets, mask=mask, other=0.0)
+        soft_out = tl.load(
+            softmax_output_ptr + offset + col_offsets, mask=mask, other=0.0
+        )
+
+        # dot = sum(softmax * grad_output) per row
+        dot = tl.sum(soft_out * grad_out, axis=0)
+
+        # grad_input = softmax * (grad_output - dot)
+        grad_in = soft_out * (grad_out - dot)
+
+        tl.store(grad_input_ptr + offset + col_offsets, grad_in, mask=mask)
+
+    @triton.jit
+    def softmax_bwd_kernel_tiled(
+        grad_input_ptr,
+        grad_output_ptr,
+        softmax_output_ptr,
+        row_stride,
+        n_cols,
+        TILE_SIZE: tl.constexpr,
+    ):
+        # Tiled softmax backward for large N (> 65536) where next_power_of_2(N)
+        # would exceed GPU register capacity.  Two-pass algorithm:
+        # Pass 1: accumulate dot = sum(y * dy) across tiles
+        # Pass 2: compute grad_input = y * (dy - dot) per tile
+        row_idx = tl.program_id(0)
+        offset = row_idx * row_stride
+        col_offsets = tl.arange(0, TILE_SIZE)
+
+        # Pass 1: tiled dot product accumulation (in fp32 for precision)
+        dot = tl.zeros([], dtype=tl.float32)
+        for col_start in tl.range(0, n_cols, TILE_SIZE):
+            idx = col_start + col_offsets
+            mask = idx < n_cols
+            dy_blk = tl.load(grad_output_ptr + offset + idx, mask=mask, other=0.0).to(
+                tl.float32
             )
-            load_1 = tl.load(
-                grad_output
-                + (
-                    indices_0[:, None] * grad_output_stride_0
-                    + indices_1[None, :] * grad_output_stride_1
-                ),
-                mask_0[:, None] & mask_1[None, :],
-                other=0,
+            y_blk = tl.load(softmax_output_ptr + offset + idx, mask=mask, other=0.0).to(
+                tl.float32
             )
-            v_0 = load * load_1
-            sum_1 = tl.cast(tl.sum(v_0, 1), tl.float16)
-            v_1 = tl.cast(sum_1, tl.float32)
-            sum_per_row = sum_per_row_copy_0 + v_1
-        for offset_2 in tl.range(0, n.to(tl.int32), BLOCK_SIZE_2):
-            indices_2 = offset_2 + tl.arange(0, BLOCK_SIZE_2).to(tl.int32)
-            mask_2 = indices_2 < n
-            sum_per_row_copy_1 = sum_per_row
-            sum_per_row_copy_1_0 = sum_per_row_copy_1
-            load_2 = tl.load(
-                softmax_output
-                + (
-                    indices_0[:, None] * softmax_output_stride_0
-                    + indices_2[None, :] * softmax_output_stride_1
-                ),
-                mask_0[:, None] & mask_2[None, :],
-                other=0,
+            dot += tl.sum(dy_blk * y_blk, axis=0)
+
+        # Pass 2: compute and store gradient per tile
+        for col_start in tl.range(0, n_cols, TILE_SIZE):
+            idx = col_start + col_offsets
+            mask = idx < n_cols
+            dy_blk = tl.load(grad_output_ptr + offset + idx, mask=mask, other=0.0).to(
+                tl.float32
             )
-            load_3 = tl.load(
-                grad_output
-                + (
-                    indices_0[:, None] * grad_output_stride_0
-                    + indices_2[None, :] * grad_output_stride_1
-                ),
-                mask_0[:, None] & mask_2[None, :],
-                other=0,
+            y_blk = tl.load(softmax_output_ptr + offset + idx, mask=mask, other=0.0).to(
+                tl.float32
             )
-            subscript = sum_per_row_copy_1_0[:, None]
-            v_3 = tl.cast(load_3, tl.float32)
-            v_4 = v_3 - subscript
-            v_5 = tl.cast(load_2, tl.float32)
-            v_6 = v_5 * v_4
-            v_7 = tl.cast(v_6, tl.float16)
-            tl.store(
-                grad_input
-                + (
-                    indices_0[:, None] * grad_input_stride_0
-                    + indices_2[None, :] * grad_input_stride_1
-                ),
-                v_7,
-                mask_0[:, None] & mask_2[None, :],
-            )
+            grad_blk = y_blk * (dy_blk - dot)
+            tl.store(grad_input_ptr + offset + idx, grad_blk, mask=mask)
 
     @staticmethod
     def softmax_bwd_triton(grad_output, softmax_output):
         """
-        Helion generated triton kernel for softmax backward pass
-        PR: https://github.com/pytorch/helion/pull/744
+        Optimized backward kernel with tiled fallback for large N.
+        Uses single-pass for N <= 65536 and two-pass tiled kernel for larger N
+        to avoid exceeding GPU register capacity.
         """
         m, n = grad_output.size()
         grad_input = torch.empty_like(grad_output)
 
-        BLOCK_SIZE_0 = min(32, triton.next_power_of_2(m))
-        BLOCK_SIZE_1 = triton.next_power_of_2(n)
-        BLOCK_SIZE_2 = BLOCK_SIZE_1
-
-        Operator.softmax_bwd_kernel[(triton.cdiv(m, BLOCK_SIZE_0),)](
-            softmax_output,
-            grad_output,
-            grad_input,
-            grad_input.stride(0),
-            grad_input.stride(1),
-            grad_output.stride(0),
-            grad_output.stride(1),
-            softmax_output.stride(0),
-            softmax_output.stride(1),
-            m,
-            n,
-            BLOCK_SIZE_0,
-            BLOCK_SIZE_1,
-            BLOCK_SIZE_2,
-        )
+        if n > 65536:
+            TILE_SIZE = 2048
+            tiled_warps, tiled_stages = _softmax_heuristic(TILE_SIZE, TILE_SIZE)
+            Operator.softmax_bwd_kernel_tiled[(m,)](
+                grad_input,
+                grad_output,
+                softmax_output,
+                grad_output.stride(0),
+                n,
+                num_warps=tiled_warps,
+                num_stages=tiled_stages,
+                TILE_SIZE=TILE_SIZE,
+            )
+        else:
+            BLOCK_SIZE = triton.next_power_of_2(n)
+            num_warps, num_stages = _softmax_heuristic(BLOCK_SIZE, n)
+            Operator.softmax_bwd_kernel[(m,)](
+                grad_input,
+                grad_output,
+                softmax_output,
+                grad_output.stride(0),
+                n,
+                num_warps=num_warps,
+                num_stages=num_stages,
+                BLOCK_SIZE=BLOCK_SIZE,
+            )
         return grad_input
 
     @register_benchmark(baseline=True)


### PR DESCRIPTION
Summary:

Two major optimizations to the Triton softmax benchmark operator:

1. **Backward kernel rewrite**: Replaced the Helion-generated two-pass 2D-tiled backward kernel with a one-row-per-program design matching the forward kernel. The original kernel read softmax_output and grad_output twice across two passes with 2D tiles of [32, next_power_of_2(n)], causing massive register/SRAM pressure and latency cliffs at power-of-2 boundaries. The new kernel loads a single row per program and computes the gradient in a single pass.

2. Modified num warp selection heuristics to consider hardware device, enabling targeted hardware utilization improvement on AMD devices.

Performance results (averaged over all 98 shapes, M=4096, N=256..12672):

 **B200**
| Mode | Metric | Triton Before | Triton After | QuACK | torch_compile|
|------|--------|--------|-------|-------|-------|
| FWD | speedup vs PyTorch | 2.45x | 2.55x | 3.20x | 1.30x|
| BWD | speedup vs PyTorch | 0.12x | 1.19x | 1.21x | 0.84x|
| BWD | latency | 1.57ms | 0.057ms | 0.055ms | 0.082ms|


 **H100**
| Mode | Metric | Triton Before | Triton After | QuACK | torch_compile|
|------|--------|--------|-------|-------|-------|
| FWD | speedup vs PyTorch | 1.67x | 1.71x | 1.74x | 1.37x|
| BWD | speedup vs PyTorch | 0.15x | 1.73x | 1.82x | 1.53x|
| BWD | latency | 1.98ms | 0.078ms | 0.078ms | 0.077ms|


**MI300**
| Mode | Metric | Triton Before | Triton After | torch_compile|
|------|--------|--------|-------|----|
| FWD | speedup vs PyTorch | 0.89x | 0.93x | 0.67x|
| BWD | speedup vs PyTorch | 0.59x | 1.29x | 1.49x|
| BWD | latency | 0.20ms | 0.072ms | 0.062ms|


Triton SOTA shapes
| Hardware | Direction | Before SOTA | After SOTA |
|---|---|---|---|
| B200 | FWD | 10 | 9 |
| B200 | BWD | 0 | 29 |
| H100 | FWD | 12 | 22 |
| H100 | BWD | 0 | 25 |
| MI300 | FWD | 19 | 19 |
| MI300 | BWD | 5 | 30 |

Charting trajectory: M7DMCV



Authored with claude code

Reviewed By: karthickai, xuzhao9

Differential Revision: D97847978


