### PR TITLE
[submodules] add submodules to python path by default

### DIFF
--- a/tritonbench/operators/op.py
+++ b/tritonbench/operators/op.py
@@ -4,7 +4,7 @@ import pathlib
 from typing import Dict, List
 
 import yaml
-from tritonbench.utils.path_utils import SUBMODULE_PATH, add_path
+from tritonbench.utils.path_utils import add_path, SUBMODULE_PATH
 
 OPBENCH_DIR = "operators"
 INTERNAL_OPBENCH_DIR = "fb"

--- a/tritonbench/operators/op.py
+++ b/tritonbench/operators/op.py
@@ -4,6 +4,7 @@ import pathlib
 from typing import Dict, List
 
 import yaml
+from tritonbench.utils.path_utils import SUBMODULE_PATH, add_path
 
 OPBENCH_DIR = "operators"
 INTERNAL_OPBENCH_DIR = "fb"
@@ -91,7 +92,8 @@ def load_opbench_by_name(op_name: str):
         if not _is_internal_operator(op_name)
         else f"{INTERNAL_OPBENCH_DIR}.{op_name}"
     )
-    module = importlib.import_module(f"..{op_pkg}", package=__name__)
+    with add_path(SUBMODULE_PATH):
+        module = importlib.import_module(f"..{op_pkg}", package=__name__)
 
     Operator = getattr(module, "Operator", None)
     if Operator is None:

--- a/tritonbench/utils/path_utils.py
+++ b/tritonbench/utils/path_utils.py
@@ -11,7 +11,7 @@ BUILD_PATH = REPO_PATH.joinpath("build")
 
 class add_path:
     def __init__(self, path):
-        self.path = path
+        self.path = os.fspath(path)
 
     def __enter__(self):
         sys.path.insert(0, self.path)


### PR DESCRIPTION
Adding `submodules` to PYTHON_PATH by default, to load certain modules