### PR TITLE
Update run.py

### DIFF
--- a/tritonbench/components/do_bench/run.py
+++ b/tritonbench/components/do_bench/run.py
@@ -666,7 +666,7 @@ def do_bench_wrapper(
     if (
         (warmup is None or rep is None)
         and not repcnt
-        and latency_measure_mode == "triton_do_bench"
+        and not use_cuda_graphs
     ):
         estimate_runtime = estimate_cuda_runtime_ms(fn, grad_to_none=grad_to_none)
         warmup, rep = resolve_warmup_and_rep(


### PR DESCRIPTION
The latency_measure_mode == "triton_do_bench" check does not help in skipping the outer pre-warm. Let us switch back to the check to when cuda_graphs are disabled