### PR TITLE
gpu_events: resolve None warmup/rep before use

### DIFF
--- a/tritonbench/components/do_bench/gpu_events.py
+++ b/tritonbench/components/do_bench/gpu_events.py
@@ -10,6 +10,7 @@ from tritonbench.utils.env_utils import is_hip
 from tritonbench.utils.gpu_utils import sleep_amd
 
 from .common import summarize_statistics
+from .utils import resolve_warmup_and_rep
 
 _kernel_unblock_stream = None
 
@@ -305,6 +306,7 @@ def do_bench_events(
     torch.cuda.synchronize()
 
     estimate_ms = time_events[0].elapsed_time(time_events[1]) / n_repeat
+    warmup, rep = resolve_warmup_and_rep(warmup, rep, estimate_ms)
 
     # Calculate number of warmup iterations based on target rep time
     if estimate_ms == 0:


### PR DESCRIPTION
Summary:
Followup to D103142533 (#1046), which migrated other benchmarkers to
use `resolve_warmup_and_rep` and narrowed the top-level resolution in
`do_bench_wrapper` to only run when `latency_measure_mode == "triton_do_bench"`.
`do_bench_events` was missed in that migration: it computes its own
`estimate_ms` but never resolves `warmup`/`rep` from None.

Result: `--latency-measure-mode gpu_events` (without explicit
`--warmup`/`--rep`) crashes inside `do_bench_events` at:

    n_warmup = max(1, int(warmup / estimate_ms))
    TypeError: unsupported operand type(s) for /: 'NoneType' and 'float'

Add the same `resolve_warmup_and_rep` call the other benchmarkers got,
right after `estimate_ms` is computed.

Differential Revision: D104731473


