### PR TITLE
[AMD] Allow pinning Triton commits in CI setup

### DIFF
--- a/.ci/triton/install-meta-triton.sh
+++ b/.ci/triton/install-meta-triton.sh
@@ -1,3 +1,8 @@
+usage() {
+  echo "Usage: $0 [--commit <hash-or-ref>] [--no-build] [--no-clone]"
+  exit 1
+}
+
 if [ -z "${SETUP_SCRIPT}" ]; then
   echo "ERROR: SETUP_SCRIPT is not set"
   exit 1
@@ -8,9 +13,21 @@ if [ -z "${WORKSPACE_DIR:-}" ]; then
   exit 1
 fi
 
+COMMIT=main
+COMMIT_SPECIFIED=0
+
 # Parse arguments
 while [[ "$#" -gt 0 ]]; do
     case $1 in
+        --commit)
+            if [ -z "${2:-}" ]; then
+              echo "ERROR: --commit requires a value"
+              usage
+            fi
+            COMMIT="$2"
+            COMMIT_SPECIFIED=1
+            shift
+            ;;
         --no-build) NO_BUILD="1"; ;;
         --no-clone) NO_CLONE="1"; ;;
         *) echo "Unknown parameter passed: $1"; usage ;;
@@ -27,8 +44,13 @@ if [ -n "${NO_CLONE:-}" ]; then
   CMD_SUFFIX="--no-clone $CMD_SUFFIX"
 fi
 
+NIGHTLY_ARG="--nightly"
+if [ "${COMMIT_SPECIFIED}" -eq 1 ]; then
+  NIGHTLY_ARG=""
+fi
+
 
 VENV_NAME=meta-triton
 bash .ci/triton/install.sh --conda-env "${VENV_NAME}" \
-        --repo facebookexperimental/triton --commit main --side single --nightly \
+        --repo facebookexperimental/triton --commit "${COMMIT}" --side single ${NIGHTLY_ARG} \
         --install-dir ${WORKSPACE_DIR}/meta-triton ${CMD_SUFFIX}

--- a/.ci/triton/install-triton-main.sh
+++ b/.ci/triton/install-triton-main.sh
@@ -1,3 +1,8 @@
+usage() {
+  echo "Usage: $0 [--commit <hash-or-ref>] [--no-build] [--no-clone]"
+  exit 1
+}
+
 if [ -z "${SETUP_SCRIPT}" ]; then
   echo "ERROR: SETUP_SCRIPT is not set"
   exit 1
@@ -8,9 +13,21 @@ if [ -z "${WORKSPACE_DIR:-}" ]; then
   exit 1
 fi
 
+COMMIT=main
+COMMIT_SPECIFIED=0
+
 # Parse arguments
 while [[ "$#" -gt 0 ]]; do
     case $1 in
+        --commit)
+            if [ -z "${2:-}" ]; then
+              echo "ERROR: --commit requires a value"
+              usage
+            fi
+            COMMIT="$2"
+            COMMIT_SPECIFIED=1
+            shift
+            ;;
         --no-build) NO_BUILD="1"; ;;
         --no-clone) NO_CLONE="1"; ;;
         *) echo "Unknown parameter passed: $1"; usage ;;
@@ -26,7 +43,12 @@ if [ -n "${NO_CLONE:-}" ]; then
   CMD_SUFFIX="--no-clone $CMD_SUFFIX"
 fi
 
+NIGHTLY_ARG="--nightly"
+if [ "${COMMIT_SPECIFIED}" -eq 1 ]; then
+  NIGHTLY_ARG=""
+fi
+
 VENV_NAME=triton-main
 bash .ci/triton/install.sh --conda-env "${VENV_NAME}" \
-        --repo triton-lang/triton --commit main --side single --nightly \
+        --repo triton-lang/triton --commit "${COMMIT}" --side single ${NIGHTLY_ARG} \
         --install-dir ${WORKSPACE_DIR}/triton-main ${CMD_SUFFIX}

--- a/.ci/tritonbench/setup-env.sh
+++ b/.ci/tritonbench/setup-env.sh
@@ -2,6 +2,11 @@
 
 set -xeuo pipefail
 
+usage() {
+    echo "Usage: $0 [--cuda|--hip] [--triton-main] [--meta-triton] [--no-build] [--test-nvidia-driver] [--triton-main-commit <hash-or-ref>] [--meta-triton-commit <hash-or-ref>]"
+    exit 1
+}
+
 if [ -z "${WORKSPACE_DIR:-}" ]; then
     export WORKSPACE_DIR=/workspace
 fi
@@ -17,6 +22,22 @@ while [[ "$#" -gt 0 ]]; do
         --hip) USE_HIP="1"; ;;
         --triton-main) USE_TRITON_MAIN="1"; ;;
         --meta-triton) USE_META_TRITON="1"; ;;
