### PR TITLE
Fix autotuner + C dispatcher for `ctas_per_cga` kernels (#1091)

### DIFF
--- a/tritonbench/operators/launch_latency/kernels.py
+++ b/tritonbench/operators/launch_latency/kernels.py
@@ -240,6 +240,7 @@ def make_tensordesc_inputs(m_block: int = 8, n_block: int = 32):
 
 
 # --- Autotuned kernel for benchmarking c_cache + autotune interaction ---
+# Uses num_ctas to exercise cluster dispatch path 1 (num_ctas > 1 → clusterDim.x = num_ctas).
 
 
 @triton.autotune(
@@ -251,7 +252,8 @@ def make_tensordesc_inputs(m_block: int = 8, n_block: int = 32):
                 "BLOCK_C3": 32,
                 "BLOCK_C4": 32,
                 "BLOCK_C5": 32,
-            }
+            },
+            num_ctas=2,
         ),
         triton.Config(
             {
@@ -260,7 +262,8 @@ def make_tensordesc_inputs(m_block: int = 8, n_block: int = 32):
                 "BLOCK_C3": 64,
                 "BLOCK_C4": 64,
                 "BLOCK_C5": 64,
-            }
+            },
+            num_ctas=1,
         ),
     ],
     key=[],
@@ -299,7 +302,8 @@ def nop_autotuned_kernel(
                 "BLOCK_C3": 32,
                 "BLOCK_C4": 32,
                 "BLOCK_C5": 32,
-            }
+            },
+            num_ctas=2,
         ),
         triton.Config(
             {
@@ -308,7 +312,8 @@ def nop_autotuned_kernel(
                 "BLOCK_C3": 64,
                 "BLOCK_C4": 64,
                 "BLOCK_C5": 64,
-            }
+            },
+            num_ctas=1,
         ),
     ],
     key=[],

--- a/tritonbench/operators/launch_latency/operator.py
+++ b/tritonbench/operators/launch_latency/operator.py
@@ -440,22 +440,27 @@ class Operator(BenchmarkOperator):
             BLOCK_C5=kw_vals[4],
         )
 
-    @register_benchmark()
+    @register_benchmark(enabled=is_cuda())
     def nop_triton_kernel_autotuned(self, *args):
-        """Autotuned kernel — measures autotune + c_cache interaction."""
-        if len(args) != 19:
-            return lambda: nop_kernel[1,]()
-        # Warmup: trigger autotune config selection
-        nop_autotuned_kernel[(1,)](*args[:14])
-        return lambda: nop_autotuned_kernel[(1,)](*args[:14])
+        """Autotuned kernel with num_ctas — measures autotune + c_cache + cluster."""
+        from torch import zeros
 
-    @register_benchmark()
+        targs = [zeros(1, device="cuda") for _ in range(5)]
+        iargs = [1 for _ in range(9)]
+        kernel_args = tuple([*targs, *iargs])
+        nop_autotuned_kernel[(1,)](*kernel_args)
+        return lambda: nop_autotuned_kernel[(1,)](*kernel_args)
+
+    @register_benchmark(enabled=is_cuda())
     def nop_triton_kernel_autotuned_nocache(self, *args):
         """Autotuned kernel without c_cache — baseline for autotune overhead."""
-        if len(args) != 19:
-            return lambda: nop_kernel[1,]()
-        nop_autotuned_kernel_nocache[(1,)](*args[:14])
-        return lambda: nop_autotuned_kernel_nocache[(1,)](*args[:14])
+        from torch import zeros
+
+        targs = [zeros(1, device="cuda") for _ in range(5)]
+        iargs = [1 for _ in range(9)]
+        kernel_args = tuple([*targs, *iargs])
+        nop_autotuned_kernel_nocache[(1,)](*kernel_args)
+        return lambda: nop_autotuned_kernel_nocache[(1,)](*kernel_args)
 
     @register_benchmark()
     def nop_autotuned_with_none_proxy(self, *args):


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookexperimental/triton/pull/1595

## Background

When running Triton kernels with `TRITON_USE_TRITON_DISPATCHER=1 TRITON_ENABLE_C_CACHE=1`,
kernels that use **cluster dimensions** (`ctas_per_cga > 1`, e.g., the `layernorm_gdpa_residual_rmsnorm_residual`
kernel) crash with:

```
RuntimeError: Unexpected buffer remote view in 1cta mode
```

This crash happens because the autotuner's fast dispatch path drops critical meta-parameters
(`ctas_per_cga`, `num_warps`, etc.) when dispatching via the C cache proxy, causing the kernel
to be recompiled with default `ctas_per_cga=1` instead of the autotuner's winning config
(e.g., `ctas_per_cga=(2,1,1)`).

