### PR TITLE
Add identity-based fast path (Layer 1) for JIT kernel launch (#1005)

### DIFF
--- a/tritonbench/operators/launch_latency/kernels.py
+++ b/tritonbench/operators/launch_latency/kernels.py
@@ -33,6 +33,31 @@ def nop_with_args_kernel(
     pass
 
 
+@triton.jit
+def nop_with_kwargs_kernel(
+    t1,
+    t2,
+    t3,
+    t4,
+    t5,
+    i1,
+    i2,
+    i3,
+    i4,
+    i5,
+    i6,
+    i7,
+    i8,
+    i9,
+    BLOCK_C1: tl.constexpr = 32,
+    BLOCK_C2: tl.constexpr = 32,
+    BLOCK_C3: tl.constexpr = 32,
+    BLOCK_C4: tl.constexpr = 32,
+    BLOCK_C5: tl.constexpr = 32,
+):
+    pass
+
+
 def get_trivial_add_kernel():
     @torch.compile
     def trivial_add_kernel(*args):

--- a/tritonbench/operators/launch_latency/operator.py
+++ b/tritonbench/operators/launch_latency/operator.py
@@ -1,3 +1,6 @@
+import os
+import time
+
 import torch
 from torch import zeros
 from torch._inductor.utils import triton_version_uses_attrs_dict
@@ -18,6 +21,136 @@ with try_import("HAS_CUTEDSL"):
 from .kernels import get_trivial_add_kernel, nop_kernel, nop_with_args_kernel
 
 
+def _patch_triton_run_profiling():
+    """Monkey-patch JITFunction.run to profile launch overhead breakdown."""
+    from triton.runtime.jit import JITFunction
+
+    if hasattr(JITFunction, "_original_run"):
+        return  # already patched
+
+    original_run = JITFunction.run
+
+    def profiled_run(self_jit, *args, grid, warmup, **kwargs):
+        import time as _time
+
+        from triton.runtime.jit import compute_cache_key, driver, knobs
+
+        _t0 = _time.perf_counter()
+
+        kwargs["debug"] = kwargs.get("debug", self_jit.debug) or knobs.runtime.debug
+
+        _t1 = _time.perf_counter()
+        device = driver.active.get_current_device()
+        stream = driver.active.get_current_stream(device)
+        _t2 = _time.perf_counter()
+
+        for hook in self_jit.pre_run_hooks:
+            hook(*args, **kwargs)
+
+        _t3 = _time.perf_counter()
+        kernel_cache, kernel_key_cache, target, backend, binder = (
+            self_jit.device_caches[device]
+        )
+        bound_args, specialization, options = binder(*args, **kwargs)
+        _t4 = _time.perf_counter()
+
+        key = compute_cache_key(kernel_key_cache, specialization, options)
+        kernel = kernel_cache.get(key, None)
+        _t5 = _time.perf_counter()
+
+        if kernel is None:
+            # Fall back to original for compilation
+            JITFunction.run = original_run
+            result = original_run(self_jit, *args, grid=grid, warmup=warmup, **kwargs)
+            JITFunction.run = profiled_run
+            return result
+
+        not_present = object()
+        for (name, _), (val, globals_dict) in self_jit.used_global_vals.items():
+            if globals_dict.get(name, not_present) != val:
+                raise RuntimeError(f"Global variable {name} has changed")
+        _t6 = _time.perf_counter()
+
+        if not warmup:
+            assert grid is not None
+            if callable(grid):
+                grid = grid(bound_args)
+            grid_size = len(grid)
+            grid_0 = grid[0]
+            grid_1 = grid[1] if grid_size > 1 else 1
+            grid_2 = grid[2] if grid_size > 2 else 1
+            if hasattr(kernel, "result"):
+                kernel = kernel.result()
+
+            _t7 = _time.perf_counter()
+            launch_metadata = kernel.launch_metadata(grid, stream, *bound_args.values())
+            kernel.run(
+                grid_0,
+                grid_1,
+                grid_2,
+                stream,
+                kernel.function,
+                kernel.packed_metadata,
+                launch_metadata,
+                knobs.runtime.launch_enter_hook,
+                knobs.runtime.launch_exit_hook,
+                *bound_args.values(),
+            )
+            _t8 = _time.perf_counter()
+
+            _profiled_run_samples.append(
+                (
+                    (_t1 - _t0) * 1e6,  # preamble
+                    (_t2 - _t1) * 1e6,  # driver (device+stream)
+                    (_t3 - _t2) * 1e6,  # hooks
+                    (_t4 - _t3) * 1e6,  # binder
+                    (_t5 - _t4) * 1e6,  # cache_key+lookup
+                    (_t6 - _t5) * 1e6,  # global_check
+                    (_t7 - _t6) * 1e6,  # grid
+                    (_t8 - _t7) * 1e6,  # launch
+                    (_t8 - _t0) * 1e6,  # TOTAL
+                )
+            )
+
+        return kernel
+
+    JITFunction._original_run = original_run
+    JITFunction.run = profiled_run
+
+
+_profiled_run_samples = []
+
+
+def _print_profiling_summary():
+    if not _profiled_run_samples:
+        return
+    labels = [
+        "preamble",
+        "driver",
+        "hooks",
+        "binder",
+        "cache_key+lookup",
+        "global_check",
+        "grid",
+        "launch",
+        "TOTAL",
+    ]
+    n = len(_profiled_run_samples)
+    # skip first 10% as warmup
+    skip = max(1, n // 10)
+    samples = _profiled_run_samples[skip:]
+    if not samples:
+        samples = _profiled_run_samples
+    avgs = [sum(s[i] for s in samples) / len(samples) for i in range(len(labels))]
+    print(
+        "\n[triton-launch-profile] Average over %d samples (skipped %d warmup):"
+        % (len(samples), skip)
+    )
+    for label, avg in zip(labels, avgs):
+        print(f"  {label:20s}: {avg:8.2f} us")
+    print()
+
+
 class Operator(BenchmarkOperator):
     DEFAULT_METRICS = ["walltime"]
     FWD_ONLY = True
@@ -34,6 +167,21 @@ class Operator(BenchmarkOperator):
 
     @register_benchmark()
     def nop_triton_kernel(self, *args):
+        if os.environ.get("TRITON_LAUNCH_LATENCY_PROFILE", "0") == "1":
+            _patch_triton_run_profiling()
+            _profiled_run_samples.clear()
+            if len(args) == 0:
+                fn = lambda: nop_kernel[1,]()
+            else:
+                fn = lambda: nop_with_args_kernel[1,](*args)
+
+            def profiled_fn():
+                fn()
+
+            import atexit
+
+            atexit.register(_print_profiling_summary)
+            return profiled_fn
         if len(args) == 0:
             return lambda: nop_kernel[1,]()
         return lambda: nop_with_args_kernel[1,](*args)
@@ -111,6 +259,17 @@ class Operator(BenchmarkOperator):
 
     @register_benchmark(baseline=True)
     def nop_python_function(self, *args):
+        # Dump JITFunction.run source on first call for profiling investigation
+        if os.environ.get("TRITON_LAUNCH_LATENCY_PROFILE", "0") == "1":
+            import inspect
+
+            from triton.runtime.jit import JITFunction
+
+            print("\n=== JITFunction members ===")
+            print([m for m in dir(JITFunction) if not m.startswith("__")])
+            print("\n=== JITFunction.run source ===")
+            print(inspect.getsource(JITFunction.run))
+
         def nop():
             pass
 

--- a/tritonbench/operators/launch_latency/operator.py
+++ b/tritonbench/operators/launch_latency/operator.py
@@ -18,7 +18,12 @@ with try_import("HAS_CUTEDSL"):
 
     from .cutedsl import cutedsl_nop_kernel, cutedsl_nop_with_args_kernel
 
-from .kernels import get_trivial_add_kernel, nop_kernel, nop_with_args_kernel
+from .kernels import (
+    get_trivial_add_kernel,
+    nop_kernel,
+    nop_with_args_kernel,
+    nop_with_kwargs_kernel,
+)
 
 
 def _patch_triton_run_profiling():
@@ -185,6 +190,22 @@ class Operator(BenchmarkOperator):
         if len(args) == 0:
             return lambda: nop_kernel[1,]()
         return lambda: nop_with_args_kernel[1,](*args)
+
+    @register_benchmark()
+    def nop_triton_kernel_kwargs(self, *args):
+        """Same as nop_triton_kernel but passes constexpr params as kwargs."""
+        if len(args) == 0:
+            return lambda: nop_kernel[1,]()
+        pos_args = args[:14]
+        kw_vals = args[14:] if len(args) > 14 else (32, 32, 32, 32, 32)
+        return lambda: nop_with_kwargs_kernel[1,](
+            *pos_args,
+            BLOCK_C1=kw_vals[0],
+            BLOCK_C2=kw_vals[1],
+            BLOCK_C3=kw_vals[2],
+            BLOCK_C4=kw_vals[3],
+            BLOCK_C5=kw_vals[4],
+        )
 
     @register_benchmark()
     def nop_triton_compiled_kernel_run(self, *args):


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookexperimental/triton/pull/1231

Triton's JITFunction.run() dispatch adds ~12.5 µs of Python-side overhead per
kernel launch (19 args), even when the kernel is already compiled. This is
~3.6x slower than calling the compiled kernel directly (~3.4 µs).

This diff adds an identity-based fast path (Layer 1) to JITFunction.run()
that skips the binder (arg specialization), cache key computation, and most
of the dispatch overhead on repeat calls with identical args and kwargs.

After the first successful launch, we cache the previous call's args, kwargs,
and kernel. On the next call, we check if the exact same Python objects are
being passed (args[i] is last_args[i], plus kwargs identity check). This is
just N pointer comparisons with zero attribute access — the common case in
training loops where the same tensors and BLOCK_SIZE values are reused.

kwargs support: Kernel calls like kernel[grid](*args, BLOCK_SIZE=128) now
hit the fast path. User kwargs are saved before system kwargs injection
and compared by identity on repeat calls.

bound_args correctness: The fast path stores tuple(bound_args.values())
(which includes default parameter values) and uses it for grid resolution
and kernel launch, matching the slow path's behavior.

Results (19-arg nop kernel, GB200, mode/opt -m ovr_config//triton:beta):
  Positional args: 12.45 µs → 6.96 µs (44% faster)
  With kwargs:     12.45 µs → 7.78 µs (37% faster)

Authored with Claude.

Differential Revision: D100199238


