### PR TITLE
[be] replace requirements.txt with pip dep groups

### DIFF
--- a/.ci/upload/requirements.txt
+++ b/.ci/upload/requirements.txt
@@ -1,3 +1,0 @@
-boto3
-pyyaml
-requests

--- a/.github/workflows/_linux-benchmark.yml
+++ b/.github/workflows/_linux-benchmark.yml
@@ -114,7 +114,7 @@ jobs:
         run: |
           set -eux
           . "${SETUP_SCRIPT}"
-          uv pip install -r .ci/upload/requirements.txt
+          uv pip install --group ci
 
       - name: Compile Triton (Side A)
         run: |

--- a/.github/workflows/_linux-test-h100.yml
+++ b/.github/workflows/_linux-test-h100.yml
@@ -33,7 +33,7 @@ jobs:
           . "${SETUP_SCRIPT}"
           mkdir -p /workspace/tritonbench/.data
           ln -s /workspace/tritonbench/.data .
-          uv pip install -r requirements.txt
+          uv pip install --group dev-nvidia
       - name: Test Tritonbench operators on H100 GPU
         run: |
           bash ./.ci/tritonbench/test-gpu.sh

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ autotuner.log
 .install/
 .venvs/
 bisect_logs/
+.codex

--- a/docs/install.md
+++ b/docs/install.md
@@ -8,7 +8,7 @@ If you run `python install.py` without any argument, it will do the following:
 
 
 1. If PyTorch is missing, install the latest PyTorch nightly package.
-2. Install other dependencies from requirements.txt and requirements_numpy.txt.
+2. Install the `dev-nvidia` or `dev-amd` dependency group from `pyproject.toml`, depending on the platform.
 3. Checkout all submodules
 
 ## Advanced Usage

--- a/install.py
+++ b/install.py
@@ -12,7 +12,6 @@ from tools.python_utils import (
     get_pip_cmd,
     get_pkg_versions,
     has_pkg,
-    pip_install_requirements,
 )
 
 logging.basicConfig(level=logging.INFO)
@@ -132,14 +131,15 @@ if __name__ == "__main__":
         setup_hip(args)
 
     if args.numpy or not has_pkg("numpy"):
-        pip_install_requirements("requirements-numpy.txt", add_build_constraints=False)
+        subprocess.check_call(get_pip_cmd() + ["install", "--group", "dev-numpy"])
 
     # generate build constraints before installing anything
     deps = get_pkg_versions(TRITONBENCH_DEPS)
     generate_build_constraints(deps)
 
-    # install framework dependencies
-    pip_install_requirements("requirements.txt")
+    # install framework dependencies from pyproject.toml
+    dependency_group = "dev-amd" if is_hip() else "dev-nvidia"
+    subprocess.check_call(get_pip_cmd() + ["install", "--group", dependency_group])
     # checkout submodules
     checkout_submodules(REPO_PATH)
     # install submodules

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,32 @@ dependencies = [
     "packaging",
 ]
 