## Root Cause

The dispatch flow has three layers:

```
Autotuner._try_fast_path()
  → JITFunction.__getitem__(grid) → JITCacheProxy (C extension)
    → vectorcall: FastCache lookup → dispatcher launch (fastest, zero Python)
    → fallback: run_partial(*args) → JITFunction.run()
```

**Two bugs existed:**

1. **Autotuner seeding**: The autotuner's `_try_fast_path` never seeded the C cache with the
   correct `options_hash` that includes meta-params. The C cache was inserted with hash=H
   (computed from `ctas_per_cga` etc.) during `JITFunction.run()`, but the proxy was created
   with `options_hash=0`, causing a permanent cache miss.

2. **C proxy fallback missing meta kwargs**: When the C proxy falls back to Python
   (`run_partial`), it called `JITFunction.run(*args, grid=.., warmup=False)` WITHOUT
   the meta kwargs (like `ctas_per_cga`). This caused `JITFunction.run()` to hit the
   Python kernel cache with a different key (missing `ctas_per_cga` in options) →
   cache miss → recompile with wrong defaults → crash.

## Before vs After

### Before (broken)

```
autotuner._try_fast_path:
  self.fn[grid](*full_args)
    → C proxy vectorcall:
      → hash=0 lookup → MISS (entry was stored with hash=H)
      → fallback → run_partial(*args)
        = self.fn.run(*args, grid=.., warmup=False)  ← NO meta kwargs!
        → Python cache MISS (different options key) → recompile
        → compile with ctas_per_cga=1 → CRASH
```

### After (fixed)

```
autotuner._try_fast_path:
  # Seeding: compile correctly, then set hash + meta on JITFunction
  self.fn.run(*full_args, **_meta)  → compile with correct ctas_per_cga
  self.fn._fc_options_hash = H     → matches insertion hash
  self.fn._fc_meta_kwargs = _meta  → for proxy fallback forwarding

  # Steady-state:
  self.fn[grid](*full_args)
    → C proxy vectorcall (options_hash=H, meta_kwargs baked into run_partial):
      → hash=H lookup → HIT → dispatcher launch (zero Python overhead) ✓
      → OR fallback → run_partial(*args)
        = self.fn.run(*args, grid=.., warmup=False, ctas_per_cga=(2,1,1), ...)
        → Python cache HIT → launch correctly ✓
```

## Changes

### 1. `autotuner.py` — Autotuner seeding + steady-state dispatch

- **Seeding**: After first compilation, compute correct `_fc_options_hash` from meta-params
  and store `_fc_meta_kwargs` on the JITFunction. Invalidate proxy cache so new proxies
  pick up the updated hash and meta.
- **Steady-state**: Use `self.fn[grid](*full_args)` (C proxy fast path) instead of
  the slower `self.fn.run(**_meta)` path.

### 2. `specialize.cc` — C proxy meta kwargs forwarding + nargs padding

- `native_create_jit_proxy()` accepts optional 7th argument: a `meta_kwargs` dict.
- Merges `meta_kwargs` into `run_partial`'s kwargs via `PyDict_Merge`, so the fallback
  path automatically includes meta-params like `ctas_per_cga`.
- **Padding fix**: When proxy receives fewer positional args than `n_params` (constexpr
  params not passed positionally by the autotuner), pads with `Py_None` to match the
  FastCache insertion key format. Without this, `nargs != n_params` caused immediate
  fallback (FastCache never consulted).

### 3. `jit.py` — Pass meta kwargs when creating proxy

- `KernelInterface.__getitem__()` passes `self._fc_meta_kwargs` as 7th arg to
  `native_create_jit_proxy()`.

### 4. `driver.c` — Cluster dimension support in C dispatcher (from prior session)

- `TritonDispatcher_new()` accepts `cluster_dim_x/y/z` parameters.
- Sets `CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION` when cluster dims > 1.

### 5. `triton_dispatcher_factory.py` — Pass cluster_dims from schema (from prior session)

- Extracts `cluster_dims` from kernel schema and passes to C dispatcher constructor.

## Performance

Comparison with non-cluster autotuned kernel (`nop_triton_kernel_autotuned`, `nop_triton_kernel_autotuned_nocache`):

| Case | Walltime | Speedup vs baseline |
|------|----------|---------------------|
| d=0, c=0 (no optimizations) | 25.2µs | 1.00x (baseline) |
| d=0, c=1 (C cache only) | 19.1µs | **1.32x** |
| d=1, c=0 (dispatcher only) | 21.5µs | 1.17x |
| d=1, c=1 (both) | **15.0µs** | **1.68x** |

Reviewed By: jackiexu77

Differential Revision: D106454376


