### PR TITLE
Fix `--input-loader` path in `ci.yaml` to use relative path (#1101)

### DIFF
--- a/benchmarks/common.py
+++ b/benchmarks/common.py
@@ -109,6 +109,7 @@ def run_benchmark_config_ci(
         config_file=benchmark_config_file,
         args=["--worker-mode"] + maybe_scuba_args + maybe_logging_group,
         per_config_entry=per_benchmark_map,
+        benchmark_group_name=benchmark_group_name,
     )
     # Reduce all operator CSV outputs to a single output json
     benchmark_data = [transform_func(json.load(open(f, "r"))) for f in output_files]

--- a/tritonbench/data/loader.py
+++ b/tritonbench/data/loader.py
@@ -19,11 +19,7 @@ SUPPORTED_INPUT_OPS = [
 ]
 
 INPUT_CONFIG_DIR = Path(__file__).parent.joinpath("input_configs")
-INTERNAL_INPUT_CONFIG_DIR = (
-    importlib.resources.files("tritonbench.data.input_configs.fb")
-    if is_fbcode()
-    else None
-)
+INTERNAL_INPUT_CONFIG_DIR = INPUT_CONFIG_DIR.joinpath("fb") if is_fbcode() else None
 
 
 def get_input_config_path(input_config_short_path: str):
@@ -34,7 +30,9 @@ def get_input_config_path(input_config_short_path: str):
     elif INTERNAL_INPUT_CONFIG_DIR.joinpath(input_config_short_path).exists():
         input_file_path = INTERNAL_INPUT_CONFIG_DIR.joinpath(input_config_short_path)
     else:
-        raise RuntimeError(f"Input file {input_config_short_path} does not exist.")
+        raise RuntimeError(
+            f'Input file "{input_config_short_path}" does not exist in {INPUT_CONFIG_DIR} or {INTERNAL_INPUT_CONFIG_DIR}'
+        )
     return input_file_path
 
 

--- a/tritonbench/utils/run_utils.py
+++ b/tritonbench/utils/run_utils.py
@@ -793,6 +793,7 @@ def _run_config_entry(
     extra_envs: Optional[Dict[str, str]] = None,
     override_envs: bool = False,
     capture_output: Optional[str] = None,
+    benchmark_group_name: Optional[str] = None,
 ) -> bool:
     runner = benchmark_config.get("runner", None)
     op_args = benchmark_config["args"].split(" ") + args
@@ -832,6 +833,7 @@ def _run_config_entry(
         extra_envs=config_extra_envs,
         override_envs=override_envs,
         capture_output=capture_output,
+        benchmark_group_name=benchmark_group_name,
     )
     return False
 
@@ -843,6 +845,7 @@ def run_config(
     override_envs: bool = False,
     capture_output: Optional[str] = None,
     per_config_entry: Dict[str, Any] | None = None,
+    benchmark_group_name: Optional[str] = None,
 ):
     assert Path(config_file).exists(), (
         f"Config file {config_file} must exist. Current working directory {os.getcwd()}"
@@ -880,6 +883,7 @@ def run_config(
             extra_envs=extra_envs,
             override_envs=override_envs,
             capture_output=capture_output,
+            benchmark_group_name=benchmark_group_name,
         )
         per_benchmark_callback(disabled)
 
@@ -911,7 +915,9 @@ def run_in_task(
     override_envs: bool = False,
     capture_output: Optional[str] = None,
     timeout_s: int = 900,
+    benchmark_group_name: Optional[str] = None,
 ) -> None:
+    log_prefix = benchmark_group_name or "tritonbench"
     op_task_cmd = [] if is_fbcode() else [sys.executable]
     if not op_args:
         assert op, "If op_args is none, op must not be None."
@@ -946,7 +952,7 @@ def run_in_task(
             logger.setLevel(logging.ERROR)
         start_time = time.perf_counter()
         logger.info(
-            f"[tritonbench] Running benchmark {benchmark_name}: "
+            f"[{log_prefix}] Running benchmark {benchmark_name}: "
             + " ".join(op_task_cmd)
         )
         if override_envs:
@@ -973,19 +979,19 @@ def run_in_task(
         )
         benchmark_time = time.perf_counter() - start_time
         logger.info(
-            f"[tritonbench] Complete benchmark {benchmark_name} in {benchmark_time:.3f} seconds."
+            f"[{log_prefix}] Complete benchmark {benchmark_name} in {benchmark_time:.3f} seconds."
         )
         return 0
     except subprocess.TimeoutExpired:
         logger.warning(
-            f"[tritonbench] Benchmark {benchmark_name} timed out after {timeout_s} seconds."
+            f"[{log_prefix}] Benchmark {benchmark_name} timed out after {timeout_s} seconds."
         )
         return 0
     except subprocess.CalledProcessError as e:
         # By default, we will continue on the failed operators
         return e.returncode
     except KeyboardInterrupt:
-        logger.warning("[tritonbench] KeyboardInterrupt received, exiting...")
+        logger.warning(f"[{log_prefix}] KeyboardInterrupt received, exiting...")
         sys.exit(1)
     finally:
         if capture_output:


### PR DESCRIPTION
Summary:

The `--input-loader` path for `tlx_matmul` was using an absolute-style path `pytorch/tritonbench/tritonbench/data/input_configs/fb/ads_omnifm_v5/mm.json` which does not resolve in the MAST environment. Changed it to `ads_omnifm_v5/mm.json` which resolves via `INTERNAL_INPUT_CONFIG_DIR`.

Also removed the single quotes around the `--input-loader` value in ci.yaml, which were being preserved as literal characters by `.split(" ")` in `run_utils.py`, causing the file lookup to fail.

Changes:
- `ci.yaml`: Use relative path `ads_omnifm_v5/mm.json` for `--input-loader`, remove quotes
- `loader.py`: Fix `INTERNAL_INPUT_CONFIG_DIR` to use `INPUT_CONFIG_DIR.joinpath("fb")` instead of `importlib.resources.files()` which does not work reliably in the MAST/fbpkg environment
- `servicelab_mast.bzl`: Default `job_name_prefix` to `benchmark_name` when not specified
- `BUCK`: Remove redundant `job_name_prefix` arguments from `tritonbench_servicelab_mast_wrapper` calls
- `run_utils.py`: Add `benchmark_group_name` parameter to `run_config`, `_run_config_entry`, and `run_in_task` so log messages use `[benchmark_group_name]` instead of `[tritonbench]` when available
- `common.py`: Pass `benchmark_group_name` through to `run_config`

Differential Revision: D106817342


