### PR TITLE
Fixing the MI350 segfaults

### DIFF
--- a/tritonbench/components/do_bench/run.py
+++ b/tritonbench/components/do_bench/run.py
@@ -660,7 +660,7 @@ def do_bench_wrapper(
         entropy_window_size: Size of rolling window for entropy tracking
         entropy_max_samples: Maximum samples before stopping warmup (safety limit)
     """
-    if (warmup is None or rep is None) and not repcnt:
+    if (warmup is None or rep is None) and not repcnt and not use_cuda_graphs:
         estimate_runtime = estimate_cuda_runtime_ms(fn, grad_to_none=grad_to_none)
         warmup, rep = resolve_warmup_and_rep(
             warmup,

--- a/tritonbench/components/do_bench/run.py
+++ b/tritonbench/components/do_bench/run.py
@@ -660,7 +660,7 @@ def do_bench_wrapper(
         entropy_window_size: Size of rolling window for entropy tracking
         entropy_max_samples: Maximum samples before stopping warmup (safety limit)
     """
-    if (warmup is None or rep is None) and not repcnt and not use_cuda_graphs:
+    if (warmup is None or rep is None) and not repcnt and latency_measure_mode == "triton_do_bench":
         estimate_runtime = estimate_cuda_runtime_ms(fn, grad_to_none=grad_to_none)
         warmup, rep = resolve_warmup_and_rep(
             warmup,

--- a/tritonbench/components/do_bench/run.py
+++ b/tritonbench/components/do_bench/run.py
@@ -660,7 +660,11 @@ def do_bench_wrapper(
         entropy_window_size: Size of rolling window for entropy tracking
         entropy_max_samples: Maximum samples before stopping warmup (safety limit)
     """
-    if (warmup is None or rep is None) and not repcnt and latency_measure_mode == "triton_do_bench":
+    if (
+        (warmup is None or rep is None)
+        and not repcnt
+        and latency_measure_mode == "triton_do_bench"
+    ):
         estimate_runtime = estimate_cuda_runtime_ms(fn, grad_to_none=grad_to_none)
         warmup, rep = resolve_warmup_and_rep(
             warmup,


### PR DESCRIPTION
Fixes #1044
Fixes BWD-mode benchmark segfaults on AMD ROCm (gfx950/MI350X) introduced by #1040.                                 
   
  Problem                                                                                                             
                  
  #1040 added an outer estimate_cuda_runtime_ms(fn, grad_to_none=...) pre-warm in do_bench_wrapper. For BWD kernels   
  (which use retain_graph=True backward via BenchmarkOperator.get_bwd_fn), this pre-warm corrupts GPU state and causes
   the subsequent _do_bench_cudagraph_with_cache_clear HIP graph capture to segfault on ROCm.                         
                  
  Fix                                                                                                                 
  
  One-line change: skip the outer pre-warm when use_cuda_graphs=True. The cudagraph path already does its own internal
   5-event estimation and applies resolve_warmup_and_rep, so the outer call is redundant.
                                                                                                                      
  - if (warmup is None or rep is None) and not repcnt:                                                                
  + if (warmup is None or rep is None) and not repcnt and not use_cuda_graphs:
                                                                                                                      
  Validation (AMD MI350X, ROCm 7.2)                                                                                   
                                                                                                                      
  ┌────────────────┬────────┬─────────────────────────┐                                                               
  │     Kernel     │ Shapes │         Result          │
  ├────────────────┼────────┼─────────────────────────┤                                                               
  │ rms_norm-bwd   │ 5/5        │ ✅ pass (was: SIGSEGV)  │
  ├────────────────┼────────┼─────────────────────────┤                                                               
  │ layer_norm-bwd │ 10/10   │ ✅ pass (was: SIGSEGV)  │                                                               
  ├────────────────┼────────┼─────────────────────────┤                                                               
  │ rms_norm (FWD) │ 6/6        │ ✅ pass (no regression) │                                                               
  ├────────────────┼────────┼─────────────────────────┤                                                               
  │ softmax (FWD)  │ 19/19   │ ✅ pass (no regression) │
  └────────────────┴────────┴─────────────────────────┘                                                               
                  
                                                                