### PR TITLE
[ci] remove meta triton test from pr

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -10,10 +10,6 @@ on:
       - main
 
 jobs:
-  h100-meta-triton-test:
-    uses: ./.github/workflows/_linux-test-h100.yml
-    with:
-      conda_env: "meta-triton"
   h100-triton-main-test:
     uses: ./.github/workflows/_linux-test-h100.yml
     with:


### PR DESCRIPTION
No need to test meta triton from pr level because it is deployed in upstream already.