### PR TITLE
Add random test Shape sampling (#1071)

### DIFF
--- a/docs/data.md
+++ b/docs/data.md
@@ -6,7 +6,8 @@ In TritonBench, users can customize the input data to run. Here is an overview o
 |-----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `--input-id`          | Input ID to run, starting from 0.      Default is 0.                                                                                                                                                                 |
 | `--num-inputs`        | Number of inputs to run. By default, run all available inputs.                                                                                                                                                       |
-| `--input-sample-mode` | Input sampling mode. 'first-k' (default) uses the first k inputs starting from `--input-id`.  "'equally-spaced-k' selects k equally spaced inputs from the entire input range, where k is specified by --num-inputs. |
+| `--input-sample-mode` | Input sampling mode. `first-k` (default), `equally-spaced-k`, or `random-k`. `random-k` picks a different subset each run unless `--input-sample-seed` is set. |
+| `--input-sample-seed`  | Optional seed for `random-k` mode for reproducibility. |
 | `--input-loader`      | Specify a json file (or wildcard pattern) to load inputs from input json file(s).                                                                                                                                    |
 
 

--- a/tritonbench/operators/gdpa/gdpa_blackwell_tlx.py
+++ b/tritonbench/operators/gdpa/gdpa_blackwell_tlx.py
@@ -400,7 +400,7 @@ def gdpa_kernel_tma_ws_blackwell(
 
     with tlx.async_tasks():
         # activation calculation
-        with tlx.async_task("default", registers=ACT_REGS):
+        with tlx.async_task("default"):
             accum_cnt = 0
             accum_cnt_outer = 0
             for idx in range(0, tiles_per_sm):

--- a/tritonbench/utils/parser.py
+++ b/tritonbench/utils/parser.py
@@ -252,9 +252,16 @@ def get_parser(args=None):
         "--input-sample-mode",
         type=str,
         default="first-k",
-        choices=["first-k", "equally-spaced-k"],
+        choices=["first-k", "equally-spaced-k", "random-k"],
         help="Input sampling mode. 'first-k' (default) uses the first k inputs starting from --input-id. "
-        "'equally-spaced-k' selects k equally spaced inputs from the entire input range, where k is specified by --num-inputs.",
+        "'equally-spaced-k' selects k equally spaced inputs across the input range. "
+        "'random-k' selects k random inputs (non-deterministic by default; pass --input-sample-seed for reproducibility).",
+    )
+    parser.add_argument(
+        "--input-sample-seed",
+        type=int,
+        default=None,
+        help="Optional seed for --input-sample-mode random-k. If unset, each run picks a different subset.",
     )
     parser.add_argument(
         "--test-only",

--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -861,10 +861,10 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
                     f"When specifying multiple IDs (e.g., --input-id 0,2,4), the number of inputs "
                     f"is determined by the number of IDs provided ({len(self._input_ids)} in this case)."
                 )
-            if self._input_sample_mode == "equally-spaced-k":
+            if self._input_sample_mode in ("equally-spaced-k", "random-k"):
                 raise ValueError(
-                    f"Cannot use --input-sample-mode equally-spaced-k with multiple input IDs. "
-                    f"Either specify multiple IDs directly or use equally-spaced-k with --num-inputs."
+                    f"Cannot use --input-sample-mode {self._input_sample_mode} with multiple input IDs. "
+                    f"Either specify multiple IDs directly or use {self._input_sample_mode} with --num-inputs."
                 )
             # Validate that all IDs are within range
             invalid_ids = [
@@ -911,6 +911,33 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
             print(
                 f"Equally-spaced-k mode: Selected {len(self._input_ids)} equally spaced inputs (total available: {self._available_num_inputs})",
                 file=sys.stderr,
+            )
+        elif self._input_sample_mode == "random-k":
+            if self._num_inputs is None:
+                raise ValueError(
+                    "--num-inputs must be specified when using --input-sample-mode random-k"
+                )
+            if self._input_ids[0] != 0:
+                raise ValueError(
+                    "--input-id must be 0 or omitted when using --input-sample-mode random-k"
+                )
+
+            if self._num_inputs > self._available_num_inputs:
+                logger.warning(
+                    f"Requested {self._num_inputs} inputs but only {self._available_num_inputs} available. "
+                    f"Using all available inputs.",
+                )
+                self._num_inputs = self._available_num_inputs
+
+            # Dedicated Random instance so we don't reuse the globally-seeded MAIN_RANDOM_SEED.
+            sampler = random.Random(self.tb_args.input_sample_seed)
+            self._input_ids = sorted(
+                sampler.sample(range(self._available_num_inputs), self._num_inputs)
+            )
+
+            logger.warning(
+                f"Random-k mode: Selected {len(self._input_ids)} random inputs "
+                f"(total available: {self._available_num_inputs}, seed={self.tb_args.input_sample_seed})",
             )
         else:
             # First-k mode (default) - construct sequential range based on start ID and num_inputs


### PR DESCRIPTION
Summary:

Adds a `random-k` sampling mode for Tritonbench input selection to enable evaluating benchmark performance across a randomly distributed subset of inputs. This allows for representative coverage without running the entire input suite, and includes seed support for reproducibility.

Reviewed By: xuzhao9

Differential Revision: D104881575


