### PR TITLE
Suppress `--diode-version` default when `--diode-model-config` is passed in (#1072)

### DIFF
--- a/benchmarks/compare_benchmarks/run.py
+++ b/benchmarks/compare_benchmarks/run.py
@@ -58,16 +58,11 @@ def build_op_args(
     ]
 
     if config.custom_bench == "diode" and "diode" in benchmark_name:
-        args.extend(
-            [
-                "--diode-version",
-                config.diode_version,
-                "--diode-topk",
-                str(config.diode_topk),
-            ]
-        )
         if config.diode_model_config is not None:
             args.extend(["--diode-model-config", config.diode_model_config])
+        else:
+            args.extend(["--diode-version", config.diode_version])
+        args.extend(["--diode-topk", str(config.diode_topk)])
 
     return args
 


### PR DESCRIPTION
Summary:

Suppress `--diode-version` default when `--diode-model-config` is passed in, since `diode_model_config` overrides `diode_version`. The earlier version can be misleading, since it is possible to misunderstand that `--diode-version` is being used instead of `--diode-model-config`.

Successful nightly job: f1081950092

Reviewed By: xuzhao9, warrendeng

Differential Revision: D104918154


