### PR TITLE
Log Diode version from diode_model_config if applicable (#1073)

### DIFF
--- a/benchmarks/compare_benchmarks/run.py
+++ b/benchmarks/compare_benchmarks/run.py
@@ -58,16 +58,11 @@ def build_op_args(
     ]
 
     if config.custom_bench == "diode" and "diode" in benchmark_name:
-        args.extend(
-            [
-                "--diode-version",
-                config.diode_version,
-                "--diode-topk",
-                str(config.diode_topk),
-            ]
-        )
         if config.diode_model_config is not None:
             args.extend(["--diode-model-config", config.diode_model_config])
+        else:
+            args.extend(["--diode-version", config.diode_version])
+        args.extend(["--diode-topk", str(config.diode_topk)])
 
     return args
 

--- a/benchmarks/compare_benchmarks/utils.py
+++ b/benchmarks/compare_benchmarks/utils.py
@@ -1,6 +1,7 @@
 """Utils for compare_benchmarks custom TritonBench benchmark"""
 
 import asyncio
+import json
 import logging
 import os
 from dataclasses import dataclass, field
@@ -170,6 +171,13 @@ def log_benchmark(
     triton_type = get_triton_type()
     diode_version = getattr(config, "diode_version", None)
     diode_topk = getattr(config, "diode_topk", None)
+    diode_model_config_str = getattr(config, "diode_model_config", None)
+    if diode_model_config_str is not None:
+        try:
+            parsed = json.loads(diode_model_config_str)
+            diode_version = parsed.get("feature_version", diode_version)
+        except (json.JSONDecodeError, TypeError):
+            pass
 
     async def log_row(row: pd.Series) -> None:
         try:


### PR DESCRIPTION
Summary:

If a specific `diode_model_config` is used, log the `feature_version` from the model config rather than from the default `diode_version`.

Successful nightly job: f1081950092

Reviewed By: xuzhao9

Differential Revision: D104921413


