### PR TITLE
Support TensorDescriptor (TMA path) in C dispatcher + C fast cache (#1075)

### DIFF
--- a/tritonbench/operators/launch_latency/kernels.py
+++ b/tritonbench/operators/launch_latency/kernels.py
@@ -3,6 +3,7 @@ import inspect
 import torch
 import triton
 import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
 
 # Compatibility: c_cache kwarg was added in a newer Triton version.
 # When tritonbench pins an older Triton, fall back to plain @triton.jit.
@@ -207,6 +208,35 @@ def nop_hstu_args_kernel_nocache(
     HAS_FULL_ATTN_SIZE: tl.constexpr,
 ):
     pass
+
+
+@_jit(c_cache=True)
+def nop_tensordesc_kernel(
+    out_ptr, desc, M, N, M_BLOCK: tl.constexpr, N_BLOCK: tl.constexpr
+):
+    block = desc.load([0, 0])
+    idx = tl.arange(0, M_BLOCK)[:, None] * N_BLOCK + tl.arange(0, N_BLOCK)[None, :]
+    tl.store(out_ptr + idx, block)
+
+
+@_jit(c_cache=False)
+def nop_tensordesc_kernel_nocache(
+    out_ptr, desc, M, N, M_BLOCK: tl.constexpr, N_BLOCK: tl.constexpr
+):
+    block = desc.load([0, 0])
+    idx = tl.arange(0, M_BLOCK)[:, None] * N_BLOCK + tl.arange(0, N_BLOCK)[None, :]
+    tl.store(out_ptr + idx, block)
+
+
+def make_tensordesc_inputs(m_block: int = 8, n_block: int = 32):
+    M = m_block * 3
+    N = n_block * 4
+    t = torch.zeros((M, N), device="cuda", dtype=torch.float16)
+    out = torch.zeros((m_block, n_block), device="cuda", dtype=torch.float16)
+    desc = TensorDescriptor(
+        t, shape=t.shape, strides=t.stride(), block_shape=[m_block, n_block]
+    )
+    return out, desc, M, N, m_block, n_block
 
 
 @_jit(c_cache=True)

--- a/tritonbench/operators/launch_latency/operator.py
+++ b/tritonbench/operators/launch_latency/operator.py
@@ -22,9 +22,12 @@ from .kernels import (
     get_inductor_nop_kernel,
     get_inductor_nop_kernel_0arg,
     get_inductor_nop_kernel_19arg,
+    make_tensordesc_inputs,
     nop_hstu_args_kernel,
     nop_hstu_args_kernel_nocache,
     nop_kernel,
+    nop_tensordesc_kernel,
+    nop_tensordesc_kernel_nocache,
     nop_with_args_kernel,
     nop_with_kwargs_kernel,
 )
@@ -360,6 +363,8 @@ class Operator(BenchmarkOperator):
         hstu_scalars = [1 for _ in range(26)]
         hstu_constexprs = [1 for _ in range(18)]
         yield tuple([*hstu_ptrs, *hstu_scalars, *hstu_constexprs])
+        # TensorDescriptor input: (desc, out_ptr)
+        yield make_tensordesc_inputs()
 
     def get_x_val(self, example_inputs) -> float:
         return len(example_inputs)
@@ -391,6 +396,8 @@ class Operator(BenchmarkOperator):
             return lambda: nop_with_args_kernel[1,](*args)
         if len(args) >= 58:
             return lambda: nop_hstu_args_kernel[1,](*args)
+        if len(args) == 6 and args[1].__class__.__name__ == "TensorDescriptor":
+            return lambda: nop_tensordesc_kernel[(1,)](*args)
         return lambda: nop_kernel[1,]()
 
     @register_benchmark()
@@ -407,6 +414,9 @@ class Operator(BenchmarkOperator):
         if len(args) >= 58:
             nop_hstu_args_kernel_nocache[1,](*args)
             return lambda: nop_hstu_args_kernel_nocache[1,](*args)
+        if len(args) == 6 and args[1].__class__.__name__ == "TensorDescriptor":
+            nop_tensordesc_kernel_nocache[(1,)](*args)
+            return lambda: nop_tensordesc_kernel_nocache[(1,)](*args)
         return lambda: nop_kernel_nocache[1,]()
 
     @register_benchmark()
@@ -449,11 +459,16 @@ class Operator(BenchmarkOperator):
             jit_fn = nop_hstu_args_kernel
         elif len(args) >= 19:
             jit_fn = nop_with_args_kernel
+        elif len(args) == 6 and args[1].__class__.__name__ == "TensorDescriptor":
+            jit_fn = nop_tensordesc_kernel
         else:
             return lambda: None
 
         # Warm up to populate the C fast cache
-        jit_fn[1,](*args)
+        if jit_fn is nop_tensordesc_kernel:
+            jit_fn[(1,)](*args)
+        else:
+            jit_fn[1,](*args)
 
         args_tuple = args
         params = jit_fn.params

--- a/tritonbench/utils/input.py
+++ b/tritonbench/utils/input.py
@@ -23,6 +23,14 @@ def input_cast(cond, action, example_inputs):
         return example_inputs
     elif isinstance(example_inputs, BlockMask):
         return example_inputs
+    # Triton TensorDescriptor is a non-primitive runtime object that should be
+    # passed through unchanged during input casting.
+    elif (
+        example_inputs.__class__.__name__ == "TensorDescriptor"
+        and hasattr(example_inputs, "base")
+        and hasattr(example_inputs, "block_shape")
+    ):
+        return example_inputs
     # FlexAttention passes around functions as inputs
     elif callable(example_inputs):
         return example_inputs


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookexperimental/triton/pull/1514

D103107874 (2b/N) introduced `_TritonDispatcher` and `_TensorDescDispatcherWrapper`
for host-side TensorDescriptor expansion. D104270088 (2c/N) introduced the C fast
cache (`FastCache` + `JITCacheProxy`). D104436377 (2d/N) added the tensor access
bridge and tensor detection in the cache's fallback branch.

### Fixing TMA cache misses

However, **TMA-path TensorDescriptors** (B200 GPU, `tensordesc_meta` ≠ None) had
two independent failures that combined to completely defeat the cache:

1. **Dispatcher creation failed**: `_expand_schema_arg_types()` returned `None, None`
   for TMA path, so `kernel._dispatcher = None`. Even when the cache hit,
   `entry->dispatcher == NULL` forced fallback to Python.

2. **Cache key construction had PyErr pollution**: When TensorDescriptor (which lacks
   `.dtype`) reached the tensor-detection fallback branch (2d/N),
   `fc_get_tensor_type_code` left a dangling `PyErr` from the failed
   `PyObject_GetAttr`. Additionally, unrecognized types left zeroed slots that could
   produce false cache hits across different arg types at the same position.

Additionally, even after fixing these bugs, the Python `_TensorDescDispatcherWrapper`
still added ~2.8us overhead per launch (Python iteration, object creation, method
calls for `make_tensordesc_arg`).

### Further Optimization

Move TMA expansion entirely into C and use the torch bridge for fast field extraction:

1. **New type codes**: `EXTRACTOR_TENSORDESC_INDEX = 15` (raw TensorDescriptor
   → expand in C) and `EXTRACTOR_SKIP_INDEX = 16` (shadow slots filled by
   the TENSORDESC handler, skipped in Python arg iteration).

2. **`TMASlotMeta` struct**: Per-slot metadata (swizzle, elem_size, elem_type,
   ndim, block_size, shape/stride param indices) plus per-slot TMA descriptor
   cache (keyed by data_ptr + shape + strides).

3. **Bridge integration**: Uses `g_td_bridge->extract_tensordesc()` from 2d/N
   to bypass `PyObject_GetAttrString` for `.base`, `.shape`, `.strides` —
   directly reads from the dataclass `__dict__` with interned keys and calls
   `THPVariable_Unpack` for data_ptr. Falls back to slow Python C-API when
   bridge unavailable.

4. **TMA descriptor cache**: On each call, compares (data_ptr, shape[], strides[])
   against cached values. On hit, reuses the existing CUtensorMap (skips
   `cuTensorMapEncodeTiled`). On miss, rebuilds the descriptor in-place.

5. **`num_user_args` vs `num_args`**: Separate count of Python-visible args
   from total kernel param slots (which include shadow SKIP slots).

6. **Cache key fix**: `fc_get_tensor_type_code` now calls `PyErr_Clear()` when
   TensorDescriptor lacks `.dtype`, and falls through to `fc_hash_tensordesc()`
   for proper cache key construction.

The Python-side `_TensorDescDispatcherWrapper` is now only used for host-side
TensorDescriptors (meta=None). TMA kernels return the raw C dispatcher directly.

### Code path changes

**Before (TMA TensorDescriptor kernel on B200):**
```
First call:
  JITCacheProxy → fc_build_key → cache MISS → Python run() → compiles kernel
    → make_triton_dispatcher(schema)
        → _expand_schema_arg_types: meta≠None → return None, None  ← BUG
    → kernel._dispatcher = None

Subsequent calls:
  JITCacheProxy → fc_build_key → cache HIT
    → entry->dispatcher == NULL  ← stored as None
    → goto fallback → Python run() every time (~32 us)
```

**After:**
```
First call:
  JITCacheProxy → fc_build_key → cache MISS → Python run() → compiles kernel
    → make_triton_dispatcher(schema)
        → builds tma_meta list, replaces type codes with 15/16
        → _TritonDispatcher(func_ptr, ..., tma_meta=tma_meta_list)
    → kernel._dispatcher = c_dispatcher (non-None)

Subsequent calls:
  JITCacheProxy → fc_build_key → cache HIT
    → entry->dispatcher = c_dispatcher (non-NULL)
    → c_dispatcher.__call__(grid, stream, *kernel_args)
        → td_convert_args:
            EXTRACTOR_TENSORDESC_INDEX:
              → g_td_bridge->extract_tensordesc(a, ...)  [~50ns via bridge]
              → check cache (data_ptr + shape + strides)
              → HIT: reuse CUtensorMap
              → MISS: cuTensorMapEncodeTiled → update cache
            EXTRACTOR_SKIP_INDEX: skip
        → cuLaunchKernelEx (~5.8 us total)
```

### Performance

| x_val (args) | Before (broken cache) | Bug fix only (Python wrapper) | After (C expansion + bridge) | No-cache baseline |
|-------|------|------|------|------|
| 0  | 3.3us | 3.3us | 3.3us | 8.5us |
| 19 | 4.5us | 4.5us | 4.5us | 13.5us |
| 58 | 6.2us | 6.2us | 6.2us | 24us |
| 6 (TMA) | 32.6us | 8.6us | **5.6us** | 14.8us |

TMA launch latency: 32.6us → 8.6us (bug fix) → **5.6us** (C expansion + bridge).
Overall 82% improvement / 5.6× speedup vs the broken state. The bug fixes alone
bring it from 32.6us to 8.6us by enabling the cache + Python wrapper. The C-level
TMA expansion + bridge further reduces to ~5.8us by eliminating Python overhead
(no wrapper, direct field extraction, in-C descriptor caching).
No regression on non-TMA paths.

Reviewed By: htyu

Differential Revision: D104909930


