### PR TITLE
Guard against attribute error

### DIFF
--- a/tritonbench/utils/python_utils.py
+++ b/tritonbench/utils/python_utils.py
@@ -9,5 +9,5 @@ def try_import(cond_name: str):
     try:
         yield
         _caller_globals[cond_name] = True
-    except (ImportError, ModuleNotFoundError, OSError) as e:
+    except (ImportError, ModuleNotFoundError, OSError, AttributeError) as e:
         _caller_globals[cond_name] = False


### PR DESCRIPTION
Summary:
Sometime third-party packages can be imported but there is no desired attribute, for example:

```
    from .operator import Operator
    _ = tk.bf16_b200_gemm
        ^^^^^^^^^^^^^^^^^
AttributeError: module 'thunderkittens' has no attribute 'bf16_b200_gemm'
```

Handle attribute error in `try_import`

___

overriding_review_checks_triggers_an_audit_and_retroactive_review
Oncall Short Name: triton

Differential Revision: D102627731
