### PR TITLE
Security: Unsafe eval() when parsing input loader data (FP8 GEMM)

### DIFF
--- a/tritonbench/operators/fp8_gemm/input_loader.py
+++ b/tritonbench/operators/fp8_gemm/input_loader.py
@@ -15,6 +15,7 @@ Expected op_inputs format:
 }
 """
 
+from ast import literal_eval
 from typing import Any, Callable
 
 from tritonbench.operator_loader.aten.input_loader import OperatorInputLoader
@@ -28,7 +29,7 @@ class InputLoader(OperatorInputLoader):
     def get_input_iter(
         self,
     ) -> Callable:
-        shapes = [eval(inp)[1] for inp, _cnt in self.operator_db[self.op_name].items()]
+        shapes = [literal_eval(inp)[1] for inp, _cnt in self.operator_db[self.op_name].items()]
         all_shapes = []
         for entry in shapes:
             M = int(entry["M"])


### PR DESCRIPTION
## Summary

Security: Unsafe eval() when parsing input loader data (FP8 GEMM)

## Problem

**Severity**: `High` | **File**: `tritonbench/operators/fp8_gemm/input_loader.py:L29`

Input parsing uses `eval(inp)` on serialized shape data. Malicious content in input DB/config can execute arbitrary code during benchmark setup.

## Solution

Use `ast.literal_eval()` for literal structures or switch to JSON parsing with schema validation.

## Changes

- `tritonbench/operators/fp8_gemm/input_loader.py` (modified)