### PR TITLE
Log fbhash and job summary metrics to `pytorch_adhoc_benchmarks` scuba table

### DIFF
--- a/benchmarks/common.py
+++ b/benchmarks/common.py
@@ -74,6 +74,7 @@ def run_benchmark_config_ci(
     from tritonbench.utils.run_utils import run_config, SPECIAL_CONFIG_FIELDS
     from tritonbench.utils.scuba_utils import decorate_benchmark_data, log_benchmark
 
+    benchmark_start_time = time.time()
     output_files = []
     run_timestamp, output_dir = setup_output_dir(
         benchmark_group_name, ci=ci, output_dir=output_dir
@@ -124,6 +125,11 @@ def run_benchmark_config_ci(
     if log_scuba and not is_fbcode():
         log_benchmark(aggregated_obj)
         logger.info(f"[{benchmark_group_name}] logging results to scuba table.")
+
+    if is_fbcode():
+        from tritonbench.utils.fb.utils import log_job_summary_to_scuba
+
+        log_job_summary_to_scuba(benchmark_group_name, benchmark_start_time)
 
 
 def setup_output_dir(bm_name: str, ci: bool = False, output_dir: str | None = None):


### PR DESCRIPTION
Summary:
Add scuba logging at the end of `run_benchmark_config_ci()` to log job summary metrics to the `pytorch_adhoc_benchmarks` scuba table when running in fbcode.

Metrics logged via `extra_data`:
- `fbhash`: resolved from the fbpkg `METADATA` file (`build.vcs_info.revision`), falling back to `hg id`
- `total_benchmark_time_s`: wall-clock time of the benchmark run
- `mast_job_key`: `MAST_HPC_JOB_NAME`-`MAST_HPC_JOB_VERSION`-`MAST_HPC_JOB_ATTEMPT_INDEX`
- `servicelab_experiment_id`: from `SERVICELAB_EXPERIMENT_ID` env var (when available)
- `benchmark_group_name`: the benchmark group name passed to the function

The `metric_id` field is `{mast_job_key}.job_summary` and `metric_value` is always `1.0`.

Differential Revision: D106097281


