### PR TITLE
[warmup] Change default warmup and rep time to adaptive

### DIFF
--- a/tritonbench/components/do_bench/gpu_events.py
+++ b/tritonbench/components/do_bench/gpu_events.py
@@ -10,6 +10,7 @@ from tritonbench.utils.env_utils import is_hip
 from tritonbench.utils.gpu_utils import sleep_amd
 
 from .common import summarize_statistics
+from .utils import resolve_warmup_and_rep
 
 _kernel_unblock_stream = None
 
@@ -305,6 +306,7 @@ def do_bench_events(
     torch.cuda.synchronize()
 
     estimate_ms = time_events[0].elapsed_time(time_events[1]) / n_repeat
+    warmup, rep = resolve_warmup_and_rep(warmup, rep, estimate_ms)
 
     # Calculate number of warmup iterations based on target rep time
     if estimate_ms == 0:

--- a/tritonbench/components/do_bench/gpu_events.py
+++ b/tritonbench/components/do_bench/gpu_events.py
@@ -10,7 +10,6 @@ from tritonbench.utils.env_utils import is_hip
 from tritonbench.utils.gpu_utils import sleep_amd
 
 from .common import summarize_statistics
-from .utils import resolve_warmup_and_rep
 
 _kernel_unblock_stream = None
 
@@ -306,7 +305,6 @@ def do_bench_events(
     torch.cuda.synchronize()
 
     estimate_ms = time_events[0].elapsed_time(time_events[1]) / n_repeat
-    warmup, rep = resolve_warmup_and_rep(warmup, rep, estimate_ms)
 
     # Calculate number of warmup iterations based on target rep time
     if estimate_ms == 0:

--- a/tritonbench/components/do_bench/run.py
+++ b/tritonbench/components/do_bench/run.py
@@ -677,10 +677,11 @@ def do_bench_wrapper(
         and not repcnt
         and latency_measure_mode == "triton_do_bench"
     ):
+        estimate_runtime = estimate_cuda_runtime_ms(fn, grad_to_none=grad_to_none)
         warmup, rep = resolve_warmup_and_rep(
             warmup,
             rep,
-            estimate_cuda_runtime_ms(fn, grad_to_none=grad_to_none),
+            estimate_runtime,
         )
 
     try:

--- a/tritonbench/components/do_bench/run.py
+++ b/tritonbench/components/do_bench/run.py
@@ -431,7 +431,7 @@ def _do_bench_profiler(
 
 
 def _do_bench_cpu(
-    fn, warmup, rep=20, grad_to_none=None, quantiles=None, return_mode="mean"
+    fn, warmup, rep, grad_to_none=None, quantiles=None, return_mode="mean"
 ):
     """Measure latency of a function on CPU."""
     assert return_mode in ["min", "max", "mean", "median", "all"]

--- a/tritonbench/components/do_bench/run.py
+++ b/tritonbench/components/do_bench/run.py
@@ -660,10 +660,7 @@ def do_bench_wrapper(
         entropy_window_size: Size of rolling window for entropy tracking
         entropy_max_samples: Maximum samples before stopping warmup (safety limit)
     """
-    if (
-        (warmup is None or rep is None)
-        and not repcnt
-    ):
+    if (warmup is None or rep is None) and not repcnt:
         estimate_runtime = estimate_cuda_runtime_ms(fn, grad_to_none=grad_to_none)
         warmup, rep = resolve_warmup_and_rep(
             warmup,

--- a/tritonbench/components/do_bench/run.py
+++ b/tritonbench/components/do_bench/run.py
@@ -159,8 +159,8 @@ def _do_bench_inductor(fn, warmup, rep, return_mode="all", grad_to_none=None):
     Returns:
         List of measured times in milliseconds (if return_mode="all") or single value.
     """
+    # First, estimate the runtime with a single measurement
     estimate_ms = benchmarker.benchmark_gpu(fn, estimation_iters=5, benchmark_iters=10)
-    warmup, rep = resolve_warmup_and_rep(warmup, rep, estimate_ms)
 
     # Calculate number of iterations based on target rep time
     # Similar to how triton.testing.do_bench calculates iterations
@@ -309,7 +309,6 @@ def _do_bench_profiler(
         grad_to_none=grad_to_none,
         clear_cache_fn=clear_cache_fn,
     )
-    warmup, rep = resolve_warmup_and_rep(warmup, rep, estimate_ms)
 
     # Calculate number of iterations based on target rep time
     if estimate_ms == 0:
@@ -442,7 +441,6 @@ def _do_bench_cpu(
         fn()
     t1 = time.time_ns()
     estimate_ms = (t1 - t0) * NS_TO_MS / 5
-    warmup, rep = resolve_warmup_and_rep(warmup, rep, estimate_ms)
 
     # compute number of warmup and repeat
     if estimate_ms == 0:
@@ -474,8 +472,8 @@ def _do_bench_cpu(
 
 def _do_bench_entropy(
     fn,
-    warmup=25,
-    rep=100,
+    warmup,
+    rep,
     grad_to_none=None,
     quantiles=None,
     return_mode="mean",
@@ -529,15 +527,6 @@ def _do_bench_entropy(
 
     cache = triton.runtime.driver.active.get_empty_cache_for_benchmark()
     clear_cache_fn = lambda: triton.runtime.driver.active.clear_cache(cache)
-    warmup, rep = resolve_warmup_and_rep(
-        warmup,
-        rep,
-        estimate_cuda_runtime_ms(
-            fn,
-            grad_to_none=grad_to_none,
-            clear_cache_fn=clear_cache_fn,
-        ),
-    )
 
     # Adaptive warmup loop with batched synchronization
     while True:
@@ -673,9 +662,7 @@ def do_bench_wrapper(
     """
     if (
         (warmup is None or rep is None)
-        and device != "cpu"
         and not repcnt
-        and latency_measure_mode == "triton_do_bench"
     ):
         estimate_runtime = estimate_cuda_runtime_ms(fn, grad_to_none=grad_to_none)
         warmup, rep = resolve_warmup_and_rep(

--- a/tritonbench/components/do_bench/run.py
+++ b/tritonbench/components/do_bench/run.py
@@ -14,6 +14,7 @@ from tritonbench.utils.cudagraph_utils import CudaGraphConfig
 from .common import summarize_statistics
 from .gpu_events import do_bench_events
 from .power import do_bench_power
+from .utils import estimate_cuda_runtime_ms, resolve_warmup_and_rep
 
 NS_TO_MS = 1e-6
 logger = logging.getLogger(__name__)
@@ -158,8 +159,8 @@ def _do_bench_inductor(fn, warmup, rep, return_mode="all", grad_to_none=None):
     Returns:
         List of measured times in milliseconds (if return_mode="all") or single value.
     """
-    # First, estimate the runtime with a single measurement
     estimate_ms = benchmarker.benchmark_gpu(fn, estimation_iters=5, benchmark_iters=10)
+    warmup, rep = resolve_warmup_and_rep(warmup, rep, estimate_ms)
 
     # Calculate number of iterations based on target rep time
     # Similar to how triton.testing.do_bench calculates iterations
@@ -219,6 +220,7 @@ def _do_bench_cudagraph_with_cache_clear(
         end_event.record()
         torch.cuda.synchronize()
         estimate_ms = start_event.elapsed_time(end_event) / 5
+        _, rep = resolve_warmup_and_rep(None, rep, estimate_ms)
 
         n_repeat = 1000 if estimate_ms == 0 else max(1, int(rep / estimate_ms))
 
@@ -301,22 +303,19 @@ def _do_bench_profiler(
         else None
     )
 
-    # First, estimate the runtime to calculate iterations
-    estimate_ms = triton.testing.do_bench(
+    clear_cache_fn = cache.zero_ if not skip_cache_clearing else lambda *args: None
+    estimate_ms = estimate_cuda_runtime_ms(
         fn,
-        warmup=warmup,
-        rep=rep,
         grad_to_none=grad_to_none,
-        return_mode="mean",
+        clear_cache_fn=clear_cache_fn,
     )
+    warmup, rep = resolve_warmup_and_rep(warmup, rep, estimate_ms)
 
     # Calculate number of iterations based on target rep time
     if estimate_ms == 0:
         n_repeat = DEFAULT_N_REP  # Default if function is very fast
     else:
         n_repeat = max(1, int(rep / estimate_ms))
-
-    clear_cache_fn = cache.zero_ if not skip_cache_clearing else lambda *args: None
 
     # Helper function to execute one iteration
     def run_iteration():
@@ -443,6 +442,7 @@ def _do_bench_cpu(
         fn()
     t1 = time.time_ns()
     estimate_ms = (t1 - t0) * NS_TO_MS / 5
+    warmup, rep = resolve_warmup_and_rep(warmup, rep, estimate_ms)
 
     # compute number of warmup and repeat
     if estimate_ms == 0:
@@ -528,6 +528,16 @@ def _do_bench_entropy(
     precision_increase = False
 
     cache = triton.runtime.driver.active.get_empty_cache_for_benchmark()
+    clear_cache_fn = lambda: triton.runtime.driver.active.clear_cache(cache)
+    warmup, rep = resolve_warmup_and_rep(
+        warmup,
+        rep,
+        estimate_cuda_runtime_ms(
+            fn,
+            grad_to_none=grad_to_none,
+            clear_cache_fn=clear_cache_fn,
+        ),
+    )
 
     # Adaptive warmup loop with batched synchronization
     while True:
@@ -545,7 +555,7 @@ def _do_bench_entropy(
             if grad_to_none is not None:
                 for x in grad_to_none:
                     x.grad = None
-            triton.runtime.driver.active.clear_cache(cache)
+            clear_cache_fn()
             batch_start_events[i].record()
             fn()
             batch_end_events[i].record()
@@ -619,7 +629,7 @@ def _do_bench_entropy(
         if grad_to_none is not None:
             for x in grad_to_none:
                 x.grad = None
-        triton.runtime.driver.active.clear_cache(cache)
+        clear_cache_fn()
         start_events[i].record()
         fn()
         end_events[i].record()
@@ -661,6 +671,18 @@ def do_bench_wrapper(
         entropy_window_size: Size of rolling window for entropy tracking
         entropy_max_samples: Maximum samples before stopping warmup (safety limit)
     """
+    if (
+        (warmup is None or rep is None)
+        and device != "cpu"
+        and not repcnt
+        and latency_measure_mode == "triton_do_bench"
+    ):
+        warmup, rep = resolve_warmup_and_rep(
+            warmup,
+            rep,
+            estimate_cuda_runtime_ms(fn, grad_to_none=grad_to_none),
+        )
+
     try:
         if device == "cpu":
             return Latency(

--- a/tritonbench/components/do_bench/utils.py
+++ b/tritonbench/components/do_bench/utils.py
@@ -1,0 +1,49 @@
+from typing import Callable, Iterable, Optional, Tuple
+
+import torch
+from tritonbench.utils.constants import DEFAULT_WARMUP_REP_BY_ESTIMATED_KERNEL_MS
+
+
+def resolve_warmup_and_rep(
+    warmup: Optional[int], rep: Optional[int], estimate_ms: float
+) -> Tuple[int, int]:
+    if estimate_ms <= 1:
+        default_warmup, default_rep = DEFAULT_WARMUP_REP_BY_ESTIMATED_KERNEL_MS["1"]
+    elif estimate_ms <= 10:
+        default_warmup, default_rep = DEFAULT_WARMUP_REP_BY_ESTIMATED_KERNEL_MS["10"]
+    else:
+        default_warmup, default_rep = DEFAULT_WARMUP_REP_BY_ESTIMATED_KERNEL_MS["100"]
+    return (
+        default_warmup if warmup is None else warmup,
+        default_rep if rep is None else rep,
+    )
+
+
+def estimate_cuda_runtime_ms(
+    fn: Callable,
+    grad_to_none: Optional[Iterable[torch.Tensor]] = None,
+    clear_cache_fn: Optional[Callable[[], None]] = None,
+    iters: int = 5,
+    prime: bool = True,
+) -> float:
+    clear_cache_fn = clear_cache_fn or (lambda: None)
+
+    def run_once() -> None:
+        if grad_to_none is not None:
+            for x in grad_to_none:
+                x.grad = None
+        clear_cache_fn()
+        fn()
+
+    if prime:
+        run_once()
+        torch.cuda.synchronize()
+
+    start_event = torch.cuda.Event(enable_timing=True)
+    end_event = torch.cuda.Event(enable_timing=True)
+    start_event.record()
+    for _ in range(iters):
+        run_once()
+    end_event.record()
+    torch.cuda.synchronize()
+    return start_event.elapsed_time(end_event) / iters

--- a/tritonbench/components/kineto/trace.py
+++ b/tritonbench/components/kineto/trace.py
@@ -154,6 +154,10 @@ def do_bench_kineto(
     """
     if profile_opts is None:
         profile_opts = DEFAULT_PROFILE_OPTS
+    import torch
+
+    fn()
+    torch.cuda.synchronize()
     # We maintain a buffer of 256 MB that we clear
     # before each kernel call to make sure that the L2
     # doesn't contain any input data before the run
@@ -221,6 +225,10 @@ def do_bench_kineto(
 def do_bench_kineto_walltime(fn, repcnt=5, profile_opts=None, output_dir=None):
     if profile_opts is None:
         profile_opts = DEFAULT_PROFILE_OPTS
+    import torch
+
+    fn()
+    torch.cuda.synchronize()
 
     activity_groups = [
         profiler.ProfilerActivity.CUDA,

--- a/tritonbench/components/kineto/trace.py
+++ b/tritonbench/components/kineto/trace.py
@@ -8,6 +8,10 @@ from typing import Callable, Optional
 
 import torch
 import torch.profiler as profiler
+from tritonbench.components.do_bench.utils import (
+    estimate_cuda_runtime_ms,
+    resolve_warmup_and_rep,
+)
 from tritonbench.utils.constants import DEFAULT_N_REP, DEFAULT_N_WARMUP
 from tritonbench.utils.env_utils import has_manifold
 
@@ -122,8 +126,8 @@ def do_bench_kineto_cudagraph(
 
 def do_bench_kineto(
     fn: Callable,
-    warmup: int,
-    rep: int,
+    warmup: Optional[int],
+    rep: Optional[int],
     grad_to_none=None,
     fast_flush=True,
     profile_opts=None,
@@ -150,11 +154,6 @@ def do_bench_kineto(
     """
     if profile_opts is None:
         profile_opts = DEFAULT_PROFILE_OPTS
-    import torch
-
-    fn()
-    torch.cuda.synchronize()
-
     # We maintain a buffer of 256 MB that we clear
     # before each kernel call to make sure that the L2
     # doesn't contain any input data before the run
@@ -167,16 +166,8 @@ def do_bench_kineto(
     else:
         clear_cache = lambda *args: None
 
-    # Estimate the runtime of the function
-    start_event = torch.cuda.Event(enable_timing=True)
-    end_event = torch.cuda.Event(enable_timing=True)
-    start_event.record()
-    for _ in range(5):
-        clear_cache()
-        fn()
-    end_event.record()
-    torch.cuda.synchronize()
-    estimate_ms = start_event.elapsed_time(end_event) / 5
+    estimate_ms = estimate_cuda_runtime_ms(fn, clear_cache_fn=clear_cache)
+    warmup, rep = resolve_warmup_and_rep(warmup, rep, estimate_ms)
 
     # Calculate number of iterations based on target rep time
     if estimate_ms == 0:
@@ -230,10 +221,6 @@ def do_bench_kineto(
 def do_bench_kineto_walltime(fn, repcnt=5, profile_opts=None, output_dir=None):
     if profile_opts is None:
         profile_opts = DEFAULT_PROFILE_OPTS
-    import torch
-
-    fn()
-    torch.cuda.synchronize()
 
     activity_groups = [
         profiler.ProfilerActivity.CUDA,

--- a/tritonbench/components/ncu/__init__.py
+++ b/tritonbench/components/ncu/__init__.py
@@ -44,7 +44,7 @@ def do_bench_in_task(
 
     cache = torch.empty(int(256e6 // 4), dtype=torch.int, device="cuda")
 
-    if warmup is None or warmup:
+    if warmup == True:
         estimate_ms = estimate_cuda_runtime_ms(fn, clear_cache_fn=cache.zero_)
         warmup, _ = resolve_warmup_and_rep(warmup, None, estimate_ms)
 

--- a/tritonbench/components/ncu/__init__.py
+++ b/tritonbench/components/ncu/__init__.py
@@ -1,6 +1,10 @@
 from typing import Callable
 
 import torch
+from tritonbench.components.do_bench.utils import (
+    estimate_cuda_runtime_ms,
+    resolve_warmup_and_rep,
+)
 
 
 class cuda_profiler_range:
@@ -40,20 +44,12 @@ def do_bench_in_task(
 
     cache = torch.empty(int(256e6 // 4), dtype=torch.int, device="cuda")
 
-    if warmup:
-        # Estimate the runtime of the function
-        start_event = torch.cuda.Event(enable_timing=True)
-        end_event = torch.cuda.Event(enable_timing=True)
-        start_event.record()
-        for _ in range(5):
-            cache.zero_()
-            fn()
-        end_event.record()
-        torch.cuda.synchronize()
-        estimate_ms = start_event.elapsed_time(end_event) / 5
+    if warmup is None or warmup:
+        estimate_ms = estimate_cuda_runtime_ms(fn, clear_cache_fn=cache.zero_)
+        warmup, _ = resolve_warmup_and_rep(warmup, None, estimate_ms)
 
         # compute number of warmup and repeat
-        n_warmup = max(1, int(warmup / estimate_ms))
+        n_warmup = 1 if estimate_ms == 0 else max(1, int(warmup / estimate_ms))
         # Warm-up
         for _ in range(n_warmup):
             fn()

--- a/tritonbench/utils/constants.py
+++ b/tritonbench/utils/constants.py
@@ -1,5 +1,10 @@
-DEFAULT_WARMUP = 3000
-DEFAULT_REP = 3000
+from typing import Dict, Tuple
+
+DEFAULT_WARMUP_REP_BY_ESTIMATED_KERNEL_MS: Dict[str, Tuple[int, int]] = {
+    "1": (100, 100),
+    "10": (1000, 1000),
+    "100": (3000, 3000),
+}
 DEFAULT_POWER_REPCNT = 2000
 DEFAULT_QUANTILES = [0.5, 0.1, 0.9]
 DEFAULT_SLEEP = 0.0

--- a/tritonbench/utils/parser.py
+++ b/tritonbench/utils/parser.py
@@ -7,8 +7,6 @@ from tritonbench.utils.constants import (
     DEFAULT_ENTROPY_MAX_SAMPLES,
     DEFAULT_ENTROPY_MIN_R2,
     DEFAULT_ENTROPY_WINDOW_SIZE,
-    DEFAULT_REP,
-    DEFAULT_WARMUP,
 )
 from tritonbench.utils.env_utils import AVAILABLE_PRECISIONS, is_fbcode
 from tritonbench.utils.gpu_utils import get_gpu_device_name
@@ -76,14 +74,14 @@ def get_parser(args=None):
     parser.add_argument(
         "--warmup",
         type=int,
-        default=DEFAULT_WARMUP,
-        help="Num of warmup runs for each benchmark run.",
+        default=None,
+        help="Warmup time in ms for each benchmark run. Default: auto by estimated kernel latency.",
     )
     parser.add_argument(
         "--rep",
         type=int,
-        default=DEFAULT_REP,
-        help="The rep time for each benchmark run.",
+        default=None,
+        help="Target measurement time in ms for each benchmark run. Default: auto by estimated kernel latency.",
     )
     parser.add_argument(
         "--autotune-warmup",

--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -1043,8 +1043,8 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
 
     def run(
         self,
-        warmup=None,
-        rep=None,
+        warmup: int | None=None,
+        rep: int | None=None,
         quantiles=DEFAULT_QUANTILES,
         sleep=DEFAULT_SLEEP,
     ) -> None:
@@ -1910,8 +1910,8 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
         self,
         input_id: int,
         fn_name: str,
-        warmup=None,
-        rep=None,
+        warmup: int | None,
+        rep: int | None,
         repcnt=None,
         quantiles=DEFAULT_QUANTILES,
         baseline: bool = False,

--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -164,7 +164,14 @@ class TimerContext:
 
 
 def do_bench_walltime(fn, warmup=None, rep=None):
-    estimate_ms = estimate_cuda_runtime_ms(fn)
+    fn()
+    torch.cuda.synchronize()
+
+    with TimerContext() as timer:
+        for _ in range(5):
+            fn()
+        torch.cuda.synchronize()
+    estimate_ms = timer.elapsed_ms / 5
     warmup, rep = resolve_warmup_and_rep(warmup, rep, estimate_ms)
 
     # compute number of warmup and repeat

--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -1043,8 +1043,8 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
 
     def run(
         self,
-        warmup: int | None=None,
-        rep: int | None=None,
+        warmup: int | None = None,
+        rep: int | None = None,
         quantiles=DEFAULT_QUANTILES,
         sleep=DEFAULT_SLEEP,
     ) -> None:

--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -29,15 +29,19 @@ import triton
 from torch.utils._pytree import tree_map
 from triton.runtime.errors import OutOfResources as TritonOutOfResources
 from tritonbench.components.do_bench import do_bench_wrapper, Latency
+from tritonbench.components.do_bench.utils import (
+    estimate_cuda_runtime_ms,
+    resolve_warmup_and_rep,
+)
 from tritonbench.components.export import export_data
 from tritonbench.components.power import PowerManagerTask
 from tritonbench.data import get_input_loader
 from tritonbench.utils.constants import (
+    DEFAULT_N_REP,
+    DEFAULT_N_WARMUP,
     DEFAULT_POWER_REPCNT,
     DEFAULT_QUANTILES,
-    DEFAULT_REP,
     DEFAULT_SLEEP,
-    DEFAULT_WARMUP,
 )
 from tritonbench.utils.cudagraph_utils import CudaGraphConfig, CudaGraphError
 from tritonbench.utils.diode_utils import (
@@ -159,19 +163,17 @@ class TimerContext:
             self.elapsed_ms = (end_time - self._start_time) * 1e3
 
 
-def do_bench_walltime(fn, warmup=25, rep=DEFAULT_REP):
-    fn()
-    torch.cuda.synchronize()
-
-    with TimerContext() as timer:
-        for _ in range(5):
-            fn()
-        torch.cuda.synchronize()
-    estimate_ms = timer.elapsed_ms / 5
+def do_bench_walltime(fn, warmup=None, rep=None):
+    estimate_ms = estimate_cuda_runtime_ms(fn)
+    warmup, rep = resolve_warmup_and_rep(warmup, rep, estimate_ms)
 
     # compute number of warmup and repeat
-    n_warmup = max(1, int(warmup / estimate_ms))
-    n_repeat = max(1, int(rep / estimate_ms))
+    if estimate_ms == 0:
+        n_warmup = DEFAULT_N_WARMUP
+        n_repeat = DEFAULT_N_REP
+    else:
+        n_warmup = max(1, int(warmup / estimate_ms))
+        n_repeat = max(1, int(rep / estimate_ms))
 
     # Warm-up
     for _ in range(n_warmup):
@@ -1034,8 +1036,8 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
 
     def run(
         self,
-        warmup=DEFAULT_WARMUP,
-        rep=DEFAULT_REP,
+        warmup=None,
+        rep=None,
         quantiles=DEFAULT_QUANTILES,
         sleep=DEFAULT_SLEEP,
     ) -> None:
@@ -1901,8 +1903,8 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
         self,
         input_id: int,
         fn_name: str,
-        warmup=DEFAULT_WARMUP,
-        rep=DEFAULT_REP,
+        warmup=None,
+        rep=None,
         repcnt=None,
         quantiles=DEFAULT_QUANTILES,
         baseline: bool = False,


### PR DESCRIPTION
This PR makes TritonBench’s benchmark timing defaults adaptive instead of fixed. It introduces shared helpers to estimate kernel runtime and derive sensible warmup/rep windows, then applies that logic
  consistently across the main benchmarking paths (do_bench, GPU events, Kineto, NCU, profiler, entropy mode, CPU walltime, and operator execution). The CLI now treats --warmup and --rep as optional
  overrides, with automatic defaults chosen from the estimated kernel latency.

  In practice, this should make short kernels benchmark faster while keeping longer-running kernels on larger measurement windows, and it removes duplicated timing-estimation code across the codebase. The
  change also cleans up a few profiling paths so cache clearing, replay counts, and warmup behavior stay aligned across CUDA/ROCm benchmarking flows.

For kernels:

* estimated ms = 0ms (really small kernels): run DEFAULT_N_WARMUP (25) and DEFAULT_N_REP (100) iterations 
* estimated ms < 1ms: warmup = rep = 100 ms
* 10ms < estimated_ms < 1ms: warmup = rep = 1000 ms
* estimated_ms > 10 ms: warmup = rep = 3000 ms


Fixes https://github.com/meta-pytorch/tritonbench/issues/1034 and https://github.com/meta-pytorch/tritonbench/issues/1036