+[dependency-groups]
+dev-nvidia = [
+    "packaging",
+    "psutil",
+    "tabulate",
+    "matplotlib",
+    "nvidia-ml-py",
+    "transformers==5.0.0rc3",
+]
+dev-amd = [
+    "packaging",
+    "psutil",
+    "tabulate",
+    "matplotlib",
+]
+dev-cpu = [
+    "packaging",
+    "psutil",
+    "tabulate",
+    "matplotlib",
+]
+dev-numpy = [
+    "numpy==2.0.2; python_version < '3.11'",
+    "numpy==2.1.0; python_version >= '3.11'",
+]
+
 [tool.setuptools.packages.find]
 include = ["tritonbench*"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,11 @@ dev-numpy = [
     "numpy==2.0.2; python_version < '3.11'",
     "numpy==2.1.0; python_version >= '3.11'",
 ]
+ci = [
+    "boto3",
+    "pyyaml",
+    "requests",
+]
 
 [tool.setuptools.packages.find]
 include = ["tritonbench*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dev-amd = [
     "tabulate",
     "matplotlib",
     "pyyaml",
+    "transformers==5.0.0rc3",
 ]
 dev-cpu = [
     "packaging",
@@ -37,6 +38,7 @@ dev-cpu = [
     "tabulate",
     "matplotlib",
     "pyyaml",
+    "transformers==5.0.0rc3",
 ]
 dev-numpy = [
     "numpy==2.0.2; python_version < '3.11'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,9 @@ dev-cpu = [
     "transformers==5.0.0rc3",
 ]
 dev-numpy = [
-    "numpy==2.0.2; python_version < '3.11'",
-    "numpy==2.1.0; python_version >= '3.11'",
+    "numpy==2.0.2; python_version < '3.10'",
+    "numpy==2.1.0; python_version >= '3.10' and python_version < '3.14'",
+    "numpy==2.3.4; python_version >= '3.14'",
 ]
 ci = [
     "boto3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dev-nvidia = [
     "psutil",
     "tabulate",
     "matplotlib",
+    "pyyaml",
     "nvidia-ml-py",
     "transformers==5.0.0rc3",
 ]
@@ -28,12 +29,14 @@ dev-amd = [
     "psutil",
     "tabulate",
     "matplotlib",
+    "pyyaml",
 ]
 dev-cpu = [
     "packaging",
     "psutil",
     "tabulate",
     "matplotlib",
+    "pyyaml",
 ]
 dev-numpy = [
     "numpy==2.0.2; python_version < '3.11'",

--- a/requirements-numpy.txt
+++ b/requirements-numpy.txt
@@ -1,4 +1,0 @@
-# We need to pin numpy version to the same as the torch testing environment
-# Reference: https://github.com/pytorch/pytorch/blob/fcbde24c1cb54f3e0417e123bdb9ae09da134c8d/.ci/manywheel/build_common.sh#L103
-numpy==2.0.2; python_version < '3.11'
-numpy==2.1.0; python_version >= '3.11'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,0 @@
-packaging
-nvidia-ml-py
-psutil
-tabulate
-matplotlib
-transformers==5.0.0rc3

--- a/test/test_cpu/test_dependency_groups.py
+++ b/test/test_cpu/test_dependency_groups.py
@@ -42,7 +42,8 @@ class TestDependencyGroups(unittest.TestCase):
         self.assertEqual(
             set(self.groups["dev-numpy"]),
             {
-                "numpy==2.0.2; python_version < '3.11'",
-                "numpy==2.1.0; python_version >= '3.11'",
+                "numpy==2.0.2; python_version < '3.10'",
+                "numpy==2.1.0; python_version >= '3.10' and python_version < '3.14'",
+                "numpy==2.3.4; python_version >= '3.14'",
             },
         )

--- a/test/test_cpu/test_dependency_groups.py
+++ b/test/test_cpu/test_dependency_groups.py
@@ -1,0 +1,48 @@
+import tomllib
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PYPROJECT_PATH = REPO_ROOT / "pyproject.toml"
+
+
+class TestDependencyGroups(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        with PYPROJECT_PATH.open("rb") as f:
+            cls.groups = tomllib.load(f)["dependency-groups"]
+
+    def test_ci_group_matches_uploader_dependencies(self):
+        self.assertEqual(
+            set(self.groups["ci"]),
+            {"boto3", "pyyaml", "requests"},
+        )
+
+    def test_dev_nvidia_group_includes_runtime_yaml_dependency(self):
+        self.assertTrue(
+            {
+                "packaging",
+                "psutil",
+                "tabulate",
+                "matplotlib",
+                "pyyaml",
+                "nvidia-ml-py",
+                "transformers==5.0.0rc3",
+            }.issubset(set(self.groups["dev-nvidia"]))
+        )
+
+    def test_non_nvidia_groups_keep_runtime_import_dependencies(self):
+        for group_name in ("dev-amd", "dev-cpu"):
+            with self.subTest(group=group_name):
+                self.assertIn("pyyaml", self.groups[group_name])
+                self.assertIn("transformers==5.0.0rc3", self.groups[group_name])
+
+    def test_dev_numpy_group_keeps_expected_pins(self):
+        self.assertEqual(
+            set(self.groups["dev-numpy"]),
+            {
+                "numpy==2.0.2; python_version < '3.11'",
+                "numpy==2.1.0; python_version >= '3.11'",
+            },
+        )


### PR DESCRIPTION
As the title says.
It is clearer to manage deps in a unifed place `pyproject.toml`