### PR TITLE
fix: cap n_repeat in _do_bench_cudagraph_with_cache_clear to prevent …

### DIFF
--- a/tritonbench/components/do_bench/run.py
+++ b/tritonbench/components/do_bench/run.py
@@ -222,7 +222,11 @@ def _do_bench_cudagraph_with_cache_clear(
         torch.cuda.synchronize()
         estimate_ms = start_event.elapsed_time(end_event) / 5
 
-        n_repeat = MAX_CUDAGRAPH_REPEAT if estimate_ms == 0 else min(MAX_CUDAGRAPH_REPEAT, max(1, int(rep / estimate_ms)))
+        n_repeat = (
+            MAX_CUDAGRAPH_REPEAT
+            if estimate_ms == 0
+            else min(MAX_CUDAGRAPH_REPEAT, max(1, int(rep / estimate_ms)))
+        )
 
         g = torch.cuda.CUDAGraph()
         with torch.cuda.graph(g):

--- a/tritonbench/components/do_bench/run.py
+++ b/tritonbench/components/do_bench/run.py
@@ -9,6 +9,8 @@ import triton
 from torch._inductor.runtime.benchmarking import benchmarker
 from tritonbench.components.do_bench.entropy.entropy_criterion import EntropyCriterion
 from tritonbench.utils.constants import DEFAULT_N_REP, DEFAULT_N_WARMUP
+
+MAX_CUDAGRAPH_REPEAT = 1000
 from tritonbench.utils.cudagraph_utils import CudaGraphConfig
 
 from .common import summarize_statistics
@@ -220,7 +222,7 @@ def _do_bench_cudagraph_with_cache_clear(
         torch.cuda.synchronize()
         estimate_ms = start_event.elapsed_time(end_event) / 5
 
-        n_repeat = 1000 if estimate_ms == 0 else max(1, int(rep / estimate_ms))
+        n_repeat = MAX_CUDAGRAPH_REPEAT if estimate_ms == 0 else min(MAX_CUDAGRAPH_REPEAT, max(1, int(rep / estimate_ms)))
 
         g = torch.cuda.CUDAGraph()
         with torch.cuda.graph(g):


### PR DESCRIPTION
Fix #1034

After #993 increased DEFAULT_REP from 100ms to 3000ms, fast kernels (~0.05ms) compute n_repeat = int(3000/0.05) = 60,000. Building a single HIP/CUDA graph with 60,000 kernel dispatches segfaults on ROCm (gfx950/MI350X, exit code 139).

Add MAX_CUDAGRAPH_REPEAT = 1000 cap so the graph never exceeds a size that causes driver-level failures. The n_retries=10 outer replay loop already provides sufficient measurement quality.

Verified on AMD Instinct MI350X (gfx950, ROCm 7.2).

Fixes #993 regression for ROCm users.