### PR TITLE
Add OKR B200 gdpa benchmark (#1070)

### DIFF
--- a/tritonbench/operators/gdpa/gdpa_blackwell_tlx.py
+++ b/tritonbench/operators/gdpa/gdpa_blackwell_tlx.py
@@ -400,7 +400,7 @@ def gdpa_kernel_tma_ws_blackwell(
 
     with tlx.async_tasks():
         # activation calculation
-        with tlx.async_task("default", registers=ACT_REGS):
+        with tlx.async_task("default"):
             accum_cnt = 0
             accum_cnt_outer = 0
             for idx in range(0, tiles_per_sm):


### PR DESCRIPTION
Summary:

Wires up OKR B200 benchmarks for the generalized_dot_product_attention
operator (gdpa fwd and bwd) with gdpa baseline + gdpa_opt and tlx_gdpa
beta backends.

- generalized_dot_product_attention/operator.py: mark gdpa_opt as
  baseline=True so the framework treats it as the canonical baseline
  in beta runs.
- fb/BUCK: add okr_gdpa_fwd and okr_gdpa_bwd to okr_b200_zgpu_ops.
- fb/benchmark_config.json: add okr_gdpa_fwd and okr_gdpa_bwd config
  entries.

Reviewed By: xuzhao9

Differential Revision: D104739805


