### PR TITLE
Profile inductor launch overhead and clean up nop_inductor_kernel (#1016)

### DIFF
--- a/tritonbench/operators/launch_latency/kernels.py
+++ b/tritonbench/operators/launch_latency/kernels.py
@@ -58,9 +58,102 @@ def nop_with_kwargs_kernel(
     pass
 
 
-def get_trivial_add_kernel():
-    @torch.compile
-    def trivial_add_kernel(*args):
-        return sum([torch.tensor(1.0, device="cuda"), *args])
+def get_inductor_nop_kernel_0arg():
+    """Minimal torch.compile'd function — 0 external args.
 
-    return trivial_add_kernel
+    Internally operates on a pre-allocated tensor to force exactly one kernel
+    launch, but the caller invokes it with no arguments.
+    """
+    x = torch.zeros(1, device="cuda")
+
+    @torch.compile
+    def _nop_impl(x):
+        x.add_(0)
+
+    def nop_0arg():
+        _nop_impl(x)
+
+    return nop_0arg
+
+
+def get_inductor_nop_kernel_19arg():
+    """Minimal torch.compile'd function with 19 args matching the triton nop_with_args_kernel signature.
+
+    Uses a fixed signature (not *args) so torch.compile doesn't need to handle
+    variable-length args, and the compiled graph is stable.
+    """
+
+    @torch.compile
+    def nop_19arg(
+        t1, t2, t3, t4, t5, i1, i2, i3, i4, i5, i6, i7, i8, i9, c1, c2, c3, c4, c5
+    ):
+        t1.add_(0)
+
+    return nop_19arg
+
+
+def get_inductor_nop_multi_kernel(n_kernels=100):
+    """Simulate a compiled graph with n_kernels separate triton kernel launches.
+
+    Compiles a single nop kernel via torch.compile, extracts the CachingAutotuner
+    instance from the generated code, then calls kernel.run() N times in a loop.
+
+    This directly measures N × CachingAutotuner.run() (per-kernel overhead)
+    without fighting inductor's fusion optimizer.
+    """
+    import glob
+    import importlib.util
+    import os
+
+    from torch._C import _cuda_getCurrentRawStream as get_raw_stream
+    from torch._inductor.runtime.triton_heuristics import CachingAutotuner
+
+    x = torch.zeros(1, device="cuda")
+
+    @torch.compile
+    def _nop(t):
+        t.add_(0)
+
+    _nop(x)
+
+    # Find the generated inductor code in the cache
+    cache_dir = os.path.join(
+        os.environ.get(
+            "TORCHINDUCTOR_CACHE_DIR", f"/var/tmp/torchinductor_{os.environ['USER']}"
+        ),
+    )
+    py_files = glob.glob(os.path.join(cache_dir, "**", "*.py"), recursive=True)
+    candidates = []
+    for f in py_files:
+        try:
+            with open(f) as fh:
+                content = fh.read()
+                if "fused_add_copy" in content and "def call(args)" in content:
+                    candidates.append((os.path.getmtime(f), f))
+        except (OSError, UnicodeDecodeError):
+            pass
+    if not candidates:
+        raise RuntimeError("Could not find generated inductor code in cache")
+    candidates.sort(reverse=True)
+
+    spec = importlib.util.spec_from_file_location("generated_multi", candidates[0][1])
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    # Find the CachingAutotuner kernel instance
+    kernel = None
+    for name in dir(mod):
+        attr = getattr(mod, name, None)
+        if isinstance(attr, CachingAutotuner):
+            kernel = attr
+            break
+    if kernel is None:
+        raise RuntimeError("Could not find CachingAutotuner in generated module")
+
+    stream = get_raw_stream(0)
+
+    def run():
+        for _ in range(n_kernels):
+            kernel.run(x, x, 1, stream=stream)
+
+    return run

--- a/tritonbench/operators/launch_latency/operator.py
+++ b/tritonbench/operators/launch_latency/operator.py
@@ -1,5 +1,4 @@
 import os
-import time
 
 import torch
 from torch import zeros
@@ -20,7 +19,9 @@ with try_import("HAS_CUTEDSL"):
     from .cutedsl import cutedsl_nop_kernel, cutedsl_nop_with_args_kernel
 
 from .kernels import (
-    get_trivial_add_kernel,
+    get_inductor_nop_kernel_0arg,
+    get_inductor_nop_kernel_19arg,
+    get_inductor_nop_multi_kernel,
     nop_kernel,
     nop_with_args_kernel,
     nop_with_kwargs_kernel,
@@ -452,8 +453,33 @@ class Operator(BenchmarkOperator):
 
     @register_benchmark()
     def nop_inductor_kernel(self, *args):
-        trivial_add_kernel = get_trivial_add_kernel()
-        return lambda: trivial_add_kernel(*args)
+        """Inductor nop kernel via torch.compile.
+
+        Uses a proper nop kernel (t1.add_(0)) with the same arg count as the
+        triton benchmarks, for a fair apples-to-apples comparison.
+        """
+        if len(args) == 0:
+            nop_fn = get_inductor_nop_kernel_0arg()
+            nop_fn()
+            return nop_fn
+        nop_fn = get_inductor_nop_kernel_19arg()
+        nop_fn(*args)
+        return lambda: nop_fn(*args)
+
+    @register_benchmark()
+    def nop_inductor_per_kernel(self, *args):
+        """Pure per-kernel overhead: CachingAutotuner.run() only.
+
+        Extracts the CachingAutotuner from a compiled inductor nop kernel and
+        calls kernel.run() directly — bypassing guard check, DeviceGuard, and
+        assert_size_stride. This measures what each kernel costs in a multi-kernel
+        compiled graph where per-graph overhead is amortized.
+
+        Compare with nop_inductor_kernel (full e2e including guard) to see
+        how much overhead is per-graph vs per-kernel.
+        """
+        nop_fn = get_inductor_nop_multi_kernel(n_kernels=1)
+        return nop_fn
 
     @register_benchmark(enabled=HAS_TILELANG)
     def nop_tilelang(self, *args):


### PR DESCRIPTION
Summary:

This diff adds a standalone benchmark and analysis doc for profiling the inductor
kernel launch overhead, and cleans up the `nop_inductor_kernel` benchmark in
tritonbench.

**Motivation**: Inductor's torch.compile'd kernel launch takes ~33µs e2e vs ~1.3µs for
a raw cuLaunchKernel. We want to understand where the ~32µs overhead comes from and
identify optimization targets.

**benchmark.py** (`scripts/tissue030/benchmark_inductor_launcher/`):
- Compiles a nop kernel via torch.compile, loads the generated wrapper code
- Benchmarks each individual line in the inductor-generated `call()` function:
  args unpack, assert_size_stride, DeviceGuard, get_raw_stream, kernel.run
- Breaks down CachingAutotuner.run() internals: set_allocator, TritonBundler,
  debug_mode, launcher, CompiledKernel.run, cuLaunchKernel
- Tests stripped variants (no assert, no DeviceGuard, minimal) for cross-validation

**inductor_launch_overhead.md**: Documents the full dispatch stack from cuLaunchKernel
(~1.3µs) → CompiledKernel.run (~4µs) → launcher (~4.5µs) → CachingAutotuner (~6.5µs)
→ call() wrapper (~9µs) → CompiledFxGraph (~12µs) → e2e with guard (~33µs).
Identifies per-kernel vs per-graph overhead and proposes optimization targets:
- P0: CachingAutotuner preamble (~2µs/kernel × N) — set_allocator, TritonBundler, debug_mode
- P0: Triton Python binder (~2.7µs/kernel × N)
- P1: assert_size_stride (~0.45µs/tensor, redundant with guard)

**operator.py cleanup**:
- Replace `nop_inductor_kernel` with proper nop kernel (`t1.add_(0)`) using
  fixed-signature functions (0-arg and 19-arg) matching triton benchmark arg counts
  for fair apples-to-apples comparison
- Remove `get_trivial_add_kernel` (old `*args` version) from kernels.py
- Remove unused `import time`

Differential Revision: D100873705


