### PR TITLE
Gate tlx_hstu blackwell backend on is_triton_beta()

### DIFF
--- a/tritonbench/operators/blackwell_attentions/operator.py
+++ b/tritonbench/operators/blackwell_attentions/operator.py
@@ -65,7 +65,7 @@ if SUPPORT_GLUON:
 
 import logging
 
-from tritonbench.utils.env_utils import IS_BLACKWELL, is_blackwell
+from tritonbench.utils.env_utils import IS_BLACKWELL, is_blackwell, is_triton_beta
 
 logger = logging.getLogger(__name__)
 
@@ -815,7 +815,10 @@ class Operator(BenchmarkOperator):
 
         return preproc_noop, fn
 
-    @register_benchmark(enabled=IS_BLACKWELL and HAS_TLX_HSTU, label="tlx-hstu")
+    @register_benchmark(
+        enabled=IS_BLACKWELL and HAS_TLX_HSTU and is_triton_beta(),
+        label="tlx-hstu",
+    )
     @multi_input_wrapper
     def tlx_hstu(self, *args) -> Tuple[Callable, Callable]:
         if self.varlen:


### PR DESCRIPTION
Summary:
The tlx_hstu backend in the blackwell_attentions operator imports tlx_bw_hstu_mha_wrapper from hammer/v2/ops/triton/template/tlx_bw_hstu_attention.py, whose backward kernel calls tlx.async_descriptor_store(..., store_reduce="add"). The store_reduce kwarg only exists on the beta TLX async_descriptor_store signature; the stable variant rejects it with TypeError: async_descriptor_store() got an unexpected keyword argument 'store_reduce' at JIT-compile time, failing test_gpu_tritonbench_blackwell_attentions under the stable variant of triton_test_stable_and_beta.

Add is_triton_beta() to the enabled= predicate so the backend is skipped on stable triton. This mirrors the existing pattern of composing module-level booleans with helper-call runtime checks (e.g. is_blackwell(), _is_sdpa_cudnn_attention_available()) already used elsewhere in this operator file.

Differential Revision: D106655601


