### PR TITLE
prioritize explicit benchmark_name over ops name (#1024)

### DIFF
--- a/tritonbench/utils/run_utils.py
+++ b/tritonbench/utils/run_utils.py
@@ -614,7 +614,7 @@ def _run(args: argparse.Namespace, extra_args: List[str]) -> BenchmarkOperatorRe
 
             kwargs = {
                 "metrics": metrics,
-                "benchmark_name": args.op,
+                "benchmark_name": args.benchmark_name or args.op,
                 "device": args.device,
                 "logging_group": args.logging_group or args.op,
                 "precision": args.precision,


### PR DESCRIPTION
Summary:


Prioritize explicit benchmark_name over ops name

Reviewed By: sryap

Differential Revision: D101678600
