### PR TITLE
Add attn_vis metrics and widgets (#999)

### DIFF
--- a/tritonbench/utils/run_utils.py
+++ b/tritonbench/utils/run_utils.py
@@ -614,7 +614,7 @@ def _run(args: argparse.Namespace, extra_args: List[str]) -> BenchmarkOperatorRe
 
             kwargs = {
                 "metrics": metrics,
-                "benchmark_name": args.op,
+                "benchmark_name": args.benchmark_name or args.op,
                 "device": args.device,
                 "logging_group": args.logging_group or args.op,
                 "precision": args.precision,


### PR DESCRIPTION
Summary:
X-link: https://github.com/mslsrc/mslk/pull/4


Rebuilding mast image and generate metrics:
```
bash run_blackwell_attn_tritonbench_mast.sh --mast --rebuild-fbpkg --attn-type sweep_pretraining
```
fbsource/fbcode/mslk/fb/scripts/bench/attention/mast_gb200_sweep_pretraining_attn_040126141546.log

Fetch result into CSV
```
bash format_blackwell_attn_tritonbench_mast.sh mast_gb200_sweep_pretraining_attn_033026223142.log
```
Generated CSV
```
fbsource/fbcode/mslk/fb/scripts/bench/attention/mast_gb200_sweep_pretraining_attn_040126141546.result
```

Reviewed By: sryap

Differential Revision: D98781902


