### PR TITLE
[ci] skip embedding kernel on hip

### DIFF
--- a/test/test_gpu/skip_tests.yaml
+++ b/test/test_gpu/skip_tests.yaml
@@ -9,6 +9,11 @@
 # we rely on the code to determine specific backends to skip
 # aoti_kernel requires --artifact arg; tested separately
 aoti_kernel:
+
+# embedding will segfault on hip
+embedding:
+  devices:
+    - cuda
 # cpu-op for testing
 test_op:
 # fb-only ops


### PR DESCRIPTION
embedding kernel will segfault non-deterministically on AMD MI350X, so skipping it in the CI.

Example:

https://github.com/meta-pytorch/tritonbench/actions/runs/26554834688/job/78224406866