### PR TITLE
Add B200 warp-specialized addmm benchmark (#1007)

### DIFF
--- a/tritonbench/operators/addmm/hstu.py
+++ b/tritonbench/operators/addmm/hstu.py
@@ -6,7 +6,10 @@ import triton
 from tritonbench.utils.path_utils import add_path, SUBMODULE_PATH
 
 with add_path(str(SUBMODULE_PATH.joinpath("generative-recommenders"))):
-    from generative_recommenders.ops.triton.triton_addmm import _AddMmFunction
+    from generative_recommenders.ops.triton.triton_addmm import (
+        _AddMmFunction,
+        triton_addmm_fwd_tma_persistent,
+    )
 
 
 @torch.fx.wrap
@@ -16,3 +19,12 @@ def triton_addmm(
     mat2: torch.Tensor,
 ) -> torch.Tensor:
     return _AddMmFunction.apply(mat1, mat2, input)
+
+
+@torch.fx.wrap
+def triton_addmm_fwd_b200_direct(
+    input: torch.Tensor,
+    mat1: torch.Tensor,
+    mat2: torch.Tensor,
+) -> torch.Tensor:
+    return triton_addmm_fwd_tma_persistent(mat1, mat2, input)

--- a/tritonbench/operators/addmm/operator.py
+++ b/tritonbench/operators/addmm/operator.py
@@ -6,7 +6,7 @@ from typing import Any, Callable, Generator, List, Optional, Tuple
 import torch
 import torch._inductor.config as inductor_config
 import triton
-from tritonbench.utils.env_utils import get_logger, is_fbcode
+from tritonbench.utils.env_utils import get_logger, IS_BLACKWELL, is_fbcode
 from tritonbench.utils.python_utils import try_import
 
 with try_import("HAS_HSTU"):
@@ -16,6 +16,8 @@ with try_import("HAS_HSTU"):
         )
     except ModuleNotFoundError:
         from .hstu import triton_addmm as hstu_triton_addmm
+
+    from .hstu import triton_addmm_fwd_b200_direct
 
 with try_import("HAS_STREAMK"):
     from tritonbench.operators.gemm.stream_k import streamk_cuda_matmul
@@ -34,7 +36,6 @@ if is_fbcode():
     from tritonbench.utils.fb.addmm_prod import get_prod_shapes
 else:
     get_prod_shapes = lambda x: None
-
 
 # Shape encoding information: (M, K, N, BIAS_1D_Y)
 BUILDIN_SHAPES = [
@@ -135,6 +136,10 @@ class Operator(BenchmarkOperator):
     @register_benchmark(enabled=HAS_HSTU)  # type: ignore # noqa: F821
     def triton_addmm(self, a, mat1, mat2) -> Callable:
         return lambda: hstu_triton_addmm(a, mat1, mat2)
+
+    @register_benchmark(enabled=HAS_HSTU and IS_BLACKWELL)  # type: ignore # noqa: F821
+    def triton_b200_ws(self, a, mat1, mat2) -> Callable:
+        return lambda: triton_addmm_fwd_b200_direct(a, mat1, mat2)
 
     # FIXME: bwd has some problem, need to re-enable it
     @register_benchmark(enabled=False)


### PR DESCRIPTION
Summary:
Adds direct access to the Triton internal benchmark for testing. Used to compare TLX to Triton.


Reviewed By: xuzhao9

Differential Revision: D100380015

Pulled By: njriasan


