### PR TITLE
[autoWS] add partition schedule options for FA

### DIFF
--- a/tritonbench/kernels/blackwell_triton_fused_attention_dp.py
+++ b/tritonbench/kernels/blackwell_triton_fused_attention_dp.py
@@ -223,7 +223,13 @@ def _attn_fwd_inner_oss_dp(
 
     # loop over k, v and update accumulator
     for start_n in tl.range(
-        lo, hi, BLOCK_N, warp_specialize=warp_specialize, disallow_acc_multi_buffer=True
+        lo,
+        hi,
+        BLOCK_N,
+        warp_specialize=warp_specialize,
+        merge_epilogue=True,
+        separate_epilogue_store=True,
+        disallow_acc_multi_buffer=True,
     ):
         start_n = tl.multiple_of(start_n, BLOCK_N)
 
@@ -726,7 +732,13 @@ def _attn_fwd_persist(
     )
 
     # inner loop warpspec vs. outer loop warpspec
-    for _ in tl.range(0, tiles_per_sm, warp_specialize=warp_specialize and OUTER_LOOP):
+    for _ in tl.range(
+        0,
+        tiles_per_sm,
+        warp_specialize=warp_specialize and OUTER_LOOP,
+        merge_epilogue=True,
+        separate_epilogue_store=True,
+    ):
         group_id = tile_idx // num_pid_in_group
         first_pid_n = group_id * GROUP_SIZE_N
         group_size_n = min(num_pid_n - first_pid_n, GROUP_SIZE_N)


### PR DESCRIPTION
Add loop options for partitionSchedulingMeta pass to assign correct partitions to FA (explicit data partition) kernel.

### TODO
1. Accuracy debugging. This generates the correct partition layout for FA; but still leads to a accuracy mismatch.
2. Debugging causal FA.

### Test plan

Test command:
```
CUDA_VISIBLE_DEVICES=6 TRITON_ALWAYS_COMPILE=1 TRITON_USE_META_WS=1 bash ~/fbsource/fbcode/ads_mkl/benchmarks/denoise.sh python run.py --op blackwell_attentions --seq-len 8192 --batch 4 --n-heads 32 --d-head 128 --metrics accuracy --simple-output --baseline tlx_blackwell_ws_pipelined_persistent --only tlx_blackwell_ws_pipelined_persistent,triton_tutorial_flash_dp_persistent_blackwell --force --rtol 0 --atol 1e-2
```
shows slight accuracy mismatch:
```
Mismatched elements: 363 / 134217728 (0.0%)
Greatest absolute difference: 0.03515625 at index (1, 17, 2851, 75) (up to 0.01 allowed)
Greatest relative difference: 249.0 at index (2, 13, 8045, 0) (up to 0.0 allowed)
```
Performance test:
```
CUDA_VISIBLE_DEVICES=6 TRITON_ALWAYS_COMPILE=1 TRITON_USE_META_WS=1 bash ~/fbsource/fbcode/ads_mkl/benchmarks/denoise.sh python run.py --op blackwell_attentions --seq-len 8192 --batch 4 --n-heads 32 --d-head 128 --metrics tflops --simple-output --only triton_tutorial_flash_dp_persistent_blackwell --force
```
shows
```
(Batch, Heads, Heads_KV, SeqLen, SeqLen_KV, Dhead)
----------------------------------------------------
(4, 32, 32, 8192, 8192, 128) fwd
  (Batch, Heads, Heads_KV, SeqLen, SeqLen_KV, Dhead)    triton_tutorial_flash_dp_persistent_blackwell-tflops
----------------------------------------------------  ------------------------------------------------------
                    (4, 32, 32, 8192, 8192, 128) fwd                                                 870.688
                                    870.687909806939
```