### PR TITLE
Gate warp_specialize=True GEMM benchmarks on Hopper behind meta_ws

### DIFF
--- a/tritonbench/operators/gemm/operator.py
+++ b/tritonbench/operators/gemm/operator.py
@@ -14,6 +14,7 @@ from tritonbench.operators.gemm.partition_k import (
 )
 from tritonbench.operators.gemm.stream_k import streamk_amd_matmul, streamk_cuda_matmul
 from tritonbench.operators.gemm.warp_spec_persistent_matmul import (
+    _use_meta_ws,
     blackwell_matmul_descriptor_persistent,
     blackwell_matmul_tma,
     blackwell_matmul_tma_persistent,
@@ -653,7 +654,7 @@ class Operator(BenchmarkOperator):
         else:
             return lambda: _tlx_matmul_2cta(a_contig, b_contig).to(target_dtype)
 
-    @register_benchmark(enabled=IS_BLACKWELL or IS_HOPPER)
+    @register_benchmark(enabled=IS_BLACKWELL or (IS_HOPPER and _use_meta_ws()))
     def triton_warpspec_tma_persistent_matmul(self, a, b, bias) -> Callable:
         if bias is not None:
             return (
@@ -663,7 +664,9 @@ class Operator(BenchmarkOperator):
         else:
             return lambda: blackwell_matmul_tma_persistent(a, b, warp_specialize=True)
 
-    @register_benchmark(enabled=IS_BLACKWELL or IS_HOPPER, fwd_only=True)
+    @register_benchmark(
+        enabled=IS_BLACKWELL or (IS_HOPPER and _use_meta_ws()), fwd_only=True
+    )
     def triton_warpspec_tma_persistent_splitk_matmul(self, a, b, bias) -> Callable:
         """Warp-specialized persistent split-K matmul for large-K undersaturated GEMMs.
 
@@ -687,7 +690,7 @@ class Operator(BenchmarkOperator):
         else:
             return lambda: blackwell_matmul_tma_persistent(a, b, warp_specialize=False)
 
-    @register_benchmark(enabled=IS_BLACKWELL or IS_HOPPER)
+    @register_benchmark(enabled=IS_BLACKWELL or (IS_HOPPER and _use_meta_ws()))
     def triton_warpspec_tma_matmul(self, a, b, bias) -> Callable:
         if bias is not None:
             return lambda: blackwell_matmul_tma(a, b, warp_specialize=True) + bias
@@ -701,7 +704,7 @@ class Operator(BenchmarkOperator):
         else:
             return lambda: blackwell_matmul_tma(a, b, warp_specialize=False)
 
-    @register_benchmark(enabled=IS_BLACKWELL or IS_HOPPER)
+    @register_benchmark(enabled=IS_BLACKWELL or (IS_HOPPER and _use_meta_ws()))
     def triton_warpspec_descriptor_persistent_matmul(self, a, b, bias) -> Callable:
         if bias is not None:
             return (


### PR DESCRIPTION
Summary:
D101840063 widened the `triton_warpspec_*` GEMM benchmark gates from `IS_BLACKWELL` to `IS_BLACKWELL or IS_HOPPER`. Those benchmarks all call kernels with `warp_specialize=True`, which on Hopper is only viable through Meta's AutoWS pipeline (`triton.knobs.nvidia.use_meta_ws`). The OAI Triton WS lowering with `WARP_SPECIALIZE=True, FLATTEN=False` on Hopper crashes the compiler with `RuntimeError: PassManager::run failed` inside `make_ttgir`, which surfaces as a `pytorch/tritonbench/test/test_gpu:test_gpu - test_gpu_tritonbench_gemm` failure on the triton-stable channel (where `_use_meta_ws()` returns False).

Tighten the four `triton_warpspec_*` gates so on Hopper they are only enabled when Meta's AutoWS is available: `IS_BLACKWELL or (IS_HOPPER and _use_meta_ws())`. Blackwell behavior is unchanged. On Hopper without meta_ws, the kernels are skipped instead of being autotuned into a compile failure.

Affected benchmarks:
- `triton_warpspec_tma_persistent_matmul`
- `triton_warpspec_tma_persistent_splitk_matmul`
- `triton_warpspec_tma_matmul`
- `triton_warpspec_descriptor_persistent_matmul`

Differential Revision: D106655612


