### PR TITLE
Add generic aoti_kernel tritonbench operator for automatic Triton kernel benchmarking

### DIFF
--- a/test/test_gpu/skip_tests.yaml
+++ b/test/test_gpu/skip_tests.yaml
@@ -7,6 +7,8 @@
 #    channels: <list of triton channels> (options: "triton-main", "meta-triton", default: ["triton-main", "meta-triton"])
 # to override the default, specify devices and channels to limit combinations
 # we rely on the code to determine specific backends to skip
+# aoti_kernel requires --artifact arg; tested separately
+aoti_kernel:
 # cpu-op for testing
 test_op:
 # fb-only ops


### PR DESCRIPTION
Summary:
Context: https://docs.google.com/document/d/16BtcatFaNXp-eWptTPWkzgXyaaPIeBlJO8J5Bdfgt0w/edit?tab=t.0#heading=h.a24btwk7pbzm

Add a generic `aoti_kernel` operator that reads `triton_kernel_perf_artifact.json` (produced during AOTI lowering) and automatically benchmarks any production Triton kernel without kernel-specific code. This replaces the manual 4-step registration process (create operator dir, write operator.py, add to benchmark_config.json, update BUCK) with a single `--artifact <path>` flag.

The operator dynamically compiles kernel source code from the artifact, reconstructs tensor inputs from shape/dtype/stride metadata, resolves scalar and constexpr args, and benchmarks using tritonbench infrastructure.

Verified against real production artifact P2295975799 (ragged flash attention kernels with 48 args each).

Reviewed By: xuzhao9

Differential Revision: D105984209


