### PR TITLE
Support `dispatch_arg_indices` in C fast cache for kernels with None pointer args (#1087)

### DIFF
--- a/tritonbench/operators/launch_latency/kernels.py
+++ b/tritonbench/operators/launch_latency/kernels.py
@@ -116,12 +116,12 @@ def nop_hstu_args_kernel(
 
 
 # Same kernels without C cache — for baseline comparison
-@_jit(c_cache=True)
+@_jit(c_cache=False)
 def nop_kernel_nocache():
     pass
 
 
-@_jit(c_cache=True)
+@_jit(c_cache=False)
 def nop_with_args_kernel_nocache(
     t1,
     t2,
@@ -146,7 +146,7 @@ def nop_with_args_kernel_nocache(
     pass
 
 
-@_jit(c_cache=True)
+@_jit(c_cache=False)
 def nop_hstu_args_kernel_nocache(
     p1,
     p2,
@@ -334,6 +334,40 @@ def nop_autotuned_kernel_nocache(
     BLOCK_C3: tl.constexpr,
     BLOCK_C4: tl.constexpr,
     BLOCK_C5: tl.constexpr,
+):
+    pass
+
+
+@triton.autotune(
+    configs=[
+        triton.Config(
+            {
+                "BLOCK_C1": 32,
+                "BLOCK_C2": 32,
+            }
+        ),
+        triton.Config(
+            {
+                "BLOCK_C1": 64,
+                "BLOCK_C2": 64,
+            }
+        ),
+    ],
+    key=[],
+)
+@_jit(c_cache=True)
+def nop_autotuned_with_none_kernel(
+    q,
+    k,
+    v,
+    out,
+    bias,
+    mask,
+    scale,
+    N,
+    H,
+    BLOCK_C1: tl.constexpr,
+    BLOCK_C2: tl.constexpr,
 ):
     pass
 

--- a/tritonbench/operators/launch_latency/operator.py
+++ b/tritonbench/operators/launch_latency/operator.py
@@ -25,6 +25,7 @@ from .kernels import (
     make_tensordesc_inputs,
     nop_autotuned_kernel,
     nop_autotuned_kernel_nocache,
+    nop_autotuned_with_none_kernel,
     nop_hstu_args_kernel,
     nop_hstu_args_kernel_nocache,
     nop_kernel,
@@ -455,6 +456,68 @@ class Operator(BenchmarkOperator):
             return lambda: nop_kernel[1,]()
         nop_autotuned_kernel_nocache[(1,)](*args[:14])
         return lambda: nop_autotuned_kernel_nocache[(1,)](*args[:14])
+
+    @register_benchmark()
+    def nop_autotuned_with_none_proxy(self, *args):
+        """Autotuned kernel with None pointer args via JITCacheProxy.
+
+        Reproduces the CMSL HSTU crash: autotuned kernel receives None for
+        optional tensor params on SUBSEQUENT calls (after autotuning with
+        real tensors). Tests if JITCacheProxy handles None correctly.
+        If this crashes with SystemError about data_ptr, the proxy has a bug.
+        """
+        if len(args) < 19:
+            return lambda: nop_kernel[1,]()
+        q = zeros(1, device="cuda")
+        k = zeros(1, device="cuda")
+        v = zeros(1, device="cuda")
+        out = zeros(1, device="cuda")
+        bias = zeros(1, device="cuda")
+        mask = zeros(1, device="cuda")
+        scale = zeros(1, device="cuda")
+        # First: warmup with REAL tensors to trigger autotune + compilation
+        real_args = (q, k, v, out, bias, mask, scale, 128, 8)
+        nop_autotuned_with_none_kernel[(1,)](*real_args)
+        # Now: subsequent calls pass None for optional pointers (HSTU pattern)
+        none_args = (q, k, v, out, None, None, None, 128, 8)
+        # This goes through _try_fast_path → JITCacheProxy with None args
+        return lambda: nop_autotuned_with_none_kernel[(1,)](*none_args)
+
+    @register_benchmark()
+    def nop_autotuned_proxy_vs_native(self, *args):
+        """Benchmarks JITCacheProxy path vs native_fast_dispatch for autotuned kernels.
+
+        Both use the C fast cache, but JITCacheProxy uses vectorcall proxy while
+        native_fast_dispatch is called directly. Compare to quantify proxy overhead.
+        """
+        if len(args) != 19:
+            return lambda: nop_kernel[1,]()
+        try:
+            from triton._C.libtriton import native_fast_dispatch
+        except ImportError:
+            return lambda: None
+
+        from triton.runtime import driver
+
+        # Warmup autotuned kernel to populate cache
+        nop_autotuned_kernel[(1,)](*args[:14])
+        jit_fn = nop_autotuned_kernel.fn
+        params = jit_fn.params
+        device = driver.active.get_current_device()
+        stream = driver.active.get_current_stream(device)
+        # Build full args (14 runtime + 5 constexpr from config)
+        full_args = tuple(list(args[:14]) + [32, 32, 32, 32, 32])
+        padded = (
+            full_args + (None,) * (len(params) - len(full_args))
+            if len(full_args) < len(params)
+            else full_args
+        )
+        grid = (1,)
+
+        def native_dispatch_fn():
+            native_fast_dispatch(jit_fn, padded, params, 0, grid, stream)
+
+        return native_dispatch_fn
 
     @register_benchmark()
     def nop_triton_kernel_fc_miss(self, *args):


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookexperimental/triton/pull/1583

## Problem (Before)

When an autotuned Triton kernel is first compiled with real tensor arguments and then
dispatched with `None` for optional pointer parameters (common pattern in CMSL HSTU
attention), the C fast cache dispatcher crashes:

```
SystemError: <method 'run' ...> returned a result with an exception set
# Root cause: td_get_ptr() calls .data_ptr() on None → TypeError
```

**Concrete case study**: HSTU attention kernel has optional `bias`, `mask`, `scale` pointers.
During autotuning, all are real tensors. In steady-state inference, some are `None`.
The JITCacheProxy dispatcher blindly passes ALL non-constexpr args (including None) to
the kernel's `.run()` method which tries to extract `.data_ptr()` → crash.

## Solution (After)

Store per-entry `dispatch_arg_indices` in the C fast cache. These indices record exactly
which argument positions the kernel's dispatcher expects (computed at compilation time,
stored in `kernel._dispatch_arg_indices`). On cache hit, the dispatcher uses these indices
to select only the relevant args — skipping None pointers that the compiled kernel does
not actually reference.

**Dispatch flow (before fix)**:
```
cache hit → vc_args = [all non-constexpr args] → .data_ptr() on None → CRASH
```

**Dispatch flow (after fix)**:
```
cache hit → vc_args = [args at dispatch_arg_indices positions only] → skip None → OK
```

## Performance

### Micro-benchmark: `nop_autotuned_with_none_proxy` (19 args, 3 are None)

| Config | Latency (ms/dispatch) | vs Baseline |
|--------|:--------------------:|:-----------:|
| D=0, CC=0 (baseline) | 0.0196 | — |
| D=0, CC=1 (C cache only) | 0.0213 | +8.7% |
| D=1, CC=0 (dispatcher only) | 0.0155 | **−21%** |
| D=1, CC=1 (dispatcher + C cache) | 0.0158 | **−19%** |

The fix enables D=1 + CC=1 to work without crashing. The slight regression in D=0 + CC=1
is inherent to the C cache key-building cost (not from this fix) — the C cache's value is
only realized through the Dispatcher (D=1) path.

### E2E: CMSL HSTU Training (per-batch GPU time, A100 80GB)

| Config | p50 (ms) | vs Baseline |
|--------|:--------:|:-----------:|
| Baseline (D=0, CC=0) | 779.07 | — |
| Dispatcher only (D=1, CC=0) | 577.20 | **−25.9%** |
| Dispatcher + C Cache (D=1, CC=1) | 567.66 | **−27.1%** |

Without this fix, D=1 + CC=1 crashes on the None-arg kernels in HSTU. With the fix,
we unlock the full 27% speedup.

Differential Revision: D106004978


