### PR TITLE
adding support for every-n-shape test sampling (#992)

### DIFF
--- a/tritonbench/utils/parser.py
+++ b/tritonbench/utils/parser.py
@@ -225,8 +225,9 @@ def get_parser(args=None):
     )
     parser.add_argument(
         "--num-inputs",
-        type=int,
-        help="Number of example inputs.",
+        type=str,
+        default=None,
+        help="Number of example inputs. Use /N to sample every Nth input (e.g., /2 for every other shape).",
     )
     parser.add_argument(
         "--keep-going",

--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -835,7 +835,16 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
             ]
         else:
             self._input_ids = [int(self.tb_args.input_id)]
-        self._num_inputs = self.tb_args.num_inputs
+        # Parse num_inputs: supports integer N or divisor /N (every Nth shape)
+        raw_num_inputs = self.tb_args.num_inputs
+        self._num_inputs_step = None
+        if raw_num_inputs is not None and raw_num_inputs.startswith("/"):
+            self._num_inputs_step = int(raw_num_inputs[1:])
+            self._num_inputs = None
+        elif raw_num_inputs is not None:
+            self._num_inputs = int(raw_num_inputs)
+        else:
+            self._num_inputs = None
         self._input_sample_mode = self.tb_args.input_sample_mode
         self.prod_shapes = self.tb_args.prod_shapes
         self.old_diode_topk = (
@@ -922,9 +931,14 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
             # Expand single ID to sequential range
             self._input_ids = list(range(start_id, start_id + self._num_inputs))
 
+            # Apply step-based sampling if /N was specified
+            if self._num_inputs_step:
+                self._input_ids = self._input_ids[:: self._num_inputs_step]
+                self._num_inputs = len(self._input_ids)
+
             logger.warning(
                 f"First-k mode: Selected {len(self._input_ids)} sequential inputs starting from index {start_id} "
-                f"(total available: {self._available_num_inputs})",
+                f"(step={self._num_inputs_step or 1}, total available: {self._available_num_inputs})",
             )
 
         logger.warning(


### PR DESCRIPTION
Summary:

Add /N divisor syntax to --num-inputs for step-based input sampling

Extend --num-inputs to accept a /N format (e.g., /2) that samples every Nth
input shape, enabling faster benchmark runs with representative coverage
across the full shape space without needing to know the total count upfront.

usage: buck2 run mode/opt //pytorch/tritonbench:run -- --op softmax --metrics latency,compile_time --num-inputs **/2**

this change helps us to test equally spaced shape without needing to know number of shapes

Differential Revision: D98962433


