### PR TITLE
Remove references to Diode `expand_search_space`

### DIFF
--- a/tritonbench/utils/diode_utils.py
+++ b/tritonbench/utils/diode_utils.py
@@ -62,16 +62,13 @@ def deserialize_model_config(json_str: str) -> "ModelConfig":
 def setup_diode_model(
     diode_version: str,
     topk: int = 1,
-    expand_search_space: bool = True,
     model_config: "ModelConfig | None" = None,
-) -> tuple[int, bool]:
+) -> int:
     logger.info("[DIODE][TritonBench] Setup Diode model.")
 
     old_topk = diode_config.topk
-    old_expand_search_space = diode_config.expand_search_space
 
     diode_config.topk = topk
-    diode_config.expand_search_space = expand_search_space
 
     if model_config is None:
         model_config = MODEL_CONFIGS[diode_version]
@@ -81,14 +78,12 @@ def setup_diode_model(
 
     V.set_choices_handler(DiodeInductorChoices())
 
-    return old_topk, old_expand_search_space
+    return old_topk
 
 
-def teardown_diode_model(old_configs):
+def teardown_diode_model(old_diode_topk: int):
     logger.info("[DIODE][TritonBench] Teardown Diode model.")
 
-    old_topk, old_expand_search_space = old_configs
-    diode_config.topk = old_topk
-    diode_config.expand_search_space = old_expand_search_space
+    diode_config.topk = old_diode_topk
     get_registry().clear()
     V.set_choices_handler(InductorChoices())

--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -829,7 +829,7 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
         self._num_inputs = self.tb_args.num_inputs
         self._input_sample_mode = self.tb_args.input_sample_mode
         self.prod_shapes = self.tb_args.prod_shapes
-        self.old_diode_configs = (
+        self.old_diode_topk = (
             None  # Updated in _reduce_benchmarks if running the Diode benchmark
         )
         self.old_allow_tf32 = set_allow_tf32(self.tb_args.allow_tf32)
@@ -1205,7 +1205,7 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
                             diode_model_config = deserialize_model_config(
                                 self.tb_args.diode_model_config
                             )
-                        self.old_diode_configs = setup_diode_model(
+                        self.old_diode_topk = setup_diode_model(
                             self.tb_args.diode_version,
                             topk=self.tb_args.diode_topk,
                             model_config=diode_model_config,
@@ -1228,9 +1228,9 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
                     if sleep:
                         logging.debug(f"Sleeping for {sleep} seconds before next run")
                         time.sleep(sleep)
-                    if self.old_diode_configs:
-                        teardown_diode_model(self.old_diode_configs)
-                        self.old_diode_configs = None
+                    if self.old_diode_topk is not None:
+                        teardown_diode_model(self.old_diode_topk)
+                        self.old_diode_topk = None
                     return acc
 
                 y_vals: Dict[str, BenchmarkOperatorMetrics] = functools.reduce(


### PR DESCRIPTION
Summary: Diode's `expand_search_space` will go away in D101087802, so some cleanup is possible/needed in Tritonbench.

Differential Revision: D101391987


