### PR TITLE
Profile inductor launch overhead and add per-kernel benchmark (#1017)

### DIFF
--- a/tritonbench/operators/launch_latency/kernels.py
+++ b/tritonbench/operators/launch_latency/kernels.py
@@ -58,9 +58,97 @@ def nop_with_kwargs_kernel(
     pass
 
 
-def get_trivial_add_kernel():
-    @torch.compile
-    def trivial_add_kernel(*args):
-        return sum([torch.tensor(1.0, device="cuda"), *args])
+def get_inductor_nop_kernel_0arg():
+    """Minimal torch.compile'd function — 0 external args.
 
-    return trivial_add_kernel
+    Internally operates on a pre-allocated tensor to force exactly one kernel
+    launch, but the caller invokes it with no arguments.
+    """
+    x = torch.zeros(1, device="cuda")
+
+    @torch.compile
+    def _nop_impl(x):
+        x.add_(0)
+
+    def nop_0arg():
+        _nop_impl(x)
+
+    return nop_0arg
+
+
+def get_inductor_nop_kernel_19arg():
+    """Minimal torch.compile'd function with 19 args matching the triton nop_with_args_kernel signature.
+
+    Uses a fixed signature (not *args) so torch.compile doesn't need to handle
+    variable-length args, and the compiled graph is stable.
+    """
+
+    @torch.compile
+    def nop_19arg(
+        t1, t2, t3, t4, t5, i1, i2, i3, i4, i5, i6, i7, i8, i9, c1, c2, c3, c4, c5
+    ):
+        t1.add_(0)
+
+    return nop_19arg
+
+
+def get_inductor_nop_kernel(tensor_args=None):
+    """Extract a single CachingAutotuner.run() call from a compiled nop kernel.
+
+    Compiles a nop kernel via torch.compile, intercepts CachingAutotuner.run()
+    to capture the kernel instance and exact args, then returns a callable that
+    replays kernel.run() once.
+
+    This directly measures CachingAutotuner.run() (per-kernel overhead) without
+    guard check, DeviceGuard, or assert_size_stride — i.e. the cost each kernel
+    pays inside a multi-kernel compiled graph.
+
+    When tensor_args has ≥2 tensors, compiles a multi-tensor element-wise sum
+    so the CachingAutotuner.run() call receives more positional args, allowing
+    measurement of per-kernel overhead scaling with arg count.
+    """
+    from torch._inductor.runtime.triton_heuristics import CachingAutotuner
+
+    targs = (
+        [a for a in tensor_args if isinstance(a, torch.Tensor)] if tensor_args else []
+    )
+
+    # Monkey-patch CachingAutotuner.run at the class level to capture the
+    # kernel instance + exact call args during the first compiled execution.
+    captured = []
+    original_run = CachingAutotuner.run
+
+    def capturing_run(self, *args, **kwargs):
+        result = original_run(self, *args, **kwargs)
+        captured.append((self, args, kwargs))
+        return result
+
+    CachingAutotuner.run = capturing_run
+    try:
+        if len(targs) < 2:
+            x = torch.zeros(1, device="cuda")
+
+            @torch.compile
+            def _nop(t):
+                t.add_(0)
+
+            _nop(x)
+        else:
+
+            @torch.compile
+            def _nop_multi(t1, t2, t3, t4, t5):
+                return t1 + t2 + t3 + t4 + t5
+
+            _nop_multi(*targs[:5])
+    finally:
+        CachingAutotuner.run = original_run
+
+    if not captured:
+        raise RuntimeError("No CachingAutotuner.run() calls captured")
+
+    kernel, run_args, run_kwargs = captured[-1]
+
+    def run():
+        kernel.run(*run_args, **run_kwargs)
+
+    return run

--- a/tritonbench/operators/launch_latency/operator.py
+++ b/tritonbench/operators/launch_latency/operator.py
@@ -1,5 +1,4 @@
 import os
-import time
 
 import torch
 from torch import zeros
@@ -20,7 +19,9 @@ with try_import("HAS_CUTEDSL"):
     from .cutedsl import cutedsl_nop_kernel, cutedsl_nop_with_args_kernel
 
 from .kernels import (
-    get_trivial_add_kernel,
+    get_inductor_nop_kernel,
+    get_inductor_nop_kernel_0arg,
+    get_inductor_nop_kernel_19arg,
     nop_kernel,
     nop_with_args_kernel,
     nop_with_kwargs_kernel,
@@ -451,9 +452,41 @@ class Operator(BenchmarkOperator):
         return _prepare_direct_culaunch(bin, args)
 
     @register_benchmark()
-    def nop_inductor_kernel(self, *args):
-        trivial_add_kernel = get_trivial_add_kernel()
-        return lambda: trivial_add_kernel(*args)
+    def nop_inductor_e2e(self, *args):
+        """End-to-end inductor launch via torch.compile.
+
+        Measures the full compiled-function call path: guard check,
+        DeviceGuard, assert_size_stride, CachingAutotuner dispatch, and
+        the kernel launch itself.  Compare with nop_inductor_per_kernel
+        (CachingAutotuner.run() only) to isolate per-graph overhead.
+        """
+        if len(args) == 0:
+            nop_fn = get_inductor_nop_kernel_0arg()
+            nop_fn()  # Warm up
+            return nop_fn
+        nop_fn = get_inductor_nop_kernel_19arg()
+        nop_fn(*args)  # Warm up
+        return lambda: nop_fn(*args)
+
+    @register_benchmark()
+    def nop_inductor_per_kernel(self, *args):
+        """Pure per-kernel overhead: a single CachingAutotuner.run() call.
+
+        Extracts the CachingAutotuner from a compiled inductor nop kernel and
+        calls kernel.run() directly — bypassing guard check, DeviceGuard, and
+        assert_size_stride. This measures what each kernel costs in a multi-kernel
+        compiled graph where per-graph overhead is amortized.
+
+        For x_val=0 (no args): compiles a minimal 1-tensor kernel (~3 kernel args).
+        For x_val=19 (5 tensors + scalars): compiles a 5-tensor sum kernel
+        (~7 kernel args) to measure arg-scaling overhead.
+
+        Compare with nop_inductor_e2e (full e2e including guard) to see
+        how much overhead is per-graph vs per-kernel.
+        """
+        tensor_args = [a for a in args if isinstance(a, torch.Tensor)] or None
+        nop_fn = get_inductor_nop_kernel(tensor_args=tensor_args)
+        return nop_fn
 
     @register_benchmark(enabled=HAS_TILELANG)
     def nop_tilelang(self, *args):


### PR DESCRIPTION
Summary:

This diff adds profiling infrastructure for inductor kernel launch overhead,
cleans up nop_inductor_kernel, and adds nop_inductor_per_kernel to isolate
per-kernel cost from per-graph cost.

**Motivation**: Inductor's torch.compile'd kernel launch takes ~33µs e2e vs ~1.3µs for
a raw cuLaunchKernel. We want to understand where the ~32µs overhead comes from and
identify optimization targets.

**Key finding — per-kernel overhead breakdown** (GB200, mode/opt):

| Benchmark                       | 0-arg  | 19-arg | What it measures                     |
|---------------------------------|--------|--------|--------------------------------------|
| nop_triton_direct_culaunch      | 3.0µs  | 3.3µs  | cuLaunchKernel (raw CUDA driver)     |
| nop_triton_compiled_kernel_run  | 4.7µs  | 5.6µs  | triton binder (CompiledKernel.run)   |
| nop_inductor_per_kernel         | 6.8µs  | 9.1µs  | CachingAutotuner.run (per-kernel)    |
| nop_inductor_kernel             | 44.3µs | 42.4µs | Full e2e (guard + DeviceGuard + all) |

Per-kernel overhead tree:
  CachingAutotuner.run()  6.8µs
  ├── AT preamble         2.1µs  (set_allocator, TritonBundler, debug_mode)
  ├── triton binder       1.7µs  (PyArg_ParseTuple + cuPointerGetAttribute)
  └── cuLaunchKernel      3.0µs  (irreducible CUDA driver cost)

Per-graph overhead (amortized across N kernels): guard check ~20µs,
CompiledFxGraph ~3.3µs, DeviceGuard ~1.4µs. For N=100, these add only
~0.25µs/kernel — negligible.

AOTI eliminates all Python-side per-kernel overhead (no CachingAutotuner, no
triton binder), going directly from C++ to cuLaunchKernel at ~1.3µs/kernel.
The 5.5µs/kernel gap is torch.compile-specific Python overhead.

**nop_inductor_per_kernel** (new):
- Extracts CachingAutotuner instance from compiled inductor code
- Calls kernel.run() directly, bypassing guard/DeviceGuard/wrapper
- Reports pure per-kernel overhead (CachingAutotuner.run time)
- Compare with nop_inductor_kernel to see per-graph vs per-kernel split

**benchmark.py** (scripts/tissue030/benchmark_inductor_launcher/):
- Standalone profiling script that benchmarks each line in the inductor-generated
  call() function and CachingAutotuner.run() internals

**operator.py cleanup**:
- Replace nop_inductor_kernel with proper nop kernel (t1.add_(0)) using
  fixed-signature functions (0-arg and 19-arg) for fair comparison
- Remove get_trivial_add_kernel, unused import time

Differential Revision: D100881626
