### PR TITLE
Add signature-based fast path (Layer 2) for JIT kernel launch (#1006)

### DIFF
--- a/tritonbench/operators/launch_latency/operator.py
+++ b/tritonbench/operators/launch_latency/operator.py
@@ -338,6 +338,25 @@ class Operator(BenchmarkOperator):
         )
 
     @register_benchmark()
+    def nop_triton_kernel_new_tensors(self, *args):
+        """Layer 1 misses (different tensor objects each call), Layer 2 should hit."""
+        if len(args) == 0:
+            return lambda: nop_kernel[1,]()
+        # Pre-allocate N sets of cloned tensors to avoid allocation in the hot loop.
+        N = 100
+        targs = args[:5]
+        rest_args = args[5:]
+        tensor_sets = [tuple(t.clone() for t in targs) for _ in range(N)]
+        idx = [0]
+
+        def fn():
+            i = idx[0] % N
+            idx[0] += 1
+            nop_with_args_kernel[1,](*tensor_sets[i], *rest_args)
+
+        return fn
+
+    @register_benchmark()
     def nop_triton_compiled_kernel_run(self, *args):
         if len(args) == 0:
             bin = nop_kernel[1,]()


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookexperimental/triton/pull/1243


When Layer 1 (identity check) misses — e.g., new tensors with the same
dtype/alignment after reallocation — this diff adds a signature-based dict
lookup (Layer 2) to still skip the binder and cache key computation.

Layer 2 computes a "fast key" — a minimal tuple capturing only what affects
specialization:
- constexpr args: value directly (determines compiled kernel)
- int args: value (determines type range i32/u64/i64, ==1 specialization,
  %16 alignment)
- float/bool/None: type marker only
- tensors: (dtype, data_ptr() % 16 == 0)
- TMA descriptors: 'tma'
- Unknown types: returns None (falls through to slow path)

This key is looked up in a _run_cache dict. On hit, we skip the binder and
cache key computation entirely. On miss, falls through to the slow path
which populates both Layer 1 and Layer 2 caches on success.

Results (19-arg nop kernel, GB200, mode/opt -m ovr_config//triton:beta):
  Baseline:  12.45 µs
  Layer 1:    7.91 µs  (36% faster)
  Layer 1+2:  7.04 µs  (43% faster, cumulative)

Authored with Claude.

Reviewed By: htyu

Differential Revision: D100199276


