### PR TITLE
Add triton_tutorial_FA2 benchmark to blackwell_attentions

### DIFF
--- a/tritonbench/operators/blackwell_attentions/operator.py
+++ b/tritonbench/operators/blackwell_attentions/operator.py
@@ -816,9 +816,9 @@ class Operator(BenchmarkOperator):
         atol = self.tb_args.atol if self.tb_args.atol is not None else 1e-2
         prefix = f"{mode}: " if mode else ""
 
-        assert len(grads) == len(
-            baseline_grads
-        ), f"{prefix}Mismatch in number of grad tensors"
+        assert len(grads) == len(baseline_grads), (
+            f"{prefix}Mismatch in number of grad tensors"
+        )
 
         has_gradient = False
         for i, (grad, baseline_grad) in enumerate(zip(grads, baseline_grads)):

--- a/tritonbench/operators/blackwell_attentions/operator.py
+++ b/tritonbench/operators/blackwell_attentions/operator.py
@@ -35,6 +35,24 @@ from tritonbench.kernels.triton_fused_attention import (
     attention_opt as triton_tutorial_FA2_opt,
 )
 
+try:
+    import importlib.util
+    import triton as _triton
+    _triton_tutorial_path = os.path.join(
+        os.path.dirname(os.path.dirname(_triton.__file__)),
+        "tutorials",
+        "06-fused-attention.py",
+    )
+    _spec = importlib.util.spec_from_file_location(
+        "triton_tutorial_fused_attention", _triton_tutorial_path
+    )
+    _mod = importlib.util.module_from_spec(_spec)
+    _spec.loader.exec_module(_mod)
+    triton_tutorial_FA2 = _mod.attention
+    HAS_TRITON_TUTORIAL_FA2 = True
+except Exception:
+    HAS_TRITON_TUTORIAL_FA2 = False
+
 if SUPPORT_GLUON:
     from tritonbench.kernels.gluon_attention_forward import (
         attention_forward as gluon_blackwell_fwd,
@@ -669,6 +687,21 @@ class Operator(BenchmarkOperator):
                 self.causal,
                 self.sm_scale,
                 "ws_persistent",
+            )
+
+        return preproc_noop, fn
+
+    @register_benchmark(enabled=HAS_TRITON_TUTORIAL_FA2)
+    @multi_input_wrapper
+    def triton_tutorial_FA2(self, *args) -> Tuple[Callable, Callable]:
+        _triton_tutorial_fa2 = triton_tutorial_FA2
+        def fn(q, k, v):
+            return _triton_tutorial_fa2(
+                q.to(torch.float16),
+                k.to(torch.float16),
+                v.to(torch.float16),
+                self.causal,
+                self.sm_scale,
             )
 
         return preproc_noop, fn

--- a/tritonbench/operators/blackwell_attentions/operator.py
+++ b/tritonbench/operators/blackwell_attentions/operator.py
@@ -37,7 +37,9 @@ from tritonbench.kernels.triton_fused_attention import (
 
 try:
     import importlib.util
+
     import triton as _triton
+
     _triton_tutorial_path = os.path.join(
         os.path.dirname(os.path.dirname(_triton.__file__)),
         "tutorials",
@@ -695,6 +697,7 @@ class Operator(BenchmarkOperator):
     @multi_input_wrapper
     def triton_tutorial_FA2(self, *args) -> Tuple[Callable, Callable]:
         _triton_tutorial_fa2 = triton_tutorial_FA2
+
         def fn(q, k, v):
             return _triton_tutorial_fa2(
                 q.to(torch.float16),
@@ -813,9 +816,9 @@ class Operator(BenchmarkOperator):
         atol = self.tb_args.atol if self.tb_args.atol is not None else 1e-2
         prefix = f"{mode}: " if mode else ""
 
-        assert len(grads) == len(baseline_grads), (
-            f"{prefix}Mismatch in number of grad tensors"
-        )
+        assert len(grads) == len(
+            baseline_grads
+        ), f"{prefix}Mismatch in number of grad tensors"
 
         has_gradient = False
         for i, (grad, baseline_grad) in enumerate(zip(grads, baseline_grads)):


### PR DESCRIPTION
Load the stock Triton fused attention tutorial (06-fused-attention.py) via importlib and register it as a benchmark. Inputs are cast to fp16 to match the tutorial kernel's expected dtype.



python run.py --op blackwell_attentions  --rep 3000 --sleep 1.0 --metrics accuracy,tflops  --simple-output --only triton_tutorial_FA2 --input-id 3 

 ```
 (Batch, Heads, Heads_KV, SeqLen, SeqLen_KV, Dhead)    sdpa-tflops    triton_tutorial_FA2-accuracy    triton_tutorial_FA2-tflops
----------------------------------------------------  -------------  ------------------------------  ----------------------------
                    (4, 48, 48, 1024, 1024, 128) fwd        330.145                               0                       266.989
                    (4, 48, 48, 2048, 2048, 128) fwd        355.122                               0                       427.985
                    (4, 48, 48, 4096, 4096, 128) fwd        364.96                                0                       566.918
                    (4, 48, 48, 8192, 8192, 128) fwd        369.809                               0                       670.672
                  (4, 48, 48, 16384, 16384, 128) fwd        374.548                               0                       746.301

```
python run.py --op blackwell_attentions  --rep 3000 --sleep 1.0 --metrics accuracy,tflops  --simple-output --only triton_tutorial_FA2 --input-id 3 --mode bwd

 ```
 (Batch, Heads, Heads_KV, SeqLen, SeqLen_KV, Dhead)    sdpa-tflops    triton_tutorial_FA2-accuracy    triton_tutorial_FA2-tflops
----------------------------------------------------  -------------  ------------------------------  ----------------------------
                    (4, 48, 48, 1024, 1024, 128) bwd        252.155                               1                       257.541
                    (4, 48, 48, 2048, 2048, 128) bwd        303.211                               1                       338.016
                    (4, 48, 48, 4096, 4096, 128) bwd        326.803                               1                       384.322
                    (4, 48, 48, 8192, 8192, 128) bwd        338.72                                1                       412.609
                  (4, 48, 48, 16384, 16384, 128) bwd        347.304                               1                       425.289
```