### PR TITLE
Add file paths to the tagging system (#1076)

### DIFF
--- a/benchmarks/tagging/ast_analyzer.py
+++ b/benchmarks/tagging/ast_analyzer.py
@@ -381,7 +381,8 @@ class CallGraph(ast.NodeVisitor):
                     isinstance(fn.value.func, ast.Name)
                     and fn.value.func.id == "capture_triton"
                 ) or (
-                    isinstance(fn.value.func.value, ast.Attribute)
+                    isinstance(fn.value.func, ast.Attribute)
+                    and isinstance(fn.value.func.value, ast.Attribute)
                     and fn.value.func.value.attr == "_library"
                     and fn.value.func.attr == "capture_triton"
                 ):
@@ -394,6 +395,13 @@ class CallGraph(ast.NodeVisitor):
                     else:
                         callee_func = "unknown"
                     callee = f"<torch._library.capture_triton({callee_func})>"
+                else:
+                    if isinstance(fn.value.func, ast.Name):
+                        callee = self._resolve_name(fn.value.func.id)
+                    elif isinstance(fn.value.func, ast.Attribute):
+                        callee = self._resolve_attr(fn.value.func)
+                    else:
+                        callee = "<dynamic_call>"
             else:
                 callee = "<dynamic_call>"
             maybe_triton = True  # FIXME: this could also be cute, see blackwell_attentions cute dsl
@@ -404,30 +412,47 @@ class CallGraph(ast.NodeVisitor):
         self.generic_visit(node)
 
 
-def validate_edges(edges) -> Dict[str, str]:
+def _strip_link_tree_prefix(path: str) -> str:
+    marker = "#link-tree/"
+    idx = path.find(marker)
+    if idx != -1:
+        return path[idx + len(marker) :]
+    return path
+
+
+def validate_edges(edges, source_file: str = "") -> Dict[str, str]:
+    source_file = _strip_link_tree_prefix(source_file) if source_file else ""
     result_tags = {}
     result_tags["tags"] = []
     result_tags["kernels"] = []
+    result_tags["files"] = []
     for edge in edges:
         if edge.callee == "cutlass.cute.compile":
             result_tags["tags"].append("cutedsl")
             result_tags["kernels"].append(edge.caller)
+            if source_file:
+                result_tags["files"].append(source_file)
         if edge.callee_descriptor and (
             "triton.jit" in edge.callee_descriptor.decorators
             or "<dynamic_decorator_triton.jit>" in edge.callee_descriptor.decorators
         ):
             result_tags["tags"].append("triton")
             result_tags["kernels"].append(edge.callee)
+            if source_file:
+                result_tags["files"].append(source_file)
         if edge.callee.startswith("<torch._library.capture_triton"):
             result_tags["tags"].append("triton")
             result_tags["kernels"].append(edge.callee)
+            if source_file:
+                result_tags["files"].append(source_file)
         if (
             edge.callee.startswith("torch.ops.")
             and not "cutedsl" in result_tags["tags"]
         ):
             result_tags["tags"].append("native_custom_ops")
-            # definition is in cpp, so we don't have the definition site
             result_tags["kernels"].append(edge.callee)
+            if source_file:
+                result_tags["files"].append(source_file)
         if edge.callee.startswith("triton.experimental.gluon"):
             result_tags["tags"].append("gluon")
         if edge.callee.startswith("torch.nn."):
@@ -436,6 +461,8 @@ def validate_edges(edges) -> Dict[str, str]:
         if edge.callee.startswith("tilelang.compile"):
             result_tags["tags"].append("tilelang")
             result_tags["kernels"].append(edge.caller)
+            if source_file:
+                result_tags["files"].append(source_file)
         if "torch.ops.fbgemm" in edge.callee:
             result_tags["tags"].append("fbgemm")
         if "torch.ops.mslk" in edge.callee:
@@ -448,11 +475,16 @@ def validate_edges(edges) -> Dict[str, str]:
         ):
             result_tags["tags"].append("triton")
             result_tags["kernels"].append(edge.callee)
+            if source_file:
+                result_tags["files"].append(source_file)
     # remove duplicates
     result_tags["tags"] = list(set(result_tags["tags"]))
     result_tags["kernels"] = list(set(result_tags["kernels"]))
+    result_tags["files"] = list(set(result_tags["files"]))
     if not result_tags["kernels"] and not result_tags["tags"]:
         return None
+    if not result_tags["files"]:
+        del result_tags["files"]
     return result_tags
 
 
@@ -567,7 +599,7 @@ def trace_callees(callees_with_module: List[Tuple[str, str]], depth=8):
         # get next level callees
         print(cg.edges)
         # validate the edges: if any of them uses triton, apply triton tag and stop searching
-        tags = validate_edges(cg.edges)
+        tags = validate_edges(cg.edges, source_file=source_file)
         if tags:
             return tags
         next_level_callees = [edge.callee for edge in cg.edges]

--- a/benchmarks/tagging/run.py
+++ b/benchmarks/tagging/run.py
@@ -18,7 +18,6 @@ logging.basicConfig(level=logging.INFO)
 
 from ..common import setup_tritonbench_cwd
 
-
 setup_tritonbench_cwd()
 
 import inspect
@@ -128,7 +127,11 @@ def merge_decorator_tags(op_name, backend_name, tags_dict):
     return tags_dict
 
 
-def prevalidate_backends(backend_edges, op_name=None):
+def prevalidate_backends(backend_edges, op_name=None, opbench_file=None):
+    if opbench_file:
+        from .ast_analyzer import _strip_link_tree_prefix
+
+        opbench_file = _strip_link_tree_prefix(opbench_file)
     op_with_tags = {}
     # heuristic: do not search torch.nn, torch.compile, and xformers backends
     for backend, callees in backend_edges.items():
@@ -148,6 +151,8 @@ def prevalidate_backends(backend_edges, op_name=None):
                 "tags": ["native_custom_ops"],
                 "kernels": custom_op_category,
             }
+            if opbench_file:
+                op_with_tags[backend]["files"] = [opbench_file]
             if any(["fbgemm" in callee for callee in callees]):
                 op_with_tags[backend]["tags"].append("fbgemm")
             if any(["mslk" in callee for callee in callees]):
@@ -169,7 +174,11 @@ def prevalidate_backends(backend_edges, op_name=None):
 
 def trace_op(op):
     op_with_tags = {op: {}}
-    opbench = load_operator_by_args(task_args=["--op", op])
+    try:
+        opbench = load_operator_by_args(task_args=["--op", op])
+    except (ModuleNotFoundError, NotImplementedError) as e:
+        logger.warning(f"Failed to load operator '{op}': {e}. Skipping.")
+        return op_with_tags
     opbench_file = inspect.getfile(opbench.__class__)
     opbench_file_name = Path(opbench_file).name
     module_name = opbench.__module__
@@ -187,7 +196,9 @@ def trace_op(op):
         backends=backends,
     )
     assert len(backend_edges) == len(backends)
-    op_with_tags[op] = prevalidate_backends(backend_edges, op_name=op)
+    op_with_tags[op] = prevalidate_backends(
+        backend_edges, op_name=op, opbench_file=opbench_file
+    )
     remaining_backends = [
         backend for backend in backends if backend not in op_with_tags[op]
     ]

--- a/tritonbench/operators/fp8_fused_quant_gemm_rowwise/operator.py
+++ b/tritonbench/operators/fp8_fused_quant_gemm_rowwise/operator.py
@@ -19,12 +19,12 @@ try:
         silu_mul,
         silu_mul_fp8_rowwise_quant,
     )
-    from mslk.quantize.triton.fp8_quantize import quantize_fp8_row
 
     HAS_FB_IMPORT = True
 except ImportError:
     HAS_FB_IMPORT = False
 
+from mslk.quantize.triton.fp8_quantize import quantize_fp8_row
 from tritonbench.utils.triton_op import (
     BenchmarkOperator,
     BenchmarkOperatorMetrics,

--- a/tritonbench/operators/jsd/operator.py
+++ b/tritonbench/operators/jsd/operator.py
@@ -63,6 +63,8 @@ class Operator(BenchmarkOperator):
         self.B = 4
         self.T = 2048
         self.baseline_op = TorchJSD()
+        if LigerJSD is None:
+            raise NotImplementedError("LigerJSD is not available")
         self.liger_op = LigerJSD()
 
     def get_input_iter(self) -> Generator:


### PR DESCRIPTION
Summary:

We need to track the file paths in the tagging system so that we can join by (kernel_name, file_name) as primary key with durin/tritonparse extractions.

Update `meta-cuda-kernels.yaml` to include the latest triton kernels and their files

The tags will map a tritonbench backend to the triton/tlx/helion/cutedsl/gluon kernel name together with its source file path.

Reviewed By: sfzhu93

Differential Revision: D104921328


