### PR TITLE
[autoWS][unify tests 1/N] add FA dp benchmark from triton tutorial

### DIFF
--- a/tritonbench/operators/blackwell_attentions/operator.py
+++ b/tritonbench/operators/blackwell_attentions/operator.py
@@ -163,6 +163,14 @@ except Exception:
     HAS_TRITON_AUTOWS_FA = False
 
 try:
+    HAS_TRITON_AUTOWS_FA_DP = True
+    from triton.language.extra.tlx.tutorials.fused_attention_ws_device_tma_dp import (
+        attention as autows_blackwell_dp,
+    )
+except Exception:
+    HAS_TRITON_AUTOWS_FA_DP = False
+
+try:
     from hammer.v2.ops.triton.template.tlx_bw_hstu_attention import (
         tlx_bw_hstu_mha_wrapper,
     )
@@ -739,6 +747,25 @@ class Operator(BenchmarkOperator):
                 1,  # VECT_MUL for fwd [0, 1]
                 False,  # FADD2_REDUCE for fwd
                 False,  # early_tma_store_lowering for bwd
+            )
+
+        return preproc_noop, fn
+
+    @register_benchmark(
+        enabled=is_blackwell() and HAS_TRITON_AUTOWS_FA_DP, fwd_only=True
+    )
+    @multi_input_wrapper
+    def triton_autows_flash_dp_persistent_blackwell(
+        self, *args
+    ) -> Tuple[Callable, Callable]:
+        def fn(q, k, v):
+            return autows_blackwell_dp(
+                q,
+                k,
+                v,
+                self.causal,
+                self.sm_scale,
+                "ws_persistent",
             )
 
         return preproc_noop, fn


### PR DESCRIPTION
Adding the FA kernel with manual data partition to Triton repo for unified CI test and kernel de-duplication.

Related PR: https://github.com/facebookexperimental/triton/pull/1527

### Test plan:
```
CUDA_VISIBLE_DEVICES=6 TRITON_ALWAYS_COMPILE=1 TRITON_USE_META_WS=1 TRITON_USE_META_PARTITION=1 bash ~/fbsource/fbcode/ads_mkl/benchmarks/denoise.sh python run.py --op blackwell_attentions --seq-len 8192 --batch 4 --n-heads 32 --d-head 128 --mode fwd --sleep 1.0 --metrics tflops --simple-output --only triton_autows_flash_dp_persistent_blackwell --force
```
shows
```
Processing GPU 6...
→ Locking power cap to 750 W and SM clock to 1965 MHz on GPU 6
  (Batch, Heads, Heads_KV, SeqLen, SeqLen_KV, Dhead)    triton_autows_flash_dp_persistent_blackwell-tflops
----------------------------------------------------  ----------------------------------------------------
                    (4, 32, 32, 8192, 8192, 128) fwd                                               886.623
                                   886.6228814124387
```
and current fbexperimental/triton commit leads to accuracy mismatch, which preexists with the tritonbench kernel too (https://github.com/meta-pytorch/tritonbench/blob/main/tritonbench/kernels/blackwell_triton_fused_attention_dp.py).
```
CUDA_VISIBLE_DEVICES=6 TRITON_ALWAYS_COMPILE=1 TRITON_USE_META_WS=1 TRITON_USE_META_PARTITION=1 bash ~/fbsource/fbcode/ads_mkl/benchmarks/denoise.sh python run.py --op blackwell_attentions --seq-len 8192 --batch 4 --n-heads 32 --d-head 128 --mode fwd --sleep 1.0 --metrics accuracy --simple-output --baseline tlx_blackwell_ws_pipelined_persistent --only triton_autows_flash_dp_persistent_blackwell,tlx_blackwell_ws_pipelined_persistent --force --rtol 0 --atol 1e-2
```
shows
```
Mismatched elements: 386 / 134217728 (0.0%)
Greatest absolute difference: 0.03369140625 at index (3, 28, 5453, 30) (up to 0.01 allowed)
Greatest relative difference: 274.0 at index (0, 6, 5142, 9) (up to 0.0 allowed)
```

### TODO
1. Remove the tritonbench kernel https://github.com/meta-pytorch/tritonbench/blob/main/tritonbench/kernels/blackwell_triton_fused_attention_dp.py. 
2. Update the tritonbench CI references.