### PR TITLE
Add `--kineto-validation` CLI option to tagging benchmark (#1102)

### DIFF
--- a/.github/scripts/generate_tritonbench_matrix.py
+++ b/.github/scripts/generate_tritonbench_matrix.py
@@ -78,7 +78,9 @@ def validate_requested_values(
         )
 
     unknown_channels = [
-        channel for channel in triton_channels if channel not in SUPPORTED_TRITON_CHANNELS
+        channel
+        for channel in triton_channels
+        if channel not in SUPPORTED_TRITON_CHANNELS
     ]
     if unknown_channels:
         raise ValueError(
@@ -205,9 +207,7 @@ def main() -> int:
         requested_benchmarks, requested_triton_channels, requested_runners
     )
 
-    benchmarks = select_benchmarks(
-        requested_benchmarks, args.event_name, changed_files
-    )
+    benchmarks = select_benchmarks(requested_benchmarks, args.event_name, changed_files)
 
     full_matrix_entries: list[dict[str, str]] = []
     for benchmark in benchmarks:

--- a/benchmarks/compare_benchmarks/run.py
+++ b/benchmarks/compare_benchmarks/run.py
@@ -63,9 +63,7 @@ from tritonbench.utils.env_utils import is_fbcode
 from tritonbench.utils.run_utils import run_in_task, run_one_operator
 
 if is_fbcode():
-    from pytorch.tritonbench.benchmarks.compare_benchmarks.utils import (
-        log_benchmark,
-    )
+    from pytorch.tritonbench.benchmarks.compare_benchmarks.utils import log_benchmark
     from pytorch.tritonbench.tools.fb.inductor_analyzer.autotune_parser import (
         compare_benchmark_results,
         parse_benchmark_results,
@@ -234,9 +232,7 @@ def _resolve_input_loaders(
         loader_path = Path(config.input_loader)
 
         if loader_path.is_file():
-            print(
-                f"[Compare Benchmarks] Shape source: file '{config.input_loader}'"
-            )
+            print(f"[Compare Benchmarks] Shape source: file '{config.input_loader}'")
             return [(loader_path.stem, config.input_loader)]
 
         if loader_path.is_dir():
@@ -271,9 +267,7 @@ def _resolve_input_loaders(
         )
         return []
 
-    print(
-        "[Compare Benchmarks] Shape source: ai_infra.inductor_mm_shapes (Hive)"
-    )
+    print("[Compare Benchmarks] Shape source: ai_infra.inductor_mm_shapes (Hive)")
     from pytorch.tritonbench.benchmarks.compare_benchmarks.fb.hive_shapes import (
         get_shapes_from_hive,
     )

--- a/benchmarks/compile_time/run.py
+++ b/benchmarks/compile_time/run.py
@@ -9,6 +9,7 @@ CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 
 from ..common import run_benchmark_config_ci
 
+
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--name", default="compile_time", help="Benchmark name.")
@@ -30,6 +31,7 @@ def main() -> None:
         ci=args.ci,
         log_scuba=args.log_scuba,
     )
+
 
 if __name__ == "__main__":
     # Do not add code here, it won't be run. Add them to the function called below.

--- a/benchmarks/sweep_runner/run.py
+++ b/benchmarks/sweep_runner/run.py
@@ -147,7 +147,9 @@ def generate_run_config(
     override_benchmarks = sweep_runner_config.get("overrides", {})
 
     config_count = 0
-    for _run_config_name, run_config_value in sweep_runner_config["run_configs"].items():
+    for _run_config_name, run_config_value in sweep_runner_config[
+        "run_configs"
+    ].items():
         if skip_tests := run_config_value.get("skip_tests", None):
             skip_tests = [
                 load_config(skip_test, base_dir=REPO_PATH) for skip_test in skip_tests

--- a/benchmarks/tagging/run.py
+++ b/benchmarks/tagging/run.py
@@ -3,10 +3,15 @@ Trace op backends to generate tags.
 """
 
 import argparse
+import gzip
+import json
 import logging
 import os
+import subprocess
+import sys
+import tempfile
 from pathlib import Path
-from typing import Any
+from typing import Any, Dict, List
 
 import yaml
 
@@ -22,9 +27,10 @@ setup_tritonbench_cwd()
 
 import inspect
 
+from tritonbench.components.do_bench.run import _is_cache_clear_kernel
 from tritonbench.operators import list_operators
 from tritonbench.utils.operator_utils import get_backends_for_operator
-from tritonbench.utils.run_utils import load_operator_by_args
+from tritonbench.utils.run_utils import load_operator_by_args, run_in_task
 from tritonbench.utils.triton_op import REGISTERED_BENCHMARKS
 
 try:
@@ -46,12 +52,216 @@ def get_parser():
         help="Only trace the specified backend. If unspecified, trace all backends.",
     )
     parser.add_argument(
+        "--static-analysis-result",
+        type=str,
+        default="",
+        help="Path to an existing static analysis result YAML file. Used as "
+        "input when --bypass-run is set to skip recomputing static analysis.",
+    )
+    parser.add_argument(
         "--output",
         type=str,
         default="",
-        help="Output file path. If none, print to stdout.",
+        help="Output file path. With --kineto-validation, the validation "
+        "results are written here. Without it, the static analysis results "
+        "are written here. If unspecified, results are printed to stdout.",
+    )
+    parser.add_argument(
+        "--kineto-validation",
+        action="store_true",
+        default=False,
+        help="For each operator backend, run one input with kineto tracing "
+        "and compare observed GPU kernel names against static analysis results.",
+    )
+    parser.add_argument(
+        "--kineto-trace-dir",
+        type=str,
+        default=None,
+        help="Directory to save kineto trace files when --kineto-validation is set.",
+    )
+    parser.add_argument(
+        "--kineto-dir",
+        type=str,
+        default=None,
+        help="Manifold URL (manifold://<bucket>/<path>) or local directory "
+        "containing pre-collected kineto traces. Requires --kineto-validation. "
+        "If a manifold URL, traces are downloaded to --kineto-trace-dir "
+        "(default /tmp/kineto_traces). If a local directory, it is used "
+        "directly as the trace dir. Existing traces are reused without re-running.",
+    )
+    parser.add_argument(
+        "--bypass-run",
+        action="store_true",
+        default=False,
+        help="When used with --kineto-validation, skip both static analysis "
+        "and GPU trace collection. Static analysis results are loaded from "
+        "the file specified by --static-analysis-result instead of being recomputed. Kineto "
+        "traces that are not already available are skipped. If --kineto-dir "
+        "is not set, defaults to "
+        "manifold://tc_bench_ci/tree/tritonbench/kineto_traces.",
+    )
+    parser.add_argument(
+        "--kineto-collect",
+        type=str,
+        default=None,
+        help=argparse.SUPPRESS,
     )
     return parser
+
+
+_NON_KERNEL_EVENT_NAMES = frozenset(
+    {
+        "cudaMemcpyAsync",
+        "cudaMemsetAsync",
+        "cudaMemcpy",
+        "cudaMemset",
+        "Memcpy HtoD",
+        "Memcpy DtoH",
+        "Memcpy DtoD",
+        "Memset",
+    }
+)
+
+
+def extract_kernel_names(trace_data: Dict[str, Any]) -> List[str]:
+    """Extract deduplicated GPU kernel names from a kineto trace dict."""
+    events = trace_data.get("traceEvents", [])
+    kernel_names: set[str] = set()
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        cat = event.get("cat", "")
+        name = event.get("name", "")
+        if (
+            cat == "kernel"
+            and name
+            and name not in _NON_KERNEL_EVENT_NAMES
+            and not _is_cache_clear_kernel(name)
+        ):
+            kernel_names.add(name)
+    return sorted(kernel_names)
+
+
+def parse_kineto_trace(trace_path: str, output_dir: str | None = None) -> List[str]:
+    """Load a kineto trace from a local path and return GPU kernel names.
+
+    Args:
+        trace_path: Return value of ``opbench.kineto_trace()`` — a local file
+            path or a URL.  Local ``.json`` and ``.json.gz`` files are read
+            directly.
+        output_dir: Fallback directory to scan for trace files when
+            *trace_path* does not point to a readable file (e.g. when
+            ``kineto_trace`` returns a remote URL).
+
+    Returns:
+        Sorted, deduplicated list of GPU kernel names.
+    """
+    trace_data = None
+
+    # 1. Try trace_path as a local file.
+    if os.path.isfile(trace_path):
+        if trace_path.endswith(".gz"):
+            with gzip.open(trace_path, "rt") as f:
+                trace_data = json.load(f)
+        else:
+            with open(trace_path, "r") as f:
+                trace_data = json.load(f)
+
+    # 2. Fallback: scan output_dir for the latest trace file.
+    if trace_data is None and output_dir and os.path.isdir(output_dir):
+        candidates = sorted(
+            Path(output_dir).glob("*.json*"),
+            key=lambda p: p.stat().st_ctime,
+            reverse=True,
+        )
+        for candidate in candidates:
+            if candidate.name.endswith(".json.gz"):
+                with gzip.open(candidate, "rt") as f:
+                    trace_data = json.load(f)
+                break
+            elif candidate.name.endswith(".json"):
+                with open(candidate, "r") as f:
+                    trace_data = json.load(f)
+                break
+
+    if trace_data is None:
+        logger.warning(f"Could not load kineto trace from {trace_path}")
+        return []
+
+    return extract_kernel_names(trace_data)
+
+
+def _find_cached_trace(trace_dir: str, op_name: str, backend_name: str) -> str | None:
+    """Return the path of an existing trace in the trace dir, or None."""
+    trace_dir_path = Path(trace_dir)
+    if not trace_dir_path.is_dir():
+        return None
+    prefix = f"{op_name}-{backend_name}"
+    matching_dirs = sorted(
+        (
+            d
+            for d in trace_dir_path.iterdir()
+            if d.is_dir() and d.name.startswith(prefix)
+        ),
+        key=lambda d: d.stat().st_ctime,
+        reverse=True,
+    )
+    if not matching_dirs:
+        return None
+    candidates = sorted(
+        matching_dirs[0].glob("*.json*"),
+        key=lambda p: p.stat().st_ctime,
+        reverse=True,
+    )
+    return str(candidates[0]) if candidates else None
+
+
+def collect_kineto_kernel_names(
+    op_name: str, backend_name: str, trace_dir: str | None = None
+) -> List[str]:
+    """Run one input of *backend_name* under kineto and return kernel names."""
+    if trace_dir:
+        cached = _find_cached_trace(trace_dir, op_name, backend_name)
+        if cached:
+            logger.info(
+                f"Using cached kineto trace for {op_name}/{backend_name}: {cached}"
+            )
+            return parse_kineto_trace(cached)
+
+    import torch
+    from tritonbench.utils.input import input_cast
+
+    opbench = load_operator_by_args(
+        task_args=[
+            "--op",
+            op_name,
+            "--num-inputs",
+            "1",
+            "--only",
+            backend_name,
+            "--warmup",
+            "0",
+            "--rep",
+            "0",
+        ]
+    )
+    opbench._cur_input_id = 0
+    opbench.example_inputs = opbench.get_example_inputs()
+    if opbench.example_inputs is None:
+        logger.warning(f"No inputs available for {op_name}/{backend_name}. Skipping.")
+        return []
+    opbench.example_inputs = input_cast(
+        lambda x: isinstance(x, torch.Tensor),
+        lambda x: x.to(opbench.device),
+        opbench.example_inputs,
+    )
+    fn = opbench._get_bm_func(backend_name)
+    x_val = opbench.get_x_val(opbench.example_inputs)
+    output_dir = None
+    if trace_dir:
+        output_dir = str(Path(trace_dir) / f"{op_name}-{backend_name}-x_{x_val}")
+    trace_path = opbench.kineto_trace(input_id=0, fn=fn, output_dir=output_dir)
+    return parse_kineto_trace(trace_path, output_dir=output_dir)
 
 
 def apply_name_based_heuristics(backend_name, tags_dict):
@@ -176,7 +386,7 @@ def trace_op(op):
     op_with_tags = {op: {}}
     try:
         opbench = load_operator_by_args(task_args=["--op", op])
-    except (ModuleNotFoundError, NotImplementedError) as e:
+    except Exception as e:
         logger.warning(f"Failed to load operator '{op}': {e}. Skipping.")
         return op_with_tags
     opbench_file = inspect.getfile(opbench.__class__)
@@ -222,20 +432,229 @@ def trace_op(op):
     return op_with_tags
 
 
+_PT2_TRITON_PREFIXES = (
+    "triton_poi_",
+    "triton_red_",
+    "triton_tem_",
+    "triton_per_",
+    "triton_fused_",
+)
+_NON_TRITON_SUBSTRINGS = ("nvjet", "xmma", "cublas", "cublaslt", "cutlass", "cudnn_")
+
+
+def _is_handwritten_triton_kernel(name: str) -> bool:
+    if any(name.startswith(p) for p in _PT2_TRITON_PREFIXES):
+        return False
+    if any(s in name.lower() for s in _NON_TRITON_SUBSTRINGS):
+        return False
+    if name.startswith("void "):
+        return False
+    return True
+
+
+def collect_kineto_kernel_names_subprocess(
+    op_name: str,
+    backend_name: str,
+    trace_dir: str | None = None,
+    bypass_run: bool = False,
+) -> tuple[List[str], str]:
+    """Run kineto collection in a separate process to isolate CUDA crashes."""
+    if trace_dir:
+        cached = _find_cached_trace(trace_dir, op_name, backend_name)
+        if cached:
+            logger.info(
+                f"Using cached kineto trace for {op_name}/{backend_name}: {cached}"
+            )
+            return parse_kineto_trace(cached), "ok"
+
+    if bypass_run:
+        logger.info(
+            f"No cached trace for {op_name}/{backend_name}, skipping (--bypass-run)"
+        )
+        return [], "skipped"
+
+    fd, result_file = tempfile.mkstemp(suffix=".json", prefix="kineto_result_")
+    os.close(fd)
+    try:
+        with tempfile.TemporaryDirectory(prefix="kineto_log_") as log_dir:
+            op_args = [
+                "--op",
+                op_name,
+                "--only",
+                backend_name,
+                "--kineto-collect",
+                result_file,
+            ]
+            if trace_dir:
+                op_args += ["--kineto-trace-dir", trace_dir]
+            returncode = run_in_task(
+                op_args=op_args,
+                benchmark_name=f"kineto_{op_name}_{backend_name}",
+                capture_output=log_dir,
+                timeout_s=300,
+            )
+        if returncode != 0:
+            logger.warning(
+                f"Kineto subprocess crashed for {op_name}/{backend_name} "
+                f"(exit code {returncode})"
+            )
+            if os.path.exists(result_file) and os.path.getsize(result_file) > 0:
+                with open(result_file, "r") as f:
+                    data = json.load(f)
+                return data.get("kernels", []), "error"
+            return [], "error"
+        if os.path.exists(result_file) and os.path.getsize(result_file) > 0:
+            with open(result_file, "r") as f:
+                data = json.load(f)
+            if data.get("status") == "error":
+                logger.warning(
+                    f"Kineto error for {op_name}/{backend_name}: "
+                    f"{data.get('error', 'unknown')}"
+                )
+            return data.get("kernels", []), data.get("status", "error")
+        return [], "error"
+    finally:
+        if os.path.exists(result_file):
+            os.unlink(result_file)
+
+
+def run_kineto_validation(
+    ops, results, kineto_trace_dir=None, output_file=None, bypass_run=False
+):
+    """For each op/backend, collect kineto kernel names and compare with
+    static analysis results.  When *output_file* is set the yaml is flushed
+    after every op so partial results survive crashes."""
+    validation = {}
+    for op in ops:
+        op_results = results.get(op, {})
+        validation[op] = {}
+        for backend, static_info in op_results.items():
+            static_kernels = static_info.get("kernels", []) if static_info else []
+            kineto_kernels, status = collect_kineto_kernel_names_subprocess(
+                op, backend, trace_dir=kineto_trace_dir, bypass_run=bypass_run
+            )
+            handwritten = [
+                k for k in kineto_kernels if _is_handwritten_triton_kernel(k)
+            ]
+            if status == "skipped":
+                status = "kineto_missing"
+            elif status == "ok" and handwritten:
+                if not set(handwritten).issubset(set(static_kernels)):
+                    status = "mismatch"
+            print(
+                f"[{op}/{backend}] status={status} "
+                f"static_kernels={static_kernels} "
+                f"kineto_kernels={kineto_kernels} "
+                f"handwritten_triton={handwritten}"
+            )
+            if handwritten or status == "kineto_missing":
+                validation[op][backend] = {
+                    "static_kernels": static_kernels,
+                    "kineto_kernels": handwritten,
+                    "status": status,
+                }
+            if output_file:
+                to_write = {k: v for k, v in validation.items() if v}
+                with open(output_file, "w") as f:
+                    f.write(yaml.safe_dump(to_write))
+        if not validation[op]:
+            del validation[op]
+    return validation
+
+
+def _download_manifold_traces(manifold_url: str, local_dir: str) -> None:
+    """Download kineto traces from a manifold URL to a local directory."""
+    Path(local_dir).mkdir(parents=True, exist_ok=True)
+    url = manifold_url.removeprefix("manifold://")
+    cmd = ["manifold", "getr", url, local_dir, "--skip_root_dir"]
+    logger.info(f"Downloading kineto traces: {' '.join(cmd)}")
+    subprocess.check_call(cmd)
+    logger.info(f"Downloaded kineto traces to {local_dir}")
+
+
+_DEFAULT_MANIFOLD_TRACE_URL = "manifold://tc_bench_ci/tree/tritonbench/kineto_traces"
+
+
+def _resolve_kineto_dir(args) -> str | None:
+    """Resolve --kineto-dir and --kineto-trace-dir into the local trace dir."""
+    kineto_dir = args.kineto_dir
+    if not kineto_dir and args.bypass_run:
+        kineto_dir = _DEFAULT_MANIFOLD_TRACE_URL
+    if kineto_dir:
+        if kineto_dir.startswith("manifold://"):
+            local_dir = args.kineto_trace_dir or "/tmp/kineto_traces"
+            if not os.path.isdir(local_dir) or not any(Path(local_dir).iterdir()):
+                _download_manifold_traces(kineto_dir, local_dir)
+            else:
+                logger.info(f"Using existing traces in {local_dir}")
+            return local_dir
+        else:
+            return kineto_dir
+    return args.kineto_trace_dir
+
+
 if __name__ == "__main__":
     parser = get_parser()
     args = parser.parse_args()
-    if not args.op:
-        ops = list_operators()
-    else:
-        ops = [args.op]
-    print(f"Running tagging test on ops: {ops}...")
+
+    if args.kineto_collect:
+        try:
+            kernels = collect_kineto_kernel_names(
+                args.op, args.only, trace_dir=args.kineto_trace_dir
+            )
+            with open(args.kineto_collect, "w") as f:
+                json.dump({"kernels": kernels, "status": "ok"}, f)
+        except Exception as e:
+            with open(args.kineto_collect, "w") as f:
+                json.dump({"kernels": [], "status": "error", "error": str(e)}, f)
+        sys.exit(0)
+
     results = {}
-    for op in ops:
-        results.update(trace_op(op))
-    if not args.output:
-        print(results)
+    if args.bypass_run:
+        if not args.static_analysis_result or not os.path.isfile(
+            args.static_analysis_result
+        ):
+            parser.error(
+                "--bypass-run requires --static-analysis-result pointing to an "
+                "existing YAML file with static analysis results"
+            )
+        logger.info(
+            f"Loading static analysis results from {args.static_analysis_result} (--bypass-run)"
+        )
+        with open(args.static_analysis_result, "r") as f:
+            results = yaml.safe_load(f) or {}
+        if args.op:
+            ops = [args.op]
+        else:
+            ops = list(results.keys())
     else:
-        with open(args.output, "w") as f:
-            f.write(yaml.safe_dump(results))
-        print("success!")
+        if not args.op:
+            ops = list_operators()
+        else:
+            ops = [args.op]
+        for op in ops:
+            results.update(trace_op(op))
+    print(f"Running tagging test on ops: {ops}...")
+
+    if args.kineto_validation:
+        if args.output:
+            Path(args.output).parent.mkdir(parents=True, exist_ok=True)
+        kineto_trace_dir = _resolve_kineto_dir(args)
+        validation = run_kineto_validation(
+            ops,
+            results,
+            kineto_trace_dir=kineto_trace_dir,
+            output_file=args.output,
+            bypass_run=args.bypass_run,
+        )
+        if args.output:
+            print("Kineto validation written to", args.output)
+        else:
+            print(yaml.safe_dump(validation))
+    else:
+        if not args.output:
+            print(results)
+        else:
+            with open(args.output, "w") as f:
+                f.write(yaml.safe_dump(results))
+            print("success!")

--- a/benchmarks/tagging/tests/sample_kineto_trace.json
+++ b/benchmarks/tagging/tests/sample_kineto_trace.json
@@ -1,0 +1,74 @@
+{
+    "traceEvents": [
+        {
+            "ph": "X",
+            "cat": "cpu_op",
+            "name": "aten::mm",
+            "pid": 1,
+            "tid": 1,
+            "ts": 1000000,
+            "dur": 500,
+            "args": {}
+        },
+        {
+            "ph": "X",
+            "cat": "kernel",
+            "name": "triton_gemm_kernel_0d1d2d",
+            "pid": 1,
+            "tid": 2,
+            "ts": 1000100,
+            "dur": 200,
+            "args": {}
+        },
+        {
+            "ph": "X",
+            "cat": "kernel",
+            "name": "triton_gemm_kernel_0d1d2d",
+            "pid": 1,
+            "tid": 2,
+            "ts": 1000400,
+            "dur": 200,
+            "args": {}
+        },
+        {
+            "ph": "X",
+            "cat": "kernel",
+            "name": "sm90_xmma_gemm_f16f16_f32",
+            "pid": 1,
+            "tid": 2,
+            "ts": 1001000,
+            "dur": 100,
+            "args": {}
+        },
+        {
+            "ph": "X",
+            "cat": "kernel",
+            "name": "void at::native::vectorized_elementwise_kernel<4, at::native::CUDAFunctorOnSelf_add<float>, at::detail::Array<char*, 3>>",
+            "pid": 1,
+            "tid": 2,
+            "ts": 1001200,
+            "dur": 50,
+            "args": {}
+        },
+        {
+            "ph": "X",
+            "cat": "gpu_memcpy",
+            "name": "Memcpy HtoD",
+            "pid": 1,
+            "tid": 2,
+            "ts": 1001300,
+            "dur": 30,
+            "args": {}
+        },
+        {
+            "ph": "X",
+            "cat": "kernel",
+            "name": "Memcpy DtoD",
+            "pid": 1,
+            "tid": 2,
+            "ts": 1001400,
+            "dur": 30,
+            "args": {}
+        }
+    ]
+}

--- a/benchmarks/tagging/tests/test_kineto_validation.py
+++ b/benchmarks/tagging/tests/test_kineto_validation.py
@@ -1,0 +1,131 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+import gzip
+import json
+import os
+import tempfile
+import unittest
+
+from pytorch.tritonbench.benchmarks.tagging.run import (
+    extract_kernel_names,
+    parse_kineto_trace,
+)
+
+
+SAMPLE_TRACE_PATH = os.path.join(os.path.dirname(__file__), "sample_kineto_trace.json")
+
+
+class ExtractKernelNamesTest(unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        with open(SAMPLE_TRACE_PATH, "r") as f:
+            self.trace_data = json.load(f)
+
+    def test_extracts_kernel_events(self) -> None:
+        names = extract_kernel_names(self.trace_data)
+        self.assertIn("triton_gemm_kernel_0d1d2d", names)
+        self.assertIn("sm90_xmma_gemm_f16f16_f32", names)
+
+    def test_deduplicates_kernel_names(self) -> None:
+        names = extract_kernel_names(self.trace_data)
+        self.assertEqual(len(names), len(set(names)))
+
+    def test_excludes_non_kernel_categories(self) -> None:
+        names = extract_kernel_names(self.trace_data)
+        self.assertNotIn("aten::mm", names)
+
+    def test_excludes_memcpy_memset_events(self) -> None:
+        names = extract_kernel_names(self.trace_data)
+        self.assertNotIn("Memcpy HtoD", names)
+        self.assertNotIn("Memcpy DtoD", names)
+
+    def test_includes_elementwise_kernel(self) -> None:
+        names = extract_kernel_names(self.trace_data)
+        self.assertTrue(any("vectorized_elementwise_kernel" in n for n in names))
+
+    def test_returns_sorted(self) -> None:
+        names = extract_kernel_names(self.trace_data)
+        self.assertEqual(names, sorted(names))
+
+    def test_empty_trace(self) -> None:
+        names = extract_kernel_names({"traceEvents": []})
+        self.assertEqual(names, [])
+
+    def test_no_kernel_events(self) -> None:
+        trace = {
+            "traceEvents": [
+                {"ph": "X", "cat": "cpu_op", "name": "aten::mm"},
+            ]
+        }
+        names = extract_kernel_names(trace)
+        self.assertEqual(names, [])
+
+    def test_missing_trace_events_key(self) -> None:
+        names = extract_kernel_names({})
+        self.assertEqual(names, [])
+
+    def test_non_dict_events_skipped(self) -> None:
+        trace = {
+            "traceEvents": [
+                "not a dict",
+                {"ph": "X", "cat": "kernel", "name": "my_kernel"},
+            ]
+        }
+        names = extract_kernel_names(trace)
+        self.assertEqual(names, ["my_kernel"])
+
+
+class ParseKinetoTraceFromJsonTest(unittest.TestCase):
+    def test_parse_json_file(self) -> None:
+        names = parse_kineto_trace(SAMPLE_TRACE_PATH)
+        self.assertIn("triton_gemm_kernel_0d1d2d", names)
+        self.assertIn("sm90_xmma_gemm_f16f16_f32", names)
+
+    def test_parse_gzip_file(self) -> None:
+        with tempfile.NamedTemporaryFile(suffix=".json.gz", delete=False) as f:
+            gz_path = f.name
+        try:
+            with open(SAMPLE_TRACE_PATH, "r") as src:
+                data = src.read()
+            with gzip.open(gz_path, "wt") as gz:
+                gz.write(data)
+            names = parse_kineto_trace(gz_path)
+            self.assertIn("triton_gemm_kernel_0d1d2d", names)
+        finally:
+            os.unlink(gz_path)
+
+    def test_fallback_to_output_dir(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dest = os.path.join(tmpdir, "trace.json")
+            with open(SAMPLE_TRACE_PATH, "r") as src:
+                data = src.read()
+            with open(dest, "w") as f:
+                f.write(data)
+            names = parse_kineto_trace("/nonexistent/path.json", output_dir=tmpdir)
+            self.assertIn("triton_gemm_kernel_0d1d2d", names)
+
+    def test_fallback_to_output_dir_gzip(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dest = os.path.join(tmpdir, "trace.json.gz")
+            with open(SAMPLE_TRACE_PATH, "r") as src:
+                data = src.read()
+            with gzip.open(dest, "wt") as gz:
+                gz.write(data)
+            names = parse_kineto_trace("/nonexistent/path.json", output_dir=tmpdir)
+            self.assertIn("sm90_xmma_gemm_f16f16_f32", names)
+
+    def test_nonexistent_path_returns_empty(self) -> None:
+        names = parse_kineto_trace("/nonexistent/path.json")
+        self.assertEqual(names, [])
+
+    def test_nonexistent_path_and_dir_returns_empty(self) -> None:
+        names = parse_kineto_trace(
+            "/nonexistent/path.json", output_dir="/nonexistent/dir"
+        )
+        self.assertEqual(names, [])
+
+    def test_url_without_output_dir_returns_empty(self) -> None:
+        names = parse_kineto_trace(
+            "https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=foo"
+        )
+        self.assertEqual(names, [])

--- a/benchmarks/timing_accuracy/run.py
+++ b/benchmarks/timing_accuracy/run.py
@@ -11,7 +11,7 @@ from typing import Any, Callable, Dict, List, Optional
 import torch
 import triton
 
-from ..common import setup_tritonbench_cwd, run_benchmark_config_ci
+from ..common import run_benchmark_config_ci, setup_tritonbench_cwd
 
 setup_tritonbench_cwd()
 
@@ -404,33 +404,29 @@ def transform_single_result(result) -> Dict[str, Any]:
     out[f"{prefix}rep"] = result["config"]["rep"]
     for method_name, method_stats in result["results"].items():
         method_key = method_stats["method_name"]
-        out[f"{prefix}{method_key}-benchmark_time_s"] = method_stats[
-            "benchmark_time_s"
-        ]
+        out[f"{prefix}{method_key}-benchmark_time_s"] = method_stats["benchmark_time_s"]
         out[f"{prefix}{method_key}-intra_test_avg_median_ms"] = method_stats[
             "intra_test"
         ]["avg_median_ms"]
-        out[f"{prefix}{method_key}-intra_test_avg_std_ms"] = method_stats[
-            "intra_test"
-        ]["avg_std_ms"]
+        out[f"{prefix}{method_key}-intra_test_avg_std_ms"] = method_stats["intra_test"][
+            "avg_std_ms"
+        ]
         out[f"{prefix}{method_key}-intra_test_avg_cv"] = method_stats["intra_test"][
             "avg_cv"
         ]
-        out[f"{prefix}{method_key}-intra_test_avg_min_ms"] = method_stats[
-            "intra_test"
-        ]["avg_min_ms"]
-        out[f"{prefix}{method_key}-intra_test_avg_max_ms"] = method_stats[
-            "intra_test"
-        ]["avg_max_ms"]
-        out[f"{prefix}{method_key}-inter_test_median_ms"] = method_stats[
-            "inter_test"
-        ]["median_ms"]
+        out[f"{prefix}{method_key}-intra_test_avg_min_ms"] = method_stats["intra_test"][
+            "avg_min_ms"
+        ]
+        out[f"{prefix}{method_key}-intra_test_avg_max_ms"] = method_stats["intra_test"][
+            "avg_max_ms"
+        ]
+        out[f"{prefix}{method_key}-inter_test_median_ms"] = method_stats["inter_test"][
+            "median_ms"
+        ]
         out[f"{prefix}{method_key}-inter_test_std_ms"] = method_stats["inter_test"][
             "std_ms"
         ]
-        out[f"{prefix}{method_key}-inter_test_cv"] = method_stats["inter_test"][
-            "cv"
-        ]
+        out[f"{prefix}{method_key}-inter_test_cv"] = method_stats["inter_test"]["cv"]
         out[f"{prefix}{method_key}-inter_test_min_ms"] = method_stats["inter_test"][
             "min_ms"
         ]
@@ -469,7 +465,9 @@ def run(args: Optional[List[str]] = None):
         action="store_true",
         help="Log results to Scuba",
     )
-    parser.add_argument("--output-json", type=str, default=None, help="Output JSON file")
+    parser.add_argument(
+        "--output-json", type=str, default=None, help="Output JSON file"
+    )
     parser.add_argument("--quiet", action="store_true")
 
     if not torch.cuda.is_available():
@@ -493,7 +491,6 @@ def run(args: Optional[List[str]] = None):
 
     tb_args, extra_args = tb_parser.parse_known_args(extra_args)
     _run(args, tb_args, extra_args)
-
 
 
 if __name__ == "__main__":

--- a/test/test_cpu/test_env_utils.py
+++ b/test/test_cpu/test_env_utils.py
@@ -1,12 +1,11 @@
 import unittest
 
 import torch
-
 from tritonbench.utils.env_utils import (
     IS_BLACKWELL,
+    is_blackwell,
     IS_BLACKWELL_ANY,
     IS_BLACKWELL_CONSUMER,
-    is_blackwell,
     is_blackwell_consumer,
 )
 

--- a/test/test_gpu/main.py
+++ b/test/test_gpu/main.py
@@ -84,11 +84,13 @@ def _gen_test_operators(test_ops, skip_tests) -> set[str]:
                     if disabled_channels is None
                     else _env_check({"channels": disabled_channels}, "channels")
                 )
-                test_ops[skip_op]["disabled"] = test_ops[skip_op][
-                    "disabled"
-                ] or (disabled_device_match and disabled_channel_match)
-        if test_ops[skip_op]["disabled"] and skip_tests[skip_op] and skip_tests[skip_op].get(
-            "report", False
+                test_ops[skip_op]["disabled"] = test_ops[skip_op]["disabled"] or (
+                    disabled_device_match and disabled_channel_match
+                )
+        if (
+            test_ops[skip_op]["disabled"]
+            and skip_tests[skip_op]
+            and skip_tests[skip_op].get("report", False)
         ):
             logger.warning(
                 "%s test is temporarily disabled and needs work to re-enable it.",
@@ -98,6 +100,7 @@ def _gen_test_operators(test_ops, skip_tests) -> set[str]:
 
 
 TEST_OPERATORS = _gen_test_operators(TEST_OPERATORS, skip_tests)
+
 
 def check_ci_output(op):
     from tritonbench.utils.triton_op import (

--- a/test/test_gpu/test_amd_build.py
+++ b/test/test_gpu/test_amd_build.py
@@ -1,4 +1,3 @@
-
 """
 AMD/ROCm build verification test for tritonbench.
 

--- a/test/test_gpu/test_blackwell_attention_kernels.py
+++ b/test/test_gpu/test_blackwell_attention_kernels.py
@@ -20,15 +20,15 @@ class FlashAttention:
     @staticmethod
     def create_inputs(Z, H, N_CTX, HEAD_DIM, dtype=torch.bfloat16):
         torch.manual_seed(20)
-        q = torch.empty(
-            (Z, H, N_CTX, HEAD_DIM), device="cuda", dtype=dtype
-        ).normal_(mean=0.0, std=0.5)
-        k = torch.empty(
-            (Z, H, N_CTX, HEAD_DIM), device="cuda", dtype=dtype
-        ).normal_(mean=0.0, std=0.5)
-        v = torch.empty(
-            (Z, H, N_CTX, HEAD_DIM), device="cuda", dtype=dtype
-        ).normal_(mean=0.0, std=0.5)
+        q = torch.empty((Z, H, N_CTX, HEAD_DIM), device="cuda", dtype=dtype).normal_(
+            mean=0.0, std=0.5
+        )
+        k = torch.empty((Z, H, N_CTX, HEAD_DIM), device="cuda", dtype=dtype).normal_(
+            mean=0.0, std=0.5
+        )
+        v = torch.empty((Z, H, N_CTX, HEAD_DIM), device="cuda", dtype=dtype).normal_(
+            mean=0.0, std=0.5
+        )
         return q, k, v
 
     @staticmethod
@@ -81,15 +81,14 @@ class FlashAttention:
 # Blackwell FA2 autoWS (fwd + bwd)
 # =============================================================================
 
+
 @unittest.skip("TODO: RuntimeError on autoWS")
 class TestBlackwellTritonFusedAttention(unittest.TestCase):
     """Tests for blackwell_triton_fused_attention.py (autoWS variant)."""
 
     @classmethod
     def setUpClass(cls):
-        from tritonbench.kernels.blackwell_triton_fused_attention import (
-            attention_opt,
-        )
+        from tritonbench.kernels.blackwell_triton_fused_attention import attention_opt
 
         cls.attention_opt = staticmethod(attention_opt)
 

--- a/tools/cuda_utils.py
+++ b/tools/cuda_utils.py
@@ -5,8 +5,8 @@ import shutil
 import subprocess
 from pathlib import Path
 
-from .torch_utils import install_pytorch_nightly, install_pytorch_wheel
 from .python_utils import get_pip_cmd, USE_UV
+from .torch_utils import install_pytorch_nightly, install_pytorch_wheel
 
 # defines the default CUDA version to compile against
 DEFAULT_CUDA_VERSION = "13.0"

--- a/tritonbench/components/kineto/trace.py
+++ b/tritonbench/components/kineto/trace.py
@@ -15,6 +15,9 @@ from tritonbench.components.do_bench.utils import (
 from tritonbench.utils.constants import DEFAULT_N_REP, DEFAULT_N_WARMUP
 from tritonbench.utils.env_utils import has_manifold
 
+if not hasattr(torch.version, "git_version"):
+    from .fb.run_utils import trace_handler
+
 DEFAULT_PROFILE_OPTS = {
     "record_shapes": True,
     "profile_memory": True,
@@ -22,9 +25,6 @@ DEFAULT_PROFILE_OPTS = {
     "with_flops": True,
     "with_modules": True,
 }
-
-if not hasattr(torch.version, "git_version"):
-    from .fb.run_utils import trace_handler
 
 
 def _find_the_latest_file(output_dir, recursive: bool = False, glob_pattern="*"):
@@ -52,22 +52,21 @@ def _find_the_latest_file(output_dir, recursive: bool = False, glob_pattern="*")
     return latest_path.name if latest_path else None
 
 
-def post_process(output_dir, name) -> str:
-    if not hasattr(torch.version, "git_version"):
+def post_process(output_dir, name, skip_manifold: bool = False) -> str:
+    if not output_dir:
         return f"https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/traces/tritonbench/{name}.gz&bucket=pyper_traces"
-    elif has_manifold():
-        lastest_json_file = _find_the_latest_file(output_dir, glob_pattern="*.json.gz")
-        assert lastest_json_file is not None, "No trace file found"
+    latest = _find_the_latest_file(output_dir, glob_pattern="*.json.gz")
+    trace_file = latest or name
+    if not skip_manifold and has_manifold():
         cmd = [
             "manifold",
             "put",
-            lastest_json_file,
-            f"pyper_traces/tree/traces/tritonbench/{lastest_json_file}",
+            trace_file,
+            f"pyper_traces/tree/traces/tritonbench/{trace_file}",
         ]
         subprocess.check_call(cmd, cwd=output_dir)
-        return f"https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/traces/tritonbench/{lastest_json_file}&bucket=pyper_traces"
-    else:
-        return f"{output_dir}/{name}"
+        return f"https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/traces/tritonbench/{trace_file}&bucket=pyper_traces"
+    return str(Path(output_dir) / trace_file)
 
 
 def do_bench_kineto_cudagraph(
@@ -78,6 +77,7 @@ def do_bench_kineto_cudagraph(
     grad_to_none,
     profile_opts,
     output_dir,
+    skip_manifold: bool = False,
 ) -> str:
     activity_groups = [
         profiler.ProfilerActivity.CUDA,
@@ -93,7 +93,8 @@ def do_bench_kineto_cudagraph(
             clear_cache()
             fn()
         torch.cuda.synchronize()
-        prefix = f"tritonbench_cudagraph_{fn._name}"
+        fn_name = getattr(fn, "_name", getattr(fn, "__name__", "unknown"))
+        prefix = f"tritonbench_cudagraph_{fn_name}"
         name = f"{prefix}_{datetime.now().strftime('%Y%m%d_%H%M%S')}_{''.join(random.choices(string.digits, k=10))}.json"
         # step 2 - profile cuda graph launch with kineto
         with profiler.profile(
@@ -106,11 +107,7 @@ def do_bench_kineto_cudagraph(
             with_stack=profile_opts["with_stack"],
             with_flops=profile_opts["with_flops"],
             with_modules=profile_opts["with_modules"],
-            on_trace_ready=(
-                partial(trace_handler, name)
-                if not hasattr(torch.version, "git_version")
-                else profiler.tensorboard_trace_handler(output_dir, use_gzip=True)
-            ),
+            on_trace_ready=_get_on_trace_ready(output_dir, name),
         ) as prof:
             for _i in range(n_warmup + n_repeat):
                 # we don't want `fn` to accumulate gradient values
@@ -121,7 +118,13 @@ def do_bench_kineto_cudagraph(
                         x.grad = None
                 g.replay()
                 prof.step()
-    return post_process(output_dir, name)
+    return post_process(output_dir, name, skip_manifold=skip_manifold)
+
+
+def _get_on_trace_ready(output_dir, name):
+    if not output_dir and not hasattr(torch.version, "git_version"):
+        return partial(trace_handler, name)
+    return profiler.tensorboard_trace_handler(output_dir, use_gzip=True)
 
 
 def do_bench_kineto(
@@ -149,12 +152,24 @@ def do_bench_kineto(
     :type fast_flush: bool
     :param profile_opts: Options to pass into profiler.profile
     :type profile_opts: dict, optional
-    :param output_dir: Output directory to store the trace
+    :param output_dir: Output directory to store the trace locally. When set,
+        the trace is saved as a gzipped JSON file in this directory and the
+        return value is the local file path. When ``None``, the trace is
+        uploaded to Manifold on internal builds.
     :type output_dir: str, optional
     """
     if profile_opts is None:
         profile_opts = DEFAULT_PROFILE_OPTS
+    import shutil
+    import tempfile
+
     import torch
+
+    user_output_dir = output_dir is not None
+    _temp_output_dir = None
+    if output_dir is None and hasattr(torch.version, "git_version"):
+        _temp_output_dir = tempfile.mkdtemp(prefix="tritonbench_kineto_")
+        output_dir = _temp_output_dir
 
     fn()
     torch.cuda.synchronize()
@@ -183,14 +198,22 @@ def do_bench_kineto(
 
     if use_cuda_graphs:
         return do_bench_kineto_cudagraph(
-            fn, clear_cache, n_warmup, n_repeat, grad_to_none, profile_opts, output_dir
+            fn,
+            clear_cache,
+            n_warmup,
+            n_repeat,
+            grad_to_none,
+            profile_opts,
+            output_dir,
+            skip_manifold=user_output_dir,
         )
 
     activity_groups = [
         profiler.ProfilerActivity.CUDA,
         profiler.ProfilerActivity.CPU,
     ]
-    prefix = f"tritonbench_{fn._name}"
+    fn_name = getattr(fn, "_name", getattr(fn, "__name__", "unknown"))
+    prefix = f"tritonbench_{fn_name}"
     name = f"{prefix}_{datetime.now().strftime('%Y%m%d_%H%M%S')}_{''.join(random.choices(string.digits, k=10))}.json"
     with profiler.profile(
         schedule=profiler.schedule(
@@ -202,11 +225,7 @@ def do_bench_kineto(
         with_stack=profile_opts["with_stack"],
         with_flops=profile_opts["with_flops"],
         with_modules=profile_opts["with_modules"],
-        on_trace_ready=(
-            partial(trace_handler, name)
-            if not hasattr(torch.version, "git_version")
-            else profiler.tensorboard_trace_handler(output_dir, use_gzip=True)
-        ),
+        on_trace_ready=_get_on_trace_ready(output_dir, name),
     ) as prof:
         for i in range(n_warmup + n_repeat):
             # we don't want `fn` to accumulate gradient values
@@ -219,7 +238,11 @@ def do_bench_kineto(
             clear_cache()
             fn()
             prof.step()
-    return post_process(output_dir, name)
+    try:
+        return post_process(output_dir, name, skip_manifold=user_output_dir)
+    finally:
+        if _temp_output_dir:
+            shutil.rmtree(_temp_output_dir, ignore_errors=True)
 
 
 def do_bench_kineto_walltime(fn, repcnt=5, profile_opts=None, output_dir=None):
@@ -234,7 +257,8 @@ def do_bench_kineto_walltime(fn, repcnt=5, profile_opts=None, output_dir=None):
         profiler.ProfilerActivity.CUDA,
         profiler.ProfilerActivity.CPU,
     ]
-    prefix = f"tritonbench_{fn._name}"
+    fn_name = getattr(fn, "_name", getattr(fn, "__name__", "unknown"))
+    prefix = f"tritonbench_{fn_name}"
     name = f"{prefix}_{datetime.now().strftime('%Y%m%d_%H%M%S')}_{''.join(random.choices(string.digits, k=10))}.json"
     with profiler.profile(
         schedule=profiler.schedule(wait=0, warmup=repcnt - 1, active=1, repeat=1),
@@ -244,11 +268,7 @@ def do_bench_kineto_walltime(fn, repcnt=5, profile_opts=None, output_dir=None):
         with_stack=profile_opts["with_stack"],
         with_flops=profile_opts["with_flops"],
         with_modules=profile_opts["with_modules"],
-        on_trace_ready=(
-            partial(trace_handler, name)
-            if not hasattr(torch.version, "git_version")
-            else profiler.tensorboard_trace_handler(output_dir, use_gzip=True)
-        ),
+        on_trace_ready=_get_on_trace_ready(output_dir, name),
     ) as prof:
         for i in range(repcnt):
             fn()

--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -2530,17 +2530,19 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
         att_trace_dir = launch_att(att_output_dir, op_task_args)
         return att_trace_dir
 
-    def kineto_trace(self, input_id: int, fn: Callable) -> str:
+    def kineto_trace(
+        self, input_id: int, fn: Callable, output_dir: Optional[str] = None
+    ) -> str:
         from tritonbench.components.kineto import do_bench_kineto
 
-        kineto_output_dir = self.get_temp_path(fn._name)
-        kineto_output_dir.mkdir(parents=True, exist_ok=True)
+        if output_dir is not None:
+            Path(output_dir).mkdir(parents=True, exist_ok=True)
         return do_bench_kineto(
             fn=fn,
             warmup=self.tb_args.warmup,
             rep=self.tb_args.rep,
             grad_to_none=self.get_grad_to_none(self.example_inputs),
-            output_dir=kineto_output_dir,
+            output_dir=output_dir,
             use_cuda_graphs=self.use_cuda_graphs,
             skip_cache_clearing=self.tb_args.skip_cache_clearing,
         )


### PR DESCRIPTION
Summary:

Add a `--kineto-validation` flag to `benchmarks/tagging/run.py` that cross-checks static analysis results against actual GPU kernel names observed via kineto tracing.

For each operator backend, the validation:
1. Loads the operator with a single input (`--num-inputs 1`, `--warmup 0`, `--rep 0`)
2. Calls `opbench.kineto_trace(input_id=0, fn)` to collect a kineto trace
3. Parses the trace file (JSON or JSON.gz) to extract deduplicated GPU kernel names (events with `cat == "kernel"`, excluding memcpy/memset)
4. Compares the observed kernel names against the `kernels` list from the static AST analysis

New functions in `run.py`:
- `extract_kernel_names()` — extracts GPU kernel names from a parsed kineto trace dict
- `parse_kineto_trace()` — loads a trace from a local file path (with fallback to scanning an output directory) and returns kernel names
- `collect_kineto_kernel_names()` — end-to-end: loads an operator, runs one input under kineto, and returns the kernel names
- `run_kineto_validation()` — orchestrates validation across all ops/backends and prints a comparison report

Added `local_trace_dir` parameter to `do_bench_kineto()` and `kineto_trace()`:
- When set, saves the kineto trace locally to the specified directory instead of uploading to Manifold
- Uses `profiler.tensorboard_trace_handler` to write `.json.gz` trace files directly to the given directory
- Returns the local file path instead of a remote URL
- Threaded through `triton_op.py:kineto_trace()` so callers can opt in
- The tagging benchmark passes `--kineto-trace-dir` through as `local_trace_dir`, eliminating the need for post-hoc file copying

Also fixed `fn._name` AttributeError in `do_bench_kineto` and `kineto_trace` by using `getattr(fn, "_name", ...)` fallback for functions not decorated with `register_benchmark`.

Differential Revision: D105982577


