### PR TITLE
Remove Layer 2 signature-based fast path (backout D100199276)

### DIFF
--- a/tritonbench/operators/launch_latency/operator.py
+++ b/tritonbench/operators/launch_latency/operator.py
@@ -395,25 +395,6 @@ class Operator(BenchmarkOperator):
         )
 
     @register_benchmark()
-    def nop_triton_kernel_new_tensors(self, *args):
-        """Layer 1 misses (different tensor objects each call), Layer 2 should hit."""
-        if len(args) == 0:
-            return lambda: nop_kernel[1,]()
-        # Pre-allocate N sets of cloned tensors to avoid allocation in the hot loop.
-        N = 100
-        targs = args[:5]
-        rest_args = args[5:]
-        tensor_sets = [tuple(t.clone() for t in targs) for _ in range(N)]
-        idx = [0]
-
-        def fn():
-            i = idx[0] % N
-            idx[0] += 1
-            nop_with_args_kernel[1,](*tensor_sets[i], *rest_args)
-
-        return fn
-
-    @register_benchmark()
     def nop_triton_compiled_kernel_run(self, *args):
         if len(args) == 0:
             bin = nop_kernel[1,]()


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookexperimental/triton/pull/1316

Remove the Layer 2 signature-based fast path (_compute_fast_key + _run_cache)
introduced by D100199276. Layer 2 was the root cause of two separate OOM issues:

1. _run_cache grew unbounded, with each entry pinning GPU tensors via bound_vals
   (fixed by D101712526 LRU, but the underlying design was flawed)
2. After D101207361 restricted cache population to first-call-only, _run_cache
   only cached one specialization, making Layer 2 effectively useless for
   workloads with varying shapes (e.g., vLLM inference)

Layer 1 (identity-based fast path from D100199238) is retained and provides
37-44% launch latency reduction for the common case (training loops with
repeated identical args). Layer 2 added complexity and OOM risk for negligible
benefit in its current state.

Removed:
- _compute_fast_key() method
- _run_cache dict and all references
- Layer 2 lookup section in run()
- Layer 2 cache population in slow path

Differential Revision: D102131184


