### PR TITLE
[ci] disable flash_attention on hip+triton-beta

### DIFF
--- a/.ci/tritonbench/test-gpu.sh
+++ b/.ci/tritonbench/test-gpu.sh
@@ -6,11 +6,12 @@ if [ -z "${SETUP_SCRIPT}" ]; then
   exit 1
 fi
 
+source "${SETUP_SCRIPT}"
+
+# if cuda, add cuda libraries to LD_LIBRARY_PATH
 if python -c "import re, sys, torch; sys.exit(0 if re.search(r'\+cu[0-9]+', torch.__version__) else 1)"; then
   source .ci/tritonbench/setup-nvidia-path.sh
 fi
-
-source "${SETUP_SCRIPT}"
 
 # print pytorch and triton versions for debugging
 python -c "import torch; print('torch version: ', torch.__version__); print('torch location: ', torch.__file__)"
@@ -19,5 +20,7 @@ python -c "import triton; print('triton version: ', triton.__version__); print('
 # workaround: disable inductor subprocess compilation to avoid
 # "Could not find an active GPU backend" in subprocess workers
 export TORCHINDUCTOR_COMPILE_THREADS=1
+# best effort disable autotune to speedup test
+export TORCHINDUCTOR_MAX_AUTOTUNE=0
 
 python -m unittest test.test_gpu.main -v

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -4,6 +4,7 @@ on:
     paths:
       - .github/workflows/pr.yml
       - .github/workflows/_linux-test-*.yml
