### PR TITLE
Enable C fast cache for autotuned kernels (#1074)

### DIFF
--- a/tritonbench/operators/launch_latency/kernels.py
+++ b/tritonbench/operators/launch_latency/kernels.py
@@ -239,6 +239,105 @@ def make_tensordesc_inputs(m_block: int = 8, n_block: int = 32):
     return out, desc, M, N, m_block, n_block
 
 
+# --- Autotuned kernel for benchmarking c_cache + autotune interaction ---
+
+
+@triton.autotune(
+    configs=[
+        triton.Config(
+            {
+                "BLOCK_C1": 32,
+                "BLOCK_C2": 32,
+                "BLOCK_C3": 32,
+                "BLOCK_C4": 32,
+                "BLOCK_C5": 32,
+            }
+        ),
+        triton.Config(
+            {
+                "BLOCK_C1": 64,
+                "BLOCK_C2": 64,
+                "BLOCK_C3": 64,
+                "BLOCK_C4": 64,
+                "BLOCK_C5": 64,
+            }
+        ),
+    ],
+    key=[],
+)
+@_jit(c_cache=True)
+def nop_autotuned_kernel(
+    t1,
+    t2,
+    t3,
+    t4,
+    t5,
+    i1,
+    i2,
+    i3,
+    i4,
+    i5,
+    i6,
+    i7,
+    i8,
+    i9,
+    BLOCK_C1: tl.constexpr,
+    BLOCK_C2: tl.constexpr,
+    BLOCK_C3: tl.constexpr,
+    BLOCK_C4: tl.constexpr,
+    BLOCK_C5: tl.constexpr,
+):
+    pass
+
+
+@triton.autotune(
+    configs=[
+        triton.Config(
+            {
+                "BLOCK_C1": 32,
+                "BLOCK_C2": 32,
+                "BLOCK_C3": 32,
+                "BLOCK_C4": 32,
+                "BLOCK_C5": 32,
+            }
+        ),
+        triton.Config(
+            {
+                "BLOCK_C1": 64,
+                "BLOCK_C2": 64,
+                "BLOCK_C3": 64,
+                "BLOCK_C4": 64,
+                "BLOCK_C5": 64,
+            }
+        ),
+    ],
+    key=[],
+)
+@_jit(c_cache=False)
+def nop_autotuned_kernel_nocache(
+    t1,
+    t2,
+    t3,
+    t4,
+    t5,
+    i1,
+    i2,
+    i3,
+    i4,
+    i5,
+    i6,
+    i7,
+    i8,
+    i9,
+    BLOCK_C1: tl.constexpr,
+    BLOCK_C2: tl.constexpr,
+    BLOCK_C3: tl.constexpr,
+    BLOCK_C4: tl.constexpr,
+    BLOCK_C5: tl.constexpr,
+):
+    pass
+
+
 @_jit(c_cache=True)
 def nop_with_kwargs_kernel(
     t1,

--- a/tritonbench/operators/launch_latency/operator.py
+++ b/tritonbench/operators/launch_latency/operator.py
@@ -23,6 +23,8 @@ from .kernels import (
     get_inductor_nop_kernel_0arg,
     get_inductor_nop_kernel_19arg,
     make_tensordesc_inputs,
+    nop_autotuned_kernel,
+    nop_autotuned_kernel_nocache,
     nop_hstu_args_kernel,
     nop_hstu_args_kernel_nocache,
     nop_kernel,
@@ -436,6 +438,23 @@ class Operator(BenchmarkOperator):
             BLOCK_C4=kw_vals[3],
             BLOCK_C5=kw_vals[4],
         )
+
+    @register_benchmark()
+    def nop_triton_kernel_autotuned(self, *args):
+        """Autotuned kernel — measures autotune + c_cache interaction."""
+        if len(args) != 19:
+            return lambda: nop_kernel[1,]()
+        # Warmup: trigger autotune config selection
+        nop_autotuned_kernel[(1,)](*args[:14])
+        return lambda: nop_autotuned_kernel[(1,)](*args[:14])
+
+    @register_benchmark()
+    def nop_triton_kernel_autotuned_nocache(self, *args):
+        """Autotuned kernel without c_cache — baseline for autotune overhead."""
+        if len(args) != 19:
+            return lambda: nop_kernel[1,]()
+        nop_autotuned_kernel_nocache[(1,)](*args[:14])
+        return lambda: nop_autotuned_kernel_nocache[(1,)](*args[:14])
 
     @register_benchmark()
     def nop_triton_kernel_fc_miss(self, *args):


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookexperimental/triton/pull/1512

Autotuned kernels (`triton.autotune` + `triton.jit(c_cache=True)`) previously never used the C fast cache because `Autotuner.run()` called `self.fn.run()` directly, bypassing `JITFunction.__getitem__()` → `JITCacheProxy`. This diff fixes the `Autotuner` to redirect through the C fast path on steady-state calls.


## Background

The Triton C fast cache (`JITCacheProxy` in `specialize.cc`) intercepts kernel launches at `JITFunction.__getitem__(grid)`, returning a C proxy that does:
1. `fc_build_key()` — O(1) cache key from raw arg pointers
2. `cache->lookup()` — hash table hit
3. `dispatcher(grid, stream, *args)` — direct `cuLaunchKernelEx`

This bypasses ~15 us of Python overhead (binder, specialization, dict lookup, grid eval).

### Before (broken)

```
kernel[(grid,)](*args)
  → KernelInterface.__getitem__(grid)
    → getattr(self, 'c_cache', False)  # self = Autotuner → False!
    → returns lambda → Autotuner.run()
      → self.cache[key] → config
      → self.fn.run(*args, **kwargs, **config.all_kwargs())  ← full Python path
```

`c_cache` is set on the inner `JITFunction`, but `__getitem__` is called on the `Autotuner` wrapper which doesn't have it. Result: **c_cache=True on autotuned kernels was dead code.**

### After (fixed)

```
kernel[(grid,)](*args)
  → KernelInterface.__getitem__(grid)
    → returns lambda → Autotuner.run()
      → self.cache[key] → config
      → self.fn[grid](*full_positional_args)  ← NEW: goes through JITCacheProxy
        → C fast cache HIT → dispatcher → cuLaunchKernelEx
```

On steady-state (config already selected), `Autotuner.run()` now builds the full positional arg list (user args + config constexprs) and calls `self.fn[grid](...)`, which returns a `JITCacheProxy` and dispatches entirely in C.


## Results

x_val=19 (5 tensors + 9 scalars + 5 constexprs):

| Benchmark | Before | After | Improvement |
|---|---|---|---|
| `nop_triton_kernel` (no autotune, c_cache) | 4.9 us | 4.9 us | baseline |
| `nop_triton_kernel_autotuned` (autotune + c_cache) | **21.2 us** | **16.7 us** | **1.27x faster** |
| `nop_triton_kernel_autotuned_nocache` | 27.1 us | 27.3 us | unchanged |

Remaining ~12 us gap vs non-autotuned (4.9 us) is `Autotuner.run()` Python overhead (dict zip, key build, config lookup, arg list construction). Eliminating that requires a C-level autotune proxy (future work).

Reviewed By: htyu

Differential Revision: D104917209


