### PR TITLE
Create example SL-on-mast job (#1048)

### DIFF
--- a/benchmarks/common.py
+++ b/benchmarks/common.py
@@ -35,6 +35,7 @@ def setup_tritonbench_cwd():
 setup_tritonbench_cwd()
 
 
+from tritonbench.utils.env_utils import is_fbcode
 from tritonbench.utils.path_utils import REPO_PATH
 
 BENCHMARKS_OUTPUT_DIR = REPO_PATH.joinpath(".benchmarks")
@@ -67,6 +68,7 @@ def run_benchmark_config_ci(
     op: str | None = None,
     ci: bool = False,
     log_scuba: bool = False,
+    logging_group: str | None = None,
 ):
     from tritonbench.utils.run_utils import run_config, SPECIAL_CONFIG_FIELDS
     from tritonbench.utils.scuba_utils import decorate_benchmark_data, log_benchmark
@@ -99,9 +101,11 @@ def run_benchmark_config_ci(
             ),
         }
     # Run the config file w/per-benchmark extra args and callback
+    maybe_scuba_args = ["--log-scuba"] if log_scuba and is_fbcode() else []
+    maybe_logging_group = ["--logging-group", logging_group] if logging_group else []
     run_config(
         config_file=benchmark_config_file,
-        args=None,
+        args=["--worker-mode"] + maybe_scuba_args + maybe_logging_group,
         per_config_entry=per_benchmark_map,
     )
     # Reduce all operator CSV outputs to a single output json
@@ -115,11 +119,10 @@ def run_benchmark_config_ci(
     logger.info(
         f"[{benchmark_group_name}] logging result json file to {result_json_file}."
     )
-    if log_scuba:
+    # when in oss, log to scuba at the end of the run
+    if log_scuba and not is_fbcode():
         log_benchmark(aggregated_obj)
-        logger.info(
-            f"[{benchmark_group_name}] logging results to scuba table pytorch_user_benchmarks."
-        )
+        logger.info(f"[{benchmark_group_name}] logging results to scuba table.")
 
 
 def setup_output_dir(bm_name: str, ci: bool = False, output_dir: str | None = None):

--- a/tritonbench/utils/parser.py
+++ b/tritonbench/utils/parser.py
@@ -164,6 +164,11 @@ def get_parser(args=None):
         help="Run in the CI mode.",
     )
     parser.add_argument(
+        "--worker-mode",
+        action="store_true",
+        help="Indicates that the benchmark is running in the worker mode.",
+    )
+    parser.add_argument(
         "--metrics",
         default=None,
         help="Metrics to collect, split with comma. E.g., --metrics latency,tflops,speedup.",

--- a/tritonbench/utils/scuba_utils.py
+++ b/tritonbench/utils/scuba_utils.py
@@ -9,6 +9,7 @@ from collections import defaultdict
 from typing import Any, Dict, List, Optional
 
 import requests
+from tritonbench.utils.env_utils import is_fbcode
 from tritonbench.utils.gpu_utils import get_nvidia_gpu_states, has_nvidia_smi
 from tritonbench.utils.path_utils import REPO_PATH
 
@@ -166,7 +167,7 @@ def decorate_benchmark_data(
     }
     aggregated_obj = {
         "name": name,
-        "env": get_run_env(run_timestamp, repo_locs),
+        "env": get_run_env(run_timestamp, repo_locs) if not is_fbcode() else {},
         "metrics": {},
     }
     if has_nvidia_smi():


### PR DESCRIPTION
Summary:

Create an example ServiceLab-on-MAST job for Tritonbench.

This is the first step: create a Tritonbench target that runs multiple operators or benchmarks locally.

Reviewed By: hx2224

Differential Revision: D103049699


