### PR TITLE
Warm up autotuning before NCU profiled region

### DIFF
--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -2150,6 +2150,10 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
                     fn=fn,
                     grad_to_none=self.get_grad_to_none(self.example_inputs),
                     range_name=_RANGE_NAME,
+                    # test_run=True calls fn() once before the NVTX range so
+                    # that @triton.autotune completes outside the profiled
+                    # region. NCU then only captures the winning config.
+                    test_run=True,
                 )
                 metrics.extra_metrics["single_run_in_task"] = "success"
             if self.tb_args.export:


### PR DESCRIPTION
Summary:
Pass test_run=True to do_bench_in_task so that fn() is called once before the NVTX range opens. This ensures triton.autotune completes (benchmarking all configs and selecting the winner) outside the profiled region. When NCU runs with --nvtx-include tritonbench_range, it only captures the single winning kernel launch instead of replaying every autotuning config with full counters.

Previously, the first fn() call inside the NVTX range triggered autotuning, causing NCU to capture and replay 100+ kernel launches, producing multi-GB reports and taking 45+ minutes for large persistent kernels.

Reviewed By: xuzhao9

Differential Revision: D100840679


