### PR TITLE
[compile_time] only need single input for compile time

### DIFF
--- a/benchmarks/compile_time/ci.yaml
+++ b/benchmarks/compile_time/ci.yaml
@@ -1,3 +1,4 @@
+common_args: --num-inputs 1
 fp16_addmm_fwd:
   args: --op addmm --only streamk_addmm,triton_addmm --metrics compile_time
 fp16_addmm_bwd:


### PR DESCRIPTION
In the CI, only generate single input for compile time benchmark