### PR TITLE
Remove tlx_blackwell_ws_pipelined_fwd benchmark from TritonBench

### DIFF
--- a/tritonbench/metadata/oss_cuda_kernels.yaml
+++ b/tritonbench/metadata/oss_cuda_kernels.yaml
@@ -68,9 +68,6 @@ blackwell_attentions:
   sdpa:
     tags:
     - pt2
-  tlx_blackwell_ws_pipelined_fwd:
-    tags:
-    - tlx
   tlx_blackwell_ws_pipelined_persistent_fwd:
     tags:
     - tlx

--- a/tritonbench/operators/blackwell_attentions/operator.py
+++ b/tritonbench/operators/blackwell_attentions/operator.py
@@ -683,24 +683,6 @@ class Operator(BenchmarkOperator):
 
         return preproc_noop, fn
 
-    # Only works with triton beta, forward only.
-    @register_benchmark(enabled=HAS_TLX)
-    @multi_input_wrapper
-    def tlx_blackwell_ws_pipelined_fwd(self, *args) -> Tuple[Callable, Callable]:
-        if self.D_HEAD < 128:
-            raise NotImplementedError("TLX only supports d_head >= 128")
-
-        def fn(q, k, v):
-            return tlx_blackwell(
-                q,
-                k,
-                v,
-                self.sm_scale,
-                self.causal,
-            )
-
-        return preproc_noop, fn
-
     # Only works with triton beta.
     @register_benchmark(enabled=HAS_TLX)
     @multi_input_wrapper


### PR DESCRIPTION
Summary: The non-persistent fwd-only TLX benchmark is redundant now that the persistent variant (tlx_blackwell_ws_pipelined_persistent) supports both fwd and bwd. Remove the benchmark method, metadata entries, and documentation references.

Differential Revision: D100629607


