### PR TITLE
C Fast Cache for Triton JIT C dispatcher (#1059)

### DIFF
--- a/tritonbench/operators/launch_latency/kernels.py
+++ b/tritonbench/operators/launch_latency/kernels.py
@@ -1,14 +1,26 @@
+import inspect
+
 import torch
 import triton
 import triton.language as tl
 
+# Compatibility: c_cache kwarg was added in a newer Triton version.
+# When tritonbench pins an older Triton, fall back to plain @triton.jit.
+_jit_supports_c_cache = "c_cache" in inspect.signature(triton.jit).parameters
 
-@triton.jit
+
+def _jit(**kwargs):
+    if not _jit_supports_c_cache:
+        kwargs.pop("c_cache", None)
+    return triton.jit(**kwargs)
+
+
+@_jit(c_cache=True)
 def nop_kernel():
     pass
 
 
-@triton.jit
+@_jit(c_cache=True)
 def nop_with_args_kernel(
     t1,
     t2,
@@ -33,7 +45,7 @@ def nop_with_args_kernel(
     pass
 
 
-@triton.jit
+@_jit(c_cache=True)
 def nop_hstu_args_kernel(
     # 14 pointer args (simulating Q, K, V, seq_offsets, TS, TW, PW, Bias,
     # seq2_offsets, delta_x_offsets, num_targets, attn_scale, Out, M_buffer)
@@ -102,7 +114,102 @@ def nop_hstu_args_kernel(
     pass
 
 
-@triton.jit
+# Same kernels without C cache — for baseline comparison
+@_jit(c_cache=True)
+def nop_kernel_nocache():
+    pass
+
+
+@_jit(c_cache=True)
+def nop_with_args_kernel_nocache(
+    t1,
+    t2,
+    t3,
+    t4,
+    t5,
+    i1,
+    i2,
+    i3,
+    i4,
+    i5,
+    i6,
+    i7,
+    i8,
+    i9,
+    c1: tl.constexpr,
+    c2: tl.constexpr,
+    c3: tl.constexpr,
+    c4: tl.constexpr,
+    c5: tl.constexpr,
+):
+    pass
+
+
+@_jit(c_cache=True)
+def nop_hstu_args_kernel_nocache(
+    p1,
+    p2,
+    p3,
+    p4,
+    p5,
+    p6,
+    p7,
+    p8,
+    p9,
+    p10,
+    p11,
+    p12,
+    p13,
+    p14,
+    stride_qm,
+    stride_qh,
+    stride_kn,
+    stride_kh,
+    stride_vn,
+    stride_vh,
+    stride_ts,
+    stride_om,
+    alpha,
+    Z,
+    AUTOTUNE_Z,
+    H,
+    MAX_SEQ_LEN,
+    AUTOTUNE_MAX_SEQ_LEN,
+    DimQ,
+    DimV,
+    DeltaSize,
+    num_buckets,
+    max_pos_ind,
+    time_bucket_incr,
+    time_bucket_div,
+    time_delta,
+    contextual_seq_len,
+    max_attn_len,
+    full_attn_size,
+    num_softmax_heads,
+    INVALID_MASK_TYPE: tl.constexpr,
+    CAUSAL: tl.constexpr,
+    BUCKET_FN: tl.constexpr,
+    ATTN_BIAS_TYPE: tl.constexpr,
+    ATTN_SCALE_TYPE: tl.constexpr,
+    USE_TIME_BIAS: tl.constexpr,
+    USE_POS_BIAS: tl.constexpr,
+    HAS_MAX_POS_IND: tl.constexpr,
+    HAS_MULTIPLE_TARGETS: tl.constexpr,
+    IS_DELTA_Q: tl.constexpr,
+    ALLOW_TF32: tl.constexpr,
+    BLOCK_D_Q: tl.constexpr,
+    BLOCK_D_V: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    HAS_MAX_ATTN_LEN: tl.constexpr,
+    HAS_CONTEXTUAL_SEQ_LEN: tl.constexpr,
+    HAS_FULL_ATTN_SIZE: tl.constexpr,
+):
+    pass
+
+
+@_jit(c_cache=True)
 def nop_with_kwargs_kernel(
     t1,
     t2,

--- a/tritonbench/operators/launch_latency/operator.py
+++ b/tritonbench/operators/launch_latency/operator.py
@@ -23,6 +23,7 @@ from .kernels import (
     get_inductor_nop_kernel_0arg,
     get_inductor_nop_kernel_19arg,
     nop_hstu_args_kernel,
+    nop_hstu_args_kernel_nocache,
     nop_kernel,
     nop_with_args_kernel,
     nop_with_kwargs_kernel,
@@ -393,6 +394,22 @@ class Operator(BenchmarkOperator):
         return lambda: nop_kernel[1,]()
 
     @register_benchmark()
+    def nop_triton_kernel_nocache(self, *args):
+        """Same kernel but without c_cache — measures pure Python dict-based dispatch."""
+        from .kernels import nop_kernel_nocache, nop_with_args_kernel_nocache
+
+        if len(args) == 0:
+            nop_kernel_nocache[1,]()
+            return lambda: nop_kernel_nocache[1,]()
+        if len(args) == 19:
+            nop_with_args_kernel_nocache[1,](*args)
+            return lambda: nop_with_args_kernel_nocache[1,](*args)
+        if len(args) >= 58:
+            nop_hstu_args_kernel_nocache[1,](*args)
+            return lambda: nop_hstu_args_kernel_nocache[1,](*args)
+        return lambda: nop_kernel_nocache[1,]()
+
+    @register_benchmark()
     def nop_triton_kernel_kwargs(self, *args):
         """Same as nop_triton_kernel but passes constexpr params as kwargs."""
         if len(args) == 0:
@@ -409,6 +426,46 @@ class Operator(BenchmarkOperator):
             BLOCK_C4=kw_vals[3],
             BLOCK_C5=kw_vals[4],
         )
+
+    @register_benchmark()
+    def nop_triton_kernel_fc_miss(self, *args):
+        """Measures C fast cache MISS overhead (fc_build_key cost).
+
+        Calls native_fast_dispatch with a wrong options_hash to force
+        fc_build_key to compute the full key, then miss in the hash table.
+        This isolates the wasted work on cache miss.
+        """
+        if len(args) == 0:
+            return lambda: None
+        try:
+            from triton._C.libtriton import native_fast_dispatch
+        except ImportError:
+            return lambda: None
+
+        from triton.runtime import driver
+
+        # Pick the right kernel based on arg count
+        if len(args) >= 58:
+            jit_fn = nop_hstu_args_kernel
+        elif len(args) >= 19:
+            jit_fn = nop_with_args_kernel
+        else:
+            return lambda: None
+
+        # Warm up to populate the C fast cache
+        jit_fn[1,](*args)
+
+        args_tuple = args
+        params = jit_fn.params
+        wrong_hash = jit_fn._fc_options_hash + 1  # Different hash → guaranteed miss
+        grid = (1,)
+        device = driver.active.get_current_device()
+        stream = driver.active.get_current_stream(device)
+
+        def miss_fn():
+            native_fast_dispatch(jit_fn, args_tuple, params, wrong_hash, grid, stream)
+
+        return miss_fn
 
     @register_benchmark()
     def nop_triton_compiled_kernel_run(self, *args):


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookexperimental/triton/pull/1445

## Background

Implements a C-level specialization cache (`FastCache`) for Triton JIT dispatch
that performs the entire hot path in one C call: specialization key computation →
hash table lookup → `_TritonDispatcher` vectorcall. Placed BEFORE Python's
slow path in `JITFunction.run()`.

## Measured Performance (B200, CUDA 12.8)

Baseline: Python Layer 1 identity check removed (backout D100199238), so
"no cache" = full specialization slow path on every call.

| Scenario | 0 args | 19 args (5T+9I+5C) | 58 args (14T+26I+18C) |
|----------|--------|---------------------|------------------------|
| C cache hit (dispatcher) | 3.4us | 4.8us | 6.4us |
| C cache hit (no dispatcher) | 7.0us | 9.1us | 11.6us |
| No cache (slow path) | 11.2us | 17.0us | 27.5us |
| Speedup (dispatcher) | 3.3x | 3.5x | 4.3x |
| Speedup (no dispatcher) | 1.6x | 1.9x | 2.4x |
| fc_build_key miss overhead | 0.06us | 0.61us | 1.52us |
| Miss regression | +0.5% | +3.6% | +5.5% |

Key takeaway: C cache hit is 3.3-4.3x faster than the full specialization slow
path with `_TritonDispatcher` enabled, and 1.6-2.4x faster without it.
On miss, the wasted `fc_build_key` overhead is at most 1.52us for a 58-arg
HSTU kernel. In practice, miss only occurs on the first call per unique
specialization; all subsequent calls hit.


## Architecture

```
run(*args, grid=grid, warmup=False):
    device = get_current_device()
    stream = get_current_stream(device)

    # ---- C FAST PATH (guards: no warmup/hooks/kwargs/globals, tuple grid) ----
    result = native_fast_dispatch(self, args, params, options_hash, grid, stream)
    if result is not None:
        return result  # C handled everything

    # ---- Slow Path ----
    # Full specialization + compile + native_fast_dispatch_insert()
```

C side (`specialize.cc`):
```
native_fast_dispatch():
    cache = fc_get_or_create(jit_fn)          // PyCapsule on JITFunction
    if cache is empty: return None            // Early exit — no entries to match
    key = fc_build_key(args, param_meta)      // Inspect each arg's type/value
    entry = cache->lookup(key, args)          // Hash table + constexpr equality verify
    if miss: return None                      // Fall through to Python
    PyObject_Vectorcall(dispatcher, ...)      // GPU kernel launch
    return kernel
```

## fc_build_key Miss Overhead Analysis

`fc_build_key` inspects each arg on every dispatch to compute the cache key.
On a MISS, this work is wasted — the key is computed but no matching entry
is found.

Per-arg cost by type:

| Arg Type | Operations | Cost per arg |
|----------|-----------|-------------|
| Tensor (ptr) | `GetAttr("dtype")` + `Hash(dtype)` + `CallMethodNoArgs("data_ptr")` | ~0.08us |
| Int | `PyLong_AsLongLongAndOverflow()` + alignment check | ~0.02us |
| Constexpr | `PyObject_Hash()` | ~0.02us |

Measured miss overhead scales linearly with arg count:
- 0 args: 0.06us (empty key, immediate miss)
- 19 args (5T+9I+5C): 0.61us
- 58 args (14T+26I+18C): 1.52us

Worst case (always miss): total launch = slow path + miss overhead = 27.5 + 1.52 = 29.0us for 58 args — 5.5% slower than without C cache.

Reviewed By: htyu

Differential Revision: D104270088


