### PR TITLE
Updating env_util to read from zgpu hardware type (#1057)

### DIFF
--- a/tritonbench/utils/env_utils.py
+++ b/tritonbench/utils/env_utils.py
@@ -82,6 +82,9 @@ def get_nvidia_gpu_model() -> str:
     Returns:
         str: The model of the NVIDIA GPU or empty str if not found.
     """
+    zgpu_gpu_name = os.environ.get("ZGPU_GPU_NAME", "")
+    if zgpu_gpu_name:
+        return zgpu_gpu_name
     try:
         model = subprocess.check_output(
             ["nvidia-smi", "--query-gpu=name", "--format=csv,noheader,nounits"]


### PR DESCRIPTION
Summary:

This diff modifies `env_utils` so that `get_nvidia_gpu_model()` checks the `ZGPU_HARDWARE` environment variable first (for RE, where `nvidia-smi` may be unavailable). This change is needed so functions like `is_blackwell` and `is_cuda` operate using the correct GPU environment information from `zgpu`.

Reviewed By: xuzhao9

Differential Revision: D104111216