+      - test/test_gpu/**
       - tritonbench/**
   push:
     branches:

--- a/test/test_gpu/main.py
+++ b/test/test_gpu/main.py
@@ -87,7 +87,6 @@ def _gen_test_operators(test_ops, skip_tests) -> set[str]:
                 test_ops[skip_op]["disabled"] = test_ops[skip_op][
                     "disabled"
                 ] or (disabled_device_match and disabled_channel_match)
-        logger.warning(f"Testing skip op: {skip_op}, val: {skip_tests[skip_op]}")
         if test_ops[skip_op]["disabled"] and skip_tests[skip_op] and skip_tests[skip_op].get(
             "report", False
         ):

--- a/test/test_gpu/main.py
+++ b/test/test_gpu/main.py
@@ -67,6 +67,25 @@ def _gen_test_operators(test_ops, skip_tests) -> set[str]:
             test_ops[skip_op]["disabled"] = test_ops[skip_op][
                 "disabled"
             ] or not _env_check(skip_tests[skip_op], field_name)
+        disabled_devices = skip_tests[skip_op].get("disabled_devices")
+        disabled_channels = skip_tests[skip_op].get("disabled_channels")
+        if disabled_devices is not None or disabled_channels is not None:
+            # disabled_* fields act as a deny-list over device/channel
+            # combinations. If only one side is specified, it matches any
+            # value for the other side.
+            disabled_device_match = (
+                True
+                if disabled_devices is None
+                else _env_check({"devices": disabled_devices}, "devices")
+            )
+            disabled_channel_match = (
+                True
+                if disabled_channels is None
+                else _env_check({"channels": disabled_channels}, "channels")
+            )
+            test_ops[skip_op]["disabled"] = test_ops[skip_op][
+                "disabled"
+            ] or (disabled_device_match and disabled_channel_match)
     return {test_op for test_op in test_ops if not test_ops[test_op]["disabled"]}
 
 

--- a/test/test_gpu/main.py
+++ b/test/test_gpu/main.py
@@ -86,6 +86,13 @@ def _gen_test_operators(test_ops, skip_tests) -> set[str]:
             test_ops[skip_op]["disabled"] = test_ops[skip_op][
                 "disabled"
             ] or (disabled_device_match and disabled_channel_match)
+        if test_ops[skip_op]["disabled"] and skip_tests[skip_op].get(
+            "report", False
+        ):
+            logger.warning(
+                "%s test is temporarily disabled and needs work to re-enable it.",
+                skip_op,
+            )
     return {test_op for test_op in test_ops if not test_ops[test_op]["disabled"]}
 
 

--- a/test/test_gpu/main.py
+++ b/test/test_gpu/main.py
@@ -87,7 +87,8 @@ def _gen_test_operators(test_ops, skip_tests) -> set[str]:
                 test_ops[skip_op]["disabled"] = test_ops[skip_op][
                     "disabled"
                 ] or (disabled_device_match and disabled_channel_match)
-        if test_ops[skip_op]["disabled"] and skip_tests[skip_op].get(
+        logger.warning(f"Testing skip op: {skip_op}, val: {skip_tests[skip_op]}")
+        if test_ops[skip_op]["disabled"] and skip_tests[skip_op] and skip_tests[skip_op].get(
             "report", False
         ):
             logger.warning(

--- a/test/test_gpu/main.py
+++ b/test/test_gpu/main.py
@@ -63,30 +63,30 @@ def _gen_test_operators(test_ops, skip_tests) -> set[str]:
         # ususally CI environment issue or broken operators need to be fixed
         if skip_tests[skip_op] == None:
             test_ops[skip_op]["disabled"] = True
-            continue
-        for field_name in ["devices", "channels"]:
-            test_ops[skip_op]["disabled"] = test_ops[skip_op][
-                "disabled"
-            ] or not _env_check(skip_tests[skip_op], field_name)
-        disabled_devices = skip_tests[skip_op].get("disabled_devices")
-        disabled_channels = skip_tests[skip_op].get("disabled_channels")
-        if disabled_devices is not None or disabled_channels is not None:
-            # disabled_* fields act as a deny-list over device/channel
-            # combinations. If only one side is specified, it matches any
-            # value for the other side.
-            disabled_device_match = (
-                True
-                if disabled_devices is None
-                else _env_check({"devices": disabled_devices}, "devices")
-            )
-            disabled_channel_match = (
-                True
-                if disabled_channels is None
-                else _env_check({"channels": disabled_channels}, "channels")
-            )
-            test_ops[skip_op]["disabled"] = test_ops[skip_op][
-                "disabled"
-            ] or (disabled_device_match and disabled_channel_match)
+        else:
+            for field_name in ["devices", "channels"]:
+                test_ops[skip_op]["disabled"] = test_ops[skip_op][
+                    "disabled"
+                ] or not _env_check(skip_tests[skip_op], field_name)
+            disabled_devices = skip_tests[skip_op].get("disabled_devices")
+            disabled_channels = skip_tests[skip_op].get("disabled_channels")
+            if disabled_devices is not None or disabled_channels is not None:
+                # disabled_* fields act as a deny-list over device/channel
+                # combinations. If only one side is specified, it matches any
+                # value for the other side.
+                disabled_device_match = (
+                    True
+                    if disabled_devices is None
+                    else _env_check({"devices": disabled_devices}, "devices")
+                )
+                disabled_channel_match = (
+                    True
+                    if disabled_channels is None
+                    else _env_check({"channels": disabled_channels}, "channels")
+                )
+                test_ops[skip_op]["disabled"] = test_ops[skip_op][
+                    "disabled"
+                ] or (disabled_device_match and disabled_channel_match)
         if test_ops[skip_op]["disabled"] and skip_tests[skip_op].get(
             "report", False
         ):
@@ -98,9 +98,6 @@ def _gen_test_operators(test_ops, skip_tests) -> set[str]:
 
 
 TEST_OPERATORS = _gen_test_operators(TEST_OPERATORS, skip_tests)
-
-print("Now logging!!!!!!")
-logger.warning("Now.... logger")
 
 def check_ci_output(op):
     from tritonbench.utils.triton_op import (

--- a/test/test_gpu/main.py
+++ b/test/test_gpu/main.py
@@ -35,6 +35,7 @@ with open(SKIP_FILE, "r") as f:
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 TEST_OPERATORS = (
     set(list_operators_by_collection(op_collection="buck"))
@@ -98,6 +99,8 @@ def _gen_test_operators(test_ops, skip_tests) -> set[str]:
 
 TEST_OPERATORS = _gen_test_operators(TEST_OPERATORS, skip_tests)
 
+print("Now logging!!!!!!")
+logger.warning("Now.... logger")
 
 def check_ci_output(op):
     from tritonbench.utils.triton_op import (

--- a/test/test_gpu/skip_tests.yaml
+++ b/test/test_gpu/skip_tests.yaml
@@ -10,10 +10,16 @@
 # aoti_kernel requires --artifact arg; tested separately
 aoti_kernel:
 
-# embedding will segfault on hip
+# embedding, flash_attention will segfault on hip
 embedding:
   devices:
     - cuda
+# flash_attention will segfault on hip+triton beta
+flash_attention:
+  disabled_devices:
+    - hip
+  disabled_channels:
+    - meta-triton
 # cpu-op for testing
 test_op:
 # fb-only ops

--- a/test/test_gpu/skip_tests.yaml
+++ b/test/test_gpu/skip_tests.yaml
@@ -10,16 +10,6 @@
 # aoti_kernel requires --artifact arg; tested separately
 aoti_kernel:
 
-# embedding, flash_attention will segfault on hip
-embedding:
-  devices:
-    - cuda
-# flash_attention will segfault on hip+triton beta
-flash_attention:
-  disabled_devices:
-    - hip
-  disabled_channels:
-    - meta-triton
 # cpu-op for testing
 test_op:
 # fb-only ops
@@ -40,11 +30,24 @@ mx4_to_fp32:
   devices:
     - cuda
 # ============ TODO: errors in CI ============
-## TODO: CI Failure
 ## torch.AcceleratorError: CUDA error: unspecified launch failure
 decoding_attention:
+  report: true
 # TODO: MSLK does not work with meta-triton
 # TypeError: failed to specialize argument of type: KernelParamWrapper
 fp8_gemm_rowwise:
+  report: true
   channels:
     - triton-main
+# TODO: embedding, flash_attention will segfault on hip
+embedding:
+  report: true
+  devices:
+    - cuda
+# flash_attention will segfault on hip+triton beta
+flash_attention:
+  report: true
+  disabled_devices:
+    - hip
+  disabled_channels:
+    - meta-triton


### PR DESCRIPTION
Add `disabled_devices` and `disabled_channels` to disable test on certain device/channel combination.

Disable flash_attention on meta-triton - it will cause segfault like https://github.com/facebookexperimental/triton/actions/runs/26588658752/job/78341379705?fbclid=IwY2xjawSFscFleHRuA2FlbQIxMQBicmlkETEza0x5cElZclEydVV5dTVmc3J0YwZhcHBfaWQBMAABHmRw07_5Mb_o1y0S0Bkl96rLH_HObFXUtRVJ56BCAB_nKchOly2k68d-dA6t_aem_X-yUn-NeWccjYXwZE5Cndg


<img width="2290" height="625" alt="Screenshot_20260530_115328" src="https://github.com/user-attachments/assets/82ab6008-99d0-4ab2-ae72-d1a2a3e71548" />
