### PR TITLE
Fix bisect with more thorough env cleanup (#1049)

### DIFF
--- a/.ci/bisect/run.sh
+++ b/.ci/bisect/run.sh
@@ -117,8 +117,12 @@ cd "${TRITONBENCH_DIR}"
 "${REPRO_CMD[@]}" 2>&1 | tee "${BASELINE_LOG}"
 
 # pre-flight check: install and run on the bad commit to validate regression exists
+# Clean up old build artifacts (if exists)
+rm -rf ${HOME}/.triton || true
+rm -rf ${TRITON_SRC_DIR}/build || true
 checkout_triton_commit "${TRITON_SRC_DIR}" "${BAD_COMMIT}"
 install_triton "${TRITON_SRC_DIR}"
+
 sudo ldconfig
 cd "${TRITONBENCH_DIR}"
 # allow the regression detector to exit with error code

--- a/.ci/bisect/run.sh
+++ b/.ci/bisect/run.sh
@@ -97,6 +97,9 @@ cd "${TRITON_SRC_DIR}"
 git checkout main
 git pull origin main
 git submodule update --init --recursive
+# Clean up old build artifacts (if exists)
+rm -rf ${HOME}/.triton || true
+rm -rf ${TRITON_SRC_DIR}/build || true
 
 # switch back to tritonbench dir
 cd "${TRITONBENCH_DIR}"

--- a/.ci/triton/triton_install_utils.sh
+++ b/.ci/triton/triton_install_utils.sh
@@ -52,11 +52,11 @@ install_triton() {
     if [ -n "${UV_VENV_DIR:-}" ]; then
         uv pip install ninja cmake wheel pybind11; # build-time dependencies
         uv pip install -r python/requirements.txt
-        uv pip install -e . --no-build-isolation
+        uv pip install -e .
     else
         pip install ninja cmake wheel pybind11; # build-time dependencies
         pip install -r python/requirements.txt
-        pip install -e . --no-build-isolation
+        pip install -e .
     fi
     cd -
 }

--- a/.github/workflows/_linux-bisect.yml
+++ b/.github/workflows/_linux-bisect.yml
@@ -68,7 +68,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: meta-pytorch/tritonparse
-          ref: main
+          ref: xz9/add-clean-install
           path: tritonparse
       - name: Install Tritonbench env
         run: |
@@ -90,7 +90,7 @@ jobs:
             echo "Unknown runner type ${RUNNER_TYPE}"
             exit 1
           fi
-          bash ./.ci/tritonbench/setup-env.sh ${CMD_SUFFIX}
+          bash ./.ci/tritonbench/setup-env.sh ${CMD_SUFFIX} --no-build
       - name: Install tritonparse
         run: |
           set -eux

--- a/.github/workflows/_linux-bisect.yml
+++ b/.github/workflows/_linux-bisect.yml
@@ -68,7 +68,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: meta-pytorch/tritonparse
-          ref: xz9/add-clean-install
+          ref: main
           path: tritonparse
       - name: Install Tritonbench env
         run: |

--- a/tritonbench/utils/constants.py
+++ b/tritonbench/utils/constants.py
@@ -1,9 +1,9 @@
 from typing import Dict, Tuple
 
 DEFAULT_WARMUP_REP_BY_ESTIMATED_KERNEL_MS: Dict[str, Tuple[int, int]] = {
-    "1": (100, 100),
-    "10": (100, 100),
-    "100": (100, 100),
+    "1": (25, 100),
+    "10": (25, 100),
+    "100": (25, 100),
 }
 DEFAULT_POWER_REPCNT = 2000
 DEFAULT_QUANTILES = [0.5, 0.1, 0.9]

--- a/tritonbench/utils/constants.py
+++ b/tritonbench/utils/constants.py
@@ -2,8 +2,8 @@ from typing import Dict, Tuple
 
 DEFAULT_WARMUP_REP_BY_ESTIMATED_KERNEL_MS: Dict[str, Tuple[int, int]] = {
     "1": (25, 100),
-    "10": (25, 100),
-    "100": (25, 100),
+    "10": (1000, 1000),
+    "100": (3000, 3000),
 }
 DEFAULT_POWER_REPCNT = 2000
 DEFAULT_QUANTILES = [0.5, 0.1, 0.9]

--- a/tritonbench/utils/constants.py
+++ b/tritonbench/utils/constants.py
@@ -2,8 +2,8 @@ from typing import Dict, Tuple
 
 DEFAULT_WARMUP_REP_BY_ESTIMATED_KERNEL_MS: Dict[str, Tuple[int, int]] = {
     "1": (100, 100),
-    "10": (1000, 1000),
-    "100": (3000, 3000),
+    "10": (100, 100),
+    "100": (100, 100),
 }
 DEFAULT_POWER_REPCNT = 2000
 DEFAULT_QUANTILES = [0.5, 0.1, 0.9]

--- a/tritonbench/utils/constants.py
+++ b/tritonbench/utils/constants.py
@@ -2,7 +2,7 @@ from typing import Dict, Tuple
 
 DEFAULT_WARMUP_REP_BY_ESTIMATED_KERNEL_MS: Dict[str, Tuple[int, int]] = {
     "1": (25, 100),
-    "10": (1000, 1000),
+    "10": (100, 400),
     "100": (3000, 3000),
 }
 DEFAULT_POWER_REPCNT = 2000


### PR DESCRIPTION
To understand whether https://github.com/meta-pytorch/tritonbench/commit/0f39f1420f0d01154bf25357b166f1b68a70aa24 causes https://github.com/meta-pytorch/tritonbench/issues/1036, revert it and see if MI350X tests still segfault.

Result:

It only causes one segfault `embedding`. The rest of the failures are persistent and caused by other Triton commits:

1. flash_attention
2. fp8_attention
3. group_gemm
4. ragged_attention
5. gdpa
