### PR TITLE
tritonbench: add --helion-backend to override Helion backend

### DIFF
--- a/tritonbench/utils/helion_utils.py
+++ b/tritonbench/utils/helion_utils.py
@@ -1,0 +1,74 @@
+"""Generic Helion backend override for tritonbench.
+
+This lets you experiment with a non-default Helion code-generation backend
+(e.g. the CuTe DSL backend) for *any* operator's ``helion`` benchmark without
+editing the operator or kernel definitions.
+
+It works by:
+  1. Setting ``HELION_BACKEND`` so every ``helion.kernel(...)`` that does not
+     pass an explicit ``backend`` picks up the override (and so subprocess
+     children inherit it).
+  2. Wrapping ``helion.kernel`` to drop any hardcoded ``config=``/``configs=``
+     arguments when the override is non-Triton. Those configs are Triton
+     specific (indexing / pid_type / num_warps / ...) and are not valid for
+     other backends; dropping them makes the kernel fall back to the chosen
+     backend's own default config.
+
+Usage: pass ``--helion-backend <name>`` on the tritonbench CLI, e.g.
+
+    --op <any_op_with_a_helion_backend> --only helion --helion-backend cute
+"""
+
+import functools
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+_PATCHED = False
+
+
+def apply_helion_backend_override(backend: str | None) -> None:
+    """Route all Helion kernels in this process to ``backend``.
+
+    No-op when ``backend`` is falsy or ``"triton"`` (the default). Idempotent.
+    """
+    global _PATCHED
+    if not backend:
+        return
+
+    # Selection via env var: covers kernels that don't pass an explicit backend,
+    # and is inherited by subprocess children (multi-device / in-task modes).
+    os.environ["HELION_BACKEND"] = backend
+
+    if backend == "triton" or _PATCHED:
+        return
+
+    try:
+        import helion
+    except ImportError:
+        logger.warning("helion is not available; --helion-backend has no effect")
+        return
+
+    orig_kernel = helion.kernel
+
+    @functools.wraps(orig_kernel)
+    def _kernel(fn=None, *, config=None, configs=None, key=None, **settings):
+        # Drop hardcoded Triton config(s); use the override backend's default.
+        # Only set backend when the caller used keyword settings (not a Settings
+        # object) and didn't already pin one — the env var covers the rest.
+        if "settings" not in settings:
+            settings.setdefault("backend", backend)
+        return orig_kernel(fn, key=key, **settings)
+
+    helion.kernel = _kernel
+    # Keep the `jit` alias consistent if present.
+    if getattr(helion, "jit", None) is orig_kernel:
+        helion.jit = _kernel
+
+    _PATCHED = True
+    logger.warning(
+        "Helion backend overridden to %r for all helion kernels "
+        "(hardcoded config=/configs= are ignored; default config used).",
+        backend,
+    )

--- a/tritonbench/utils/parser.py
+++ b/tritonbench/utils/parser.py
@@ -449,6 +449,19 @@ def get_parser(args=None):
         type=str,
         help="Load plugin from a Python function. This is for loading backends at runtime.",
     )
+    parser.add_argument(
+        "--helion-backend",
+        type=str,
+        default=None,
+        help=(
+            "Override the Helion code-generation backend for every operator's "
+            "`helion` benchmark (e.g. 'cute' for the CuTe DSL backend, 'triton' "
+            "is the default). Sets HELION_BACKEND and ignores any hardcoded "
+            "config= the kernels pass, so it works for any op without editing "
+            "kernel files. Pair with HELION_AUTOTUNE_EFFORT=none to skip "
+            "autotuning."
+        ),
+    )
 
     if is_fbcode():
         parser.add_argument(

--- a/tritonbench/utils/run_utils.py
+++ b/tritonbench/utils/run_utils.py
@@ -35,6 +35,7 @@ from tritonbench.utils.env_utils import (
 from tritonbench.utils.git_utils import get_branch, get_commit_time, get_current_hash
 from tritonbench.utils.gpu_telemetry_observer import TelemetryContext
 from tritonbench.utils.gpu_utils import get_amd_device_name, gpu_lockdown
+from tritonbench.utils.helion_utils import apply_helion_backend_override
 from tritonbench.utils.list_operator_details import list_operator_details
 from tritonbench.utils.parser import get_parser
 from tritonbench.utils.path_utils import (
@@ -532,6 +533,8 @@ def tritonbench_run(args: Optional[List[str]] = None):
     parser = get_parser()
     args, extra_args = parser.parse_known_args(args)
 
+    apply_helion_backend_override(getattr(args, "helion_backend", None))
+
     tritonparse_init(args.tritonparse)
 
     # Strip `--ai-analysis` from sys.argv when in unsupported modes (multi-device,
@@ -645,6 +648,9 @@ def tritonbench_run(args: Optional[List[str]] = None):
 
 def _run(args: argparse.Namespace, extra_args: List[str]) -> BenchmarkOperatorResult:
     with set_torchrun_env():
+        # Apply before the operator module is imported so the helion.kernel wrap
+        # is in effect before any Helion kernel is constructed.
+        apply_helion_backend_override(getattr(args, "helion_backend", None))
         run_timestamp = datetime.fromtimestamp(time.time()).strftime("%Y%m%d%H%M%S")
         if is_loader_op(args.op):
             Opbench = get_op_loader_bench_cls_by_name(args.op)


### PR DESCRIPTION
Summary:
Adds a generic `--helion-backend` CLI flag to tritonbench that overrides the Helion code-generation backend (e.g. `cute` for the CuTe DSL backend) for every operator's `helion` benchmark, without editing any operator or kernel files.

It works by (1) setting `HELION_BACKEND` so every `helion.kernel(...)` that does not pass an explicit backend picks it up (and subprocess children inherit it), and (2) wrapping `helion.kernel` to drop any hardcoded `config=`/`configs=` arguments when the backend is non-Triton. Those configs are Triton-specific (`indexing` / `pid_type` / `num_warps` / ...) and are not valid for other backends, so dropping them makes the kernel fall back to the chosen backend's default config.

Default behavior is unchanged (`triton`). Pair with `HELION_AUTOTUNE_EFFORT=none` to skip autotuning. The new logic lives in `tritonbench/utils/helion_utils.py` and is applied in `run_utils.py` right after arg parsing and at the start of `_run` (before the operator module is imported, so the wrap is active before any Helion kernel is built).

Reviewed By: mengluy0125

Differential Revision: D107679013


