### PR TITLE
[hip] disable mslk on hip

### DIFF
--- a/install.py
+++ b/install.py
@@ -87,7 +87,8 @@ def setup_hip(args: argparse.Namespace):
     args.all = False
     args.liger = True
     args.aiter = True
-    args.mslk = True
+    # disable mslk because mslk has linking issue on AMD
+    # args.mslk = True
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
MSLK has linking issue on AMD: https://github.com/facebookexperimental/triton/actions/runs/27086637173/job/79942270945

Disable it for now.