### PR TITLE
benchmark data AI export integration (#1054)

### DIFF
--- a/tritonbench/utils/parser.py
+++ b/tritonbench/utils/parser.py
@@ -484,6 +484,16 @@ def get_parser(args=None):
             default=1,
             help="Top K kernels to return for Diode. Default: 1",
         )
+        parser.add_argument(
+            "--ai-analysis",
+            action="store_true",
+            help=(
+                "Print a clickable URL after the benchmark, pre-loaded with the "
+                "run's CSV and a prompt requesting an interactive chart and a "
+                "per-shape table. Single-op single-device only in v0; ignored "
+                "with a warning for --devices, multi --op, or --side-a/--side-b."
+            ),
+        )
 
     args, extra_args = parser.parse_known_args(args)
     if args.op and args.ci:

--- a/tritonbench/utils/run_utils.py
+++ b/tritonbench/utils/run_utils.py
@@ -54,6 +54,22 @@ try:
 except ImportError:
     usage_report_logger = lambda *args, **kwargs: None
 
+try:
+    if is_fbcode():
+        from .fb.ai_analysis_export import (  # @manual
+            _gate_for_unsupported_modes as _ai_analysis_gate,
+            build_ai_analysis_url,
+            format_clickable_link as _format_ai_analysis_link,
+        )
+    else:
+        build_ai_analysis_url = lambda *args, **kwargs: None
+        _ai_analysis_gate = lambda *args, **kwargs: None
+        _format_ai_analysis_link = lambda url, label: f"{label}: {url}"
+except ImportError:
+    build_ai_analysis_url = lambda *args, **kwargs: None
+    _ai_analysis_gate = lambda *args, **kwargs: None
+    _format_ai_analysis_link = lambda url, label: f"{label}: {url}"
+
 ENV_CHECK_MAP = {
     "devices": {
         "h100": is_h100,
@@ -475,6 +491,10 @@ def tritonbench_run(args: Optional[List[str]] = None):
 
     tritonparse_init(args.tritonparse)
 
+    # Strip `--ai-analysis` from sys.argv when in unsupported modes (multi-device,
+    # multi-op, A/B) so subprocess children don't emit links into log files.
+    _ai_analysis_gate(args)
+
     if args.devices:
         run_multi_device(args, extra_args)
         tritonparse_parse(args.tritonparse)
@@ -664,6 +684,19 @@ def _run(args: argparse.Namespace, extra_args: List[str]) -> BenchmarkOperatorRe
                 metrics.write_csv_to_file(sys.stdout)
             else:
                 print(metrics)
+
+        # AI analysis link last on stdout; failure prints to stderr but never
+        # blocks `return metrics`.
+        if getattr(args, "ai_analysis", False):
+            try:
+                url = build_ai_analysis_url(metrics, args)
+                if url is not None:
+                    print("\n" + _format_ai_analysis_link(url, "Open AI Analysis"))
+            except Exception as e:  # noqa: BLE001
+                print(
+                    f"[ai-analysis] failed to build link ({e}); skipping",
+                    file=sys.stderr,
+                )
         return metrics
 
 


### PR DESCRIPTION
Summary:

This diff introduces a new flag `--ai-analysis` that the user can call to load the performance data and appropiate prompt into ai-analysis to begin analysis

example usage:
`buck2 run //pytorch/tritonbench:run -c fbcode.nvcc_arch=h100 --   --op gemm  --num-inputs 3 --ai-analysis`

{F1989170803}

It is hard to view the perfromance table when there is too much going on

Clicking into ai-analysis prompt prefills:

{F1989182944}

The viewing experience is improved and user can followup easily for further analysis

Time to response: ~2 minutes (need to improve here)

Reviewed By: xuzhao9

Differential Revision: D103314795


