### PR TITLE
Export workload as Tritonbench graph (#1020)

### DIFF
--- a/tritonbench/operators/op.py
+++ b/tritonbench/operators/op.py
@@ -100,3 +100,50 @@ def load_opbench_by_name(op_name: str):
     if not hasattr(Operator, "name"):
         Operator.name = op_name
     return Operator
+
+
+GRAPH_DIR = "graphs"
+
+
+def load_graph_by_name(graph_path: str):
+    """Load a graph operator by path.
+
+    Args:
+        graph_path: Path in the form "<collection>/<graph_name>",
+            e.g. "model_extractor-aps-xxx/graph_0_fwd"
+    """
+    parts = graph_path.strip("/").split("/")
+    if len(parts) != 2:
+        raise RuntimeError(
+            f"Invalid --graph format: '{graph_path}'. "
+            "Expected '<collection>/<graph_name>'"
+        )
+    collection, graph_name = parts
+
+    graph_root = pathlib.Path(__file__).parent.parent.joinpath(GRAPH_DIR)
+    graph_dir = None
+    for search_dir in [graph_root, graph_root.joinpath("fb")]:
+        candidate = search_dir.joinpath(collection).joinpath(graph_name)
+        if candidate.exists() and candidate.joinpath("__init__.py").exists():
+            graph_dir = candidate
+            break
+    if graph_dir is None:
+        raise RuntimeError(
+            f"Graph not found: {graph_path}. "
+            f"Searched {GRAPH_DIR}/ and {GRAPH_DIR}/fb/ for "
+            f"{collection}/{graph_name}/"
+        )
+
+    graph_py = graph_dir.joinpath("graph.py")
+    spec = importlib.util.spec_from_file_location(
+        f"tritonbench.{GRAPH_DIR}.{collection}.{graph_name}.graph",
+        graph_py,
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    Graph = getattr(module, "Graph", None)
+    if Graph is None:
+        raise RuntimeError(f"Graph {graph_path} does not define a Graph class")
+    if not hasattr(Graph, "name"):
+        Graph.name = graph_name
+    return Graph

--- a/tritonbench/utils/parser.py
+++ b/tritonbench/utils/parser.py
@@ -23,6 +23,13 @@ def get_parser(args=None):
         help="Operators to benchmark. Split with comma if multiple.",
     )
     parser.add_argument(
+        "--graph",
+        type=str,
+        required=False,
+        help="Subgraph to benchmark. Format: <collection>/<graph_name>, "
+        "e.g. model_extractor-aps-xxx/graph_0_fwd",
+    )
+    parser.add_argument(
         "--op-collection",
         default="default",
         type=str,

--- a/tritonbench/utils/run_utils.py
+++ b/tritonbench/utils/run_utils.py
@@ -489,6 +489,15 @@ def tritonbench_run(args: Optional[List[str]] = None):
         torch.mtia.init()
         mtia_triton_launcher.init()
 
+    if getattr(args, "graph", None):
+        # --graph mode: run a single subgraph directly
+        # Set args.op from graph name for output/logging compatibility
+        if not args.op:
+            args.op = args.graph.strip("/").replace("/", "_")
+        _run(args, extra_args)
+        tritonparse_parse(args.tritonparse)
+        return
+
     if args.op:
         ops = args.op.split(",")
     else:
@@ -553,7 +562,11 @@ def tritonbench_run(args: Optional[List[str]] = None):
 
 def _run(args: argparse.Namespace, extra_args: List[str]) -> BenchmarkOperatorResult:
     run_timestamp = datetime.fromtimestamp(time.time()).strftime("%Y%m%d%H%M%S")
-    if is_loader_op(args.op):
+    if getattr(args, "graph", None):
+        from tritonbench.operators.op import load_graph_by_name
+
+        Opbench = load_graph_by_name(args.graph)
+    elif is_loader_op(args.op):
         Opbench = get_op_loader_bench_cls_by_name(args.op)
     else:
         Opbench = load_opbench_by_name(args.op)

--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -211,10 +211,23 @@ def _find_op_name_from_module_path(module_path: str) -> str:
     PATH_PREFIX = "tritonbench.operators."
     # We have a separate operator loader for aten operator benchmark.
     PATH_PREFIX_LOADER = "tritonbench.operator_loader."
-    assert PATH_PREFIX in module_path or PATH_PREFIX_LOADER in module_path, (
-        f"We rely on module path prefix to identify operator name. Expected {PATH_PREFIX}<operator_name>, get {module_path}."
+    PATH_PREFIX_GRAPH = "tritonbench.graphs."
+    assert (
+        PATH_PREFIX in module_path
+        or PATH_PREFIX_LOADER in module_path
+        or PATH_PREFIX_GRAPH in module_path
+    ), (
+        f"We rely on module path prefix to identify operator name. "
+        f"Expected {PATH_PREFIX}<operator_name>, get {module_path}."
     )
-    if PATH_PREFIX_LOADER in module_path:
+    if PATH_PREFIX_GRAPH in module_path:
+        # graphs.<collection>.<graph_name>.graph -> graph_name
+        suffix = module_path.partition(PATH_PREFIX_GRAPH)[2]
+        parts = suffix.split(".")
+        if len(parts) >= 2:
+            return parts[-2] if parts[-1] == "graph" else parts[-1]
+        return parts[0]
+    elif PATH_PREFIX_LOADER in module_path:
         suffix = module_path.partition(PATH_PREFIX_LOADER)[2]
         suffix = suffix.partition(".")[2]
     else:


### PR DESCRIPTION
Summary:

This diff adds several features and fixes to the tritonbench model_extractor pipeline and introduces subgraph benchmarking support.

 #  FXgraph Export (--export-tritonbench)

  - tools/fb/model_extractor/model_extractor.py: Added --export-tritonbench and --model-name CLI options
  - tools/fb/model_extractor/tritonbench_utils.py: New module with:
    - _parse_load_args(): Parses reader.storage()/reader.tensor() from fx_graph files to extract input tensor shapes, dtypes, and strides
    - export_subgraphs(): Creates tritonbench operator directories with auto-generated operator.py, fx_graph.py, and __init__.py
    - Model name becomes a subdirectory (e.g., subgraphs/fb/<model_name>/<graph_name>/)

#  FXgraph Benchmarking (--graph)

  - tritonbench/utils/parser.py: Added --graph CLI argument
  - tritonbench/operators/op.py: Added load_subgraph_by_name() — loads subgraph operators via importlib.util (supports dashes in directory names), searches subgraphs/ then subgraphs/fb/
  - tritonbench/utils/run_utils.py: Wired --graph into tritonbench_run() and _run()
  - tritonbench/utils/triton_op.py: Added tritonbench.subgraphs. as a recognized module path prefix in _find_op_name_from_module_path()
  - pytorch/tritonbench/BUCK: Added tritonbench/subgraphs/**/*.py to tritonbench_operators glob


#  Example Graph
  - Created tritonbench/graphs/fb/model_extractor-aps-f1059001377-1059042040/graph_18_bwd_recompile_0/ — real production graph with 23 auto-parsed input tensors

 # Usage

```
  # Export graphs from extracted fx_graphs
  buck2 run mode/opt //pytorch/tritonbench/tools/fb/model_extractor:run -- \
      --fx-graph ./graphs/ --export-tritonbench --model-name my_model

  # Benchmark a graph
  buck2 run mode/opt //pytorch/tritonbench:run_lite -- \
      --graph my_model/graph_0_fwd
```

Differential Revision: D101082663


