### PR TITLE
[utils] detect sm_120 consumer Blackwell (RTX 5090, RTX PRO 6000)

### DIFF
--- a/test/test_cpu/test_env_utils.py
+++ b/test/test_cpu/test_env_utils.py
@@ -1,0 +1,40 @@
+import unittest
+
+import torch
+
+from tritonbench.utils.env_utils import (
+    IS_BLACKWELL,
+    IS_BLACKWELL_ANY,
+    IS_BLACKWELL_CONSUMER,
+    is_blackwell,
+    is_blackwell_consumer,
+)
+
+
+class BlackwellDetectionTest(unittest.TestCase):
+    def test_constants_are_bool(self):
+        self.assertIsInstance(IS_BLACKWELL, bool)
+        self.assertIsInstance(IS_BLACKWELL_CONSUMER, bool)
+        self.assertIsInstance(IS_BLACKWELL_ANY, bool)
+
+    def test_functions_return_bool(self):
+        self.assertIsInstance(is_blackwell(), bool)
+        self.assertIsInstance(is_blackwell_consumer(), bool)
+
+    def test_mutually_exclusive(self):
+        # A single GPU cannot be both datacenter (sm_100) and consumer
+        # (sm_120) Blackwell simultaneously.
+        self.assertFalse(IS_BLACKWELL and IS_BLACKWELL_CONSUMER)
+
+    def test_any_is_disjunction(self):
+        self.assertEqual(IS_BLACKWELL_ANY, IS_BLACKWELL or IS_BLACKWELL_CONSUMER)
+
+    def test_cpu_only_returns_false(self):
+        if not torch.cuda.is_available():
+            self.assertFalse(IS_BLACKWELL)
+            self.assertFalse(IS_BLACKWELL_CONSUMER)
+            self.assertFalse(IS_BLACKWELL_ANY)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tritonbench/operators/fp8_gemm_rowwise/operator.py
+++ b/tritonbench/operators/fp8_gemm_rowwise/operator.py
@@ -7,6 +7,7 @@ from tritonbench.utils.data_utils import get_production_shapes
 from tritonbench.utils.env_utils import (
     get_nvidia_gpu_model,
     IS_BLACKWELL,
+    IS_BLACKWELL_ANY,
     is_cuda,
     is_fbcode,
     is_hip,
@@ -184,7 +185,7 @@ class Operator(BenchmarkOperator):
 
         # This is the only config currently tested in b200.
         # TODO: Remove it when the other variants are supported.
-        if IS_BLACKWELL:
+        if IS_BLACKWELL_ANY:
             self.fp8_fast_accum = True
             self.use_tma = True
             self.no_use_persistent = False

--- a/tritonbench/utils/env_utils.py
+++ b/tritonbench/utils/env_utils.py
@@ -121,7 +121,15 @@ def is_hip_mi350():
 
 
 def is_blackwell() -> bool:
-    """Check if running on an NVIDIA Blackwell GPU (B200 or B300 series)."""
+    """Check if running on a datacenter Blackwell GPU (B200/B300, sm_100).
+
+    Kernels gated on this flag assume TMEM / tcgen05 (5th-gen tensor cores
+    with tensor memory), which exist on sm_100 only. Consumer/workstation
+    Blackwell (sm_120, e.g. RTX 5090 / RTX PRO 6000) has 5th-gen tensor cores
+    but no TMEM, so those kernels will not compile there. Use
+    ``is_blackwell_consumer()`` for sm_120, or ``IS_BLACKWELL_ANY`` when you
+    only care that the arch is some flavor of Blackwell.
+    """
     if not is_cuda_available():
         return False
     gpu_model = get_nvidia_gpu_model()
@@ -134,6 +142,41 @@ def is_blackwell() -> bool:
 
 
 IS_BLACKWELL = is_blackwell()
+
+
+def is_blackwell_consumer() -> bool:
+    """Check if running on consumer/workstation Blackwell (sm_120: GB202 etc).
+
+    Covers RTX 5090, RTX PRO 6000 Blackwell Workstation, and other GB20x
+    parts. These have 5th-gen tensor cores and NVFP4/MXFP4 support but
+    lack TMEM and cluster DSM, so kernels written for sm_100 (TMEM/tcgen05)
+    will not run here.
+    """
+    if not is_cuda_available():
+        return False
+    try:
+        if torch.cuda.get_device_capability()[0] == 12:
+            return True
+    except Exception:
+        pass
+    gpu_model = get_nvidia_gpu_model()
+    if not gpu_model:
+        return False
+    return (
+        "RTX PRO 6000" in gpu_model
+        or "RTX 5090" in gpu_model
+        or "RTX 5080" in gpu_model
+        or "RTX 5070" in gpu_model
+    )
+
+
+IS_BLACKWELL_CONSUMER = is_blackwell_consumer()
+
+# True for any Blackwell arch (sm_100 datacenter or sm_120 consumer).
+# Use this ONLY for gates that don't depend on TMEM/tcgen05 (e.g. config
+# defaults, NVFP4 paths). Kernel-level gates that rely on tensor memory
+# must keep using IS_BLACKWELL.
+IS_BLACKWELL_ANY = IS_BLACKWELL or IS_BLACKWELL_CONSUMER
 
 
 def is_hopper() -> bool:


### PR DESCRIPTION
# [utils] detect sm_120 consumer Blackwell (RTX 5090, RTX PRO 6000)

## Motivation

Per the Hopper-and-above scope discussion (@xzhao_), tritonbench targets
Blackwell as a first-class arch. Today `is_blackwell()` only matches
datacenter parts (B200/B300, sm_100). Consumer and workstation Blackwell
(GB20x, sm_120: RTX 5090 / 5080 / 5070 and RTX PRO 6000 Blackwell
Workstation) is silently treated as non-Blackwell, so config defaults
intended for Blackwell never fire on those GPUs even though their tensor
cores are the same 5th-gen family.

The wrinkle is that sm_120 does **not** have TMEM / `tcgen05`, so we
can't just broaden `is_blackwell()`: kernels that emit `tlx.storage_kind.tmem`
or call `tcgen05_gemm` assume sm_100a PTX and won't compile on sm_120.

## What changed

`tritonbench/utils/env_utils.py`:

- Clarified `is_blackwell()` docstring: explicitly sm_100 / TMEM / tcgen05.
- Added `is_blackwell_consumer()` + `IS_BLACKWELL_CONSUMER` for sm_120.
  Detection: `torch.cuda.get_device_capability()[0] == 12` first, with a
  name-match fallback for RTX PRO 6000 / RTX 5090 / 5080 / 5070.
- Added `IS_BLACKWELL_ANY = IS_BLACKWELL or IS_BLACKWELL_CONSUMER` with a
  comment documenting that it is for arch-family gates only (config
  defaults, NVFP4 paths), **not** TMEM-dependent kernels.

`tritonbench/operators/fp8_gemm_rowwise/operator.py`:

- One line: the config-defaults block that sets `fp8_fast_accum=True`,
  `use_tma=True`, etc. now gates on `IS_BLACKWELL_ANY`. These defaults
  are arch-tuning, not kernel selection, so they apply cleanly to sm_120.

## What did NOT change (and why)

- `HAS_CUTLASS_OR_CK = is_hip() or (is_cuda() and not IS_BLACKWELL)` and
  `HAS_CUBLAS = is_cuda() and not IS_BLACKWELL` are **unchanged**. These
  are kernel-availability gates and flipping them for sm_120 needs
  separate testing.
- No other `IS_BLACKWELL` callsite was touched. Anything that emits
  `tlx.storage_kind.tmem` or `tcgen05_gemm` is sm_100a-only PTX and must
  keep using `IS_BLACKWELL`.

## Verification

- Added `test/test_cpu/test_env_utils.py` covering: constants are bool,
  `IS_BLACKWELL` and `IS_BLACKWELL_CONSUMER` mutually exclusive,
  `IS_BLACKWELL_ANY == IS_BLACKWELL or IS_BLACKWELL_CONSUMER`, CPU-only
  path returns False. Skips cleanly without CUDA.
- Ran tests on RTX PRO 6000 Blackwell Workstation
  (`torch.cuda.get_device_capability() == (12, 0)`, CUDA 13.2, driver
  595.58.03, PyTorch/Triton current): 5/5 passed. Confirmed at runtime
  `IS_BLACKWELL=False`, `IS_BLACKWELL_CONSUMER=True`, `IS_BLACKWELL_ANY=True`.
- `ruff check` clean on all touched files.