+        --triton-main-commit)
+            if [ -z "${2:-}" ]; then
+                echo "ERROR: --triton-main-commit requires a value"
+                usage
+            fi
+            TRITON_MAIN_COMMIT="$2"
+            shift
+            ;;
+        --meta-triton-commit)
+            if [ -z "${2:-}" ]; then
+                echo "ERROR: --meta-triton-commit requires a value"
+                usage
+            fi
+            META_TRITON_COMMIT="$2"
+            shift
+            ;;
         --no-build) NO_BUILD="1"; ;;
         --test-nvidia-driver) TEST_NVIDIA_DRIVER="1"; ;;
         *) echo "Unknown parameter passed: $1"; usage ;;
@@ -82,17 +103,24 @@ if [ -n "${USE_CUDA:-}" ] && [ -n "${TEST_NVIDIA_DRIVER:-}" ]; then
     sudo apt-get purge -y '^nvidia-'
 fi
 
+COMMON_INSTALL_ARGS=()
 if [ -n "${NO_BUILD:-}" ]; then
-    CMD_SUFFIX="--no-build"
-else
-    CMD_SUFFIX=""
+    COMMON_INSTALL_ARGS+=(--no-build)
 fi
 
 if [ -n "${USE_TRITON_MAIN:-}" ]; then
-    bash ./.ci/triton/install-triton-main.sh ${CMD_SUFFIX}
+    TRITON_MAIN_INSTALL_ARGS=("${COMMON_INSTALL_ARGS[@]}")
+    if [ -n "${TRITON_MAIN_COMMIT:-}" ]; then
+        TRITON_MAIN_INSTALL_ARGS+=(--commit "${TRITON_MAIN_COMMIT}")
+    fi
+    bash ./.ci/triton/install-triton-main.sh "${TRITON_MAIN_INSTALL_ARGS[@]}"
 fi
 if [ -n "${USE_META_TRITON:-}" ]; then
-    bash ./.ci/triton/install-meta-triton.sh ${CMD_SUFFIX}
+    META_TRITON_INSTALL_ARGS=("${COMMON_INSTALL_ARGS[@]}")
+    if [ -n "${META_TRITON_COMMIT:-}" ]; then
+        META_TRITON_INSTALL_ARGS+=(--commit "${META_TRITON_COMMIT}")
+    fi
+    bash ./.ci/triton/install-meta-triton.sh "${META_TRITON_INSTALL_ARGS[@]}"
 fi
 
 cat "${SETUP_SCRIPT}"

--- a/docker/tritonbench-rocm-nightly.dockerfile
+++ b/docker/tritonbench-rocm-nightly.dockerfile
@@ -23,7 +23,7 @@ RUN git clone --recurse-submodules -b "${TRITONBENCH_BRANCH}" --single-branch \
 # Install and setup env
 # AMD will segfault on MI350 due to an LLVM bug: [llvm/llvm-project#193499](https://github.com/llvm/llvm-project/pull/193499)
 # commit 90cd5e2abb74c on llvm-head branch fixes the segfault
-RUN cd /workspace/tritonbench && bash ./.ci/tritonbench/setup-env.sh --hip --triton-main --meta-triton --triton-main-commit 90cd5e2abb74cd90b021a2ef210e9cdf3f910440
+RUN cd /workspace/tritonbench && bash ./.ci/tritonbench/setup-env.sh --hip --triton-main --meta-triton --triton-main-commit f7c1d69401e9f09050451f30776562954b05e850
 
 # Output setup script for inspection
 RUN cat "${SETUP_SCRIPT}"

--- a/docker/tritonbench-rocm-nightly.dockerfile
+++ b/docker/tritonbench-rocm-nightly.dockerfile
@@ -21,7 +21,9 @@ RUN git clone --recurse-submodules -b "${TRITONBENCH_BRANCH}" --single-branch \
     https://github.com/meta-pytorch/tritonbench /workspace/tritonbench
 
 # Install and setup env
-RUN cd /workspace/tritonbench && bash ./.ci/tritonbench/setup-env.sh --hip --triton-main --meta-triton
+# AMD will segfault on MI350 due to an LLVM bug: [llvm/llvm-project#193499](https://github.com/llvm/llvm-project/pull/193499)
+# commit 90cd5e2abb74c on llvm-head branch fixes the segfault
+RUN cd /workspace/tritonbench && bash ./.ci/tritonbench/setup-env.sh --hip --triton-main --meta-triton --triton-main-commit 90cd5e2abb74cd90b021a2ef210e9cdf3f910440
 
 # Output setup script for inspection
 RUN cat "${SETUP_SCRIPT}"


### PR DESCRIPTION
Pin AMD ROCM Docker commit to 90cd5e2abb74c, as it will fix the segfault error in trunk tests.