### PR TITLE
Refactor ncu/nsys metric collection and trace methods into analyzer modules (#1107)

### DIFF
--- a/tritonbench/components/ncu/ncu_analyzer.py
+++ b/tritonbench/components/ncu/ncu_analyzer.py
@@ -1,8 +1,17 @@
+import logging
 import os
+import shlex
 import shutil
+import subprocess
 import sys
 from collections import defaultdict
-from typing import List
+from pathlib import Path
+from typing import List, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from tritonbench.utils.triton_op import BenchmarkOperatorMetrics
+
+logger: logging.Logger = logging.getLogger(__name__)
 
 """
 A dictionary mapping short metric names to their corresponding NVIDIA Nsight Compute
@@ -172,22 +181,22 @@ def get_arithmetic_intensity(kernel):
 
 
 def read_ncu_report(report_path: str, required_metrics: List[str]):
-    assert os.path.exists(report_path), (
-        f"The NCU report at {report_path} does not exist."
-    )
+    assert os.path.exists(
+        report_path
+    ), f"The NCU report at {report_path} does not exist."
     _import_ncu_python_path()
     import ncu_report
 
     # save all kernels' metrics. {metric_name: [kernel1_metric_value, kernel2_metric_value, ...]}
     results = defaultdict(list)
     test_report = ncu_report.load_report(report_path)
-    assert test_report.num_ranges() > 0, (
-        f"No profile data found in the NCU report at {report_path}"
-    )
+    assert (
+        test_report.num_ranges() > 0
+    ), f"No profile data found in the NCU report at {report_path}"
     default_range = test_report.range_by_idx(0)
-    assert default_range.num_actions() > 0, (
-        f"No profile data found in the default range of the NCU report at {report_path}"
-    )
+    assert (
+        default_range.num_actions() > 0
+    ), f"No profile data found in the default range of the NCU report at {report_path}"
     total_duration = 0
     total_dram_bytes = 0
     weighted_fp32_ai_sum = 0
@@ -255,3 +264,160 @@ def read_ncu_report(report_path: str, required_metrics: List[str]):
             weighted_fp64_tflops_sum / total_duration,
         )
     return results
+
+
+def ncu_trace(
+    op_task_args: List[str],
+    output_dir: Path,
+    range_name: str,
+    replay: bool = False,
+    profile_ir: bool = False,
+    extend_ncu_args: Optional[List[str]] = None,
+) -> str:
+    """
+    Run NCU on a single operator backend/input subprocess and return the path to
+    the generated report.
+
+    Args:
+        op_task_args: The command line that runs a single operator backend/input
+            in a subprocess.
+        output_dir: The directory the report is written to.
+        range_name: The NVTX range to profile (``range_start``/``range_end``).
+        replay: Whether to generate a ``.ncu-rep`` report (vs. a ``.csv`` log).
+        profile_ir: Whether to profile with TTGIR source locations.
+        extend_ncu_args: Extra ``--metrics`` to collect; defaults to ``--set full``.
+    """
+    extend_ncu_args = (
+        ["--metrics", ",".join(extend_ncu_args)]
+        if extend_ncu_args
+        else [
+            "--set",
+            "full",
+        ]
+    )
+    # Disable DCGM
+    disable_dyno_dcgm = [
+        "sudo",
+        "dyno",
+        "dcgm_profiling",
+        "--mute=true",
+        "--duration=100000_s",
+    ]
+    disable_dcgm_service = [
+        "sudo",
+        "systemctl",
+        "stop",
+        "nvidia-dcgm",
+    ]
+
+    def service_exists(service_name):
+        try:
+            result = subprocess.run(
+                ["systemctl", "status", service_name],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=True,
+            )
+            return result.returncode == 0
+        except subprocess.CalledProcessError:
+            return False
+
+    if shutil.which("dyno") or service_exists("nvidia-dcgm"):
+        dyno_result = subprocess.run(disable_dyno_dcgm).returncode
+        systemctl_result = subprocess.run(disable_dcgm_service).returncode
+        if dyno_result != 0 and systemctl_result != 0:
+            logger.warning(
+                "DCGM may not have been successfully disabled. Proceeding to collect NCU trace anyway..."
+            )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    ext = ".csv" if not replay else ".ncu-rep"
+    ncu_output_file = output_dir.joinpath(
+        f"ncu_rep{'_ir' if profile_ir else ''}{ext}"
+    ).resolve()
+    ncu_args = [
+        "ncu",
+        "--nvtx",
+        "--nvtx-include",
+        # it is for range_start and range_end. no ending /.
+        f"{range_name}",
+        "--pm-sampling-max-passes",
+        "4",
+        "--warp-sampling-max-passes",
+        "4",
+        "--target-processes",
+        "all",
+        "--import-source",
+        "yes",
+    ]
+    ncu_args.extend(extend_ncu_args)
+    if replay:
+        ncu_args.extend(
+            [
+                "-f",
+                "-o",
+                str(ncu_output_file.resolve()),
+            ]
+        )
+    else:
+        ncu_args.extend(
+            [
+                "--csv",
+                "-f",
+                "--log-file",
+                str(ncu_output_file.resolve()),
+            ]
+        )
+    ncu_args.extend(op_task_args)
+    logger.info("Running NCU: %s", shlex.join(ncu_args))
+    # Sometimes, `ncu --target-processes all` will fail with the message "Failed to connect to process". Setting
+    # CUDA_INJECTION64_PATH=none seems to fix this issue.
+    env = {**os.environ, "CUDA_INJECTION64_PATH": "none"}
+    if profile_ir:
+        env["USE_TTGIR_LOC"] = "1"
+    subprocess.check_call(ncu_args, env=env)
+    return str(ncu_output_file.resolve())
+
+
+def analyze_ncu_metrics(
+    required_metrics: List[str],
+    op_task_args: List[str],
+    output_dir: Path,
+    range_name: str,
+    metrics: "BenchmarkOperatorMetrics",
+) -> None:
+    """
+    Collect NCU metrics (ncu_rep, ncu_rep_ir, or ncu_analyzer metrics) and
+    populate `metrics` in place.
+
+    Args:
+        required_metrics: The metrics requested for this benchmark run.
+        op_task_args: The command line that runs a single operator backend/input
+            in a subprocess, forwarded to ``ncu_trace``.
+        output_dir: The directory the NCU report is written to.
+        range_name: The NVTX range to profile, forwarded to ``ncu_trace``.
+        metrics: The ``BenchmarkOperatorMetrics`` instance to populate.
+    """
+    # ncu metrics (ncu_rep, ncu_rep_ir, or ncu_analyzer metrics)
+    ncu_metrics = get_ncu_metrics(required_metrics)
+    out = None
+    if ncu_metrics or "ncu_rep" in required_metrics or "ncu_rep_ir" in required_metrics:
+        profile_ir = "ncu_rep_ir" in required_metrics
+        out = ncu_trace(
+            op_task_args,
+            output_dir,
+            range_name,
+            replay=True,
+            extend_ncu_args=ncu_metrics,
+            profile_ir=profile_ir,
+        )
+    # Read and update NCU metrics if any required metrics match the NCU metrics
+    if ncu_metrics:
+        ncu_analyzer_results = read_ncu_report(out, required_metrics)
+        for metric_name, metric_value in ncu_analyzer_results.items():
+            metrics.extra_metrics[metric_name] = metric_value
+        if "arithmetic_intensity" in required_metrics:
+            logger.warning("Arithmetic intensity only supports FP32 and FP64 for now.")
+    if "ncu_rep" in required_metrics:
+        metrics.ncu_rep = out
+    if "ncu_rep_ir" in required_metrics:
+        metrics.ncu_rep_ir = out

--- a/tritonbench/components/ncu/nsys_analyzer.py
+++ b/tritonbench/components/ncu/nsys_analyzer.py
@@ -1,7 +1,11 @@
 import csv
 import os
 import subprocess
-from typing import Dict, List
+from pathlib import Path
+from typing import Dict, List, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from tritonbench.utils.triton_op import BenchmarkOperatorMetrics
 
 # The nsys metrics to the reports. The value is the list of reports of nsys.
 nsys_metrics_to_reports = {
@@ -31,9 +35,9 @@ def get_nsys_metrics(metrics: List[str]) -> List[str]:
 def read_nsys_report(
     report_path: str, required_metrics: List[str]
 ) -> Dict[str, List[float]]:
-    assert os.path.exists(report_path), (
-        f"The nsys report at {report_path} does not exist."
-    )
+    assert os.path.exists(
+        report_path
+    ), f"The nsys report at {report_path} does not exist."
     reports_required = []
     for metric in required_metrics:
         if metric in nsys_metrics_to_reports:
@@ -109,3 +113,81 @@ def read_nsys_report(
     )
 
     return results
+
+
+def nsys_rep(op_task_args: List[str], output_dir: Path) -> str:
+    """
+    Run nsys on a single operator backend/input subprocess and return the path to
+    the generated report.
+
+    Args:
+        op_task_args: The command line that runs a single operator backend/input
+            in a subprocess.
+        output_dir: The directory the report is written to.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    ext = ".nsys-rep"
+    nsys_bin = os.environ.get("NSYS_BIN", "nsys")
+    nsys_output_file = output_dir.joinpath(f"nsys_rep{ext}").resolve()
+    nsys_trace_cmd = [
+        nsys_bin,
+        "profile",
+        "-t",
+        "nvtx,osrt,cuda,cudnn,cublas",
+        "-w",
+        "true",
+        "-f",
+        "true",
+        "-o",
+        str(nsys_output_file),
+    ]
+    nsys_trace_cmd.extend(op_task_args)
+    try:
+        subprocess.check_call(nsys_trace_cmd)
+    except subprocess.CalledProcessError:
+        # FIXME: calling nsys on Tritonbench will throw SIGTERM with error code 143
+        pass
+    return str(nsys_output_file.resolve())
+
+
+def analyze_nsys_metrics(
+    required_metrics: List[str],
+    op_task_args: List[str],
+    output_dir: Path,
+    metrics: "BenchmarkOperatorMetrics",
+    baseline_metrics: Optional["BenchmarkOperatorMetrics"] = None,
+) -> None:
+    """
+    Collect nsys metrics (nsys_rep, nsys_analyzer metrics, nsys_gpu_speedup) and
+    populate `metrics` in place.
+
+    Args:
+        required_metrics: The metrics requested for this benchmark run.
+        op_task_args: The command line that runs a single operator backend/input
+            in a subprocess, forwarded to ``nsys_rep``.
+        output_dir: The directory the nsys report is written to.
+        metrics: The ``BenchmarkOperatorMetrics`` instance to populate.
+        baseline_metrics: The baseline metrics used to compute nsys_gpu_speedup.
+    """
+    nsys_metrics = get_nsys_metrics(required_metrics)
+    if "nsys_rep" in required_metrics or nsys_metrics:
+        nsys_rep_path = nsys_rep(op_task_args, output_dir)
+        metrics.nsys_rep = nsys_rep_path
+        if nsys_metrics:
+            nsys_analyzer_results = read_nsys_report(nsys_rep_path, nsys_metrics)
+            for metric_name, metric_value in nsys_analyzer_results.items():
+                metrics.extra_metrics[metric_name] = metric_value
+    if "nsys_gpu_speedup" in required_metrics:
+        baseline_nsys_gpu_kernel_sum = (
+            baseline_metrics.extra_metrics.get("nsys_gpu_kernel_sum", None)
+            if baseline_metrics
+            else None
+        )
+        current_nsys_gpu_kernel_sum = metrics.extra_metrics.get(
+            "nsys_gpu_kernel_sum", None
+        )
+        metrics.nsys_gpu_speedup = (
+            baseline_nsys_gpu_kernel_sum / current_nsys_gpu_kernel_sum
+            if baseline_nsys_gpu_kernel_sum and current_nsys_gpu_kernel_sum
+            else None
+        )

--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -7,10 +7,7 @@ import json
 import logging
 import os
 import random
-import shlex
-import shutil
 import statistics
-import subprocess
 import sys
 import tempfile
 import time
@@ -220,9 +217,9 @@ def _find_op_name_from_module_path(module_path: str) -> str:
     PATH_PREFIX = "tritonbench.operators."
     # We have a separate operator loader for aten operator benchmark.
     PATH_PREFIX_LOADER = "tritonbench.operator_loader."
-    assert PATH_PREFIX in module_path or PATH_PREFIX_LOADER in module_path, (
-        f"We rely on module path prefix to identify operator name. Expected {PATH_PREFIX}<operator_name>, get {module_path}."
-    )
+    assert (
+        PATH_PREFIX in module_path or PATH_PREFIX_LOADER in module_path
+    ), f"We rely on module path prefix to identify operator name. Expected {PATH_PREFIX}<operator_name>, get {module_path}."
     if PATH_PREFIX_LOADER in module_path:
         suffix = module_path.partition(PATH_PREFIX_LOADER)[2]
         suffix = suffix.partition(".")[2]
@@ -569,9 +566,9 @@ class BenchmarkOperatorResult:
             metrics_dict = asdict(y_vals)
         if metric_name in metrics_dict:
             return metrics_dict[metric_name]
-        assert metric_name in metrics_dict["extra_metrics"], (
-            f"Metric {metric_name} could not be found."
-        )
+        assert (
+            metric_name in metrics_dict["extra_metrics"]
+        ), f"Metric {metric_name} could not be found."
         return metrics_dict["extra_metrics"][metric_name]
 
     def _get_result_dict(self):
@@ -795,9 +792,9 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
         elif self.tb_args.mode == "fwd_no_grad":
             self.mode = Mode.FWD_NO_GRAD
         else:
-            assert self.tb_args.mode == "bwd", (
-                "We only accept test modes: fwd, bwd, fwd_bwd, or fwd_no_grad."
-            )
+            assert (
+                self.tb_args.mode == "bwd"
+            ), "We only accept test modes: fwd, bwd, fwd_bwd, or fwd_no_grad."
             self.mode = Mode.BWD
         self.requires_grad = not (self.mode == Mode.FWD_NO_GRAD)
         self.device = tb_args.device
@@ -986,16 +983,16 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
             setattr(fwd_fn, "_name", bm_func_name)
             return fwd_fn
         elif self.mode == Mode.BWD:
-            assert not backend.fwd_only, (
-                f"Backend {bm_func_name} does not support backward pass."
-            )
+            assert (
+                not backend.fwd_only
+            ), f"Backend {bm_func_name} does not support backward pass."
             bwd_fn = self.get_bwd_fn(fwd_fn)
             setattr(bwd_fn, "_name", bm_func_name)
             return bwd_fn
         elif self.mode == Mode.FWD_BWD:
-            assert not backend.fwd_only, (
-                f"Backend {bm_func_name} does not support backward pass."
-            )
+            assert (
+                not backend.fwd_only
+            ), f"Backend {bm_func_name} does not support backward pass."
             bwd_fn = self.get_bwd_fn(fwd_fn)
 
             # FWD_BWD returns (forward_output, grad_tensors_after_backward)
@@ -1949,9 +1946,9 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
                 self.required_metrics
             )
             for metric_name in required_custom_metrics:
-                assert metric_name not in BUILTIN_METRICS, (
-                    "Metric name {metric_name} is built-in and should be OVERRIDDEN_METRICS. Please report a bug."
-                )
+                assert (
+                    metric_name not in BUILTIN_METRICS
+                ), "Metric name {metric_name} is built-in and should be OVERRIDDEN_METRICS. Please report a bug."
                 extra_metrics[metric_name] = None
             return extra_metrics
 
@@ -2075,65 +2072,24 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
                     input_id, fn_name, metrics, kineto_trace=True
                 )
             if not is_hip():
-                # ncu metrics (ncu_rep, ncu_rep_ir, or ncu_analyzer metrics)
-                ncu_metrics: List[str] = ncu_analyzer.get_ncu_metrics(
-                    self.required_metrics
+                op_task_args = self._get_op_task_args(
+                    input_id, fn_name, "single_run_in_task"
                 )
-                if (
-                    ncu_metrics
-                    or "ncu_rep" in self.required_metrics
-                    or "ncu_rep_ir" in self.required_metrics
-                ):
-                    profile_ir = "ncu_rep_ir" in self.required_metrics
-                    out = self.ncu_trace(
-                        input_id,
-                        fn_name,
-                        replay=True,
-                        extend_ncu_args=ncu_metrics,
-                        profile_ir=profile_ir,
-                    )
-                # Read and update NCU metrics if any required metrics match the NCU metrics
-                if ncu_metrics:
-                    ncu_analyzer_results = ncu_analyzer.read_ncu_report(
-                        out, self.required_metrics
-                    )
-                    for metric_name, metric_value in ncu_analyzer_results.items():
-                        metrics.extra_metrics[metric_name] = metric_value
-                    if "arithmetic_intensity" in self.required_metrics:
-                        logger.warning(
-                            "Arithmetic intensity only supports FP32 and FP64 for now."
-                        )
-                if "ncu_rep" in self.required_metrics:
-                    metrics.ncu_rep = out
-                if "ncu_rep_ir" in self.required_metrics:
-                    metrics.ncu_rep_ir = out
-                # nsys metrics
-                nsys_metrics = nsys_analyzer.get_nsys_metrics(self.required_metrics)
-                if "nsys_rep" in self.required_metrics or nsys_metrics:
-                    nsys_rep_path = self.nsys_rep(input_id, fn_name)
-                    metrics.nsys_rep = nsys_rep_path
-                    if nsys_metrics:
-                        nsys_analyzer_results = nsys_analyzer.read_nsys_report(
-                            nsys_rep_path, nsys_metrics
-                        )
-                        for metric_name, metric_value in nsys_analyzer_results.items():
-                            metrics.extra_metrics[metric_name] = metric_value
-                if "nsys_gpu_speedup" in self.required_metrics:
-                    baseline_nsys_gpu_kernel_sum = (
-                        self.baseline_metrics.extra_metrics.get(
-                            "nsys_gpu_kernel_sum", None
-                        )
-                        if self.baseline_metrics
-                        else None
-                    )
-                    current_nsys_gpu_kernel_sum = metrics.extra_metrics.get(
-                        "nsys_gpu_kernel_sum", None
-                    )
-                    metrics.nsys_gpu_speedup = (
-                        baseline_nsys_gpu_kernel_sum / current_nsys_gpu_kernel_sum
-                        if baseline_nsys_gpu_kernel_sum and current_nsys_gpu_kernel_sum
-                        else None
-                    )
+                output_dir = self.get_temp_path(fn_name)
+                ncu_analyzer.analyze_ncu_metrics(
+                    self.required_metrics,
+                    op_task_args,
+                    output_dir,
+                    _RANGE_NAME,
+                    metrics,
+                )
+                nsys_analyzer.analyze_nsys_metrics(
+                    self.required_metrics,
+                    op_task_args,
+                    output_dir,
+                    metrics,
+                    self.baseline_metrics,
+                )
             else:
                 if "att_trace" in self.required_metrics:
                     metrics.att_trace = self.att_trace(input_id, fn_name)
@@ -2397,133 +2353,6 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
         )
         return op_task_args
 
-    def nsys_rep(self, input_id: int, fn_name: str) -> str:
-        op_task_args = self._get_op_task_args(input_id, fn_name, "single_run_in_task")
-        nsys_output_dir = self.get_temp_path(fn_name)
-        nsys_output_dir.mkdir(parents=True, exist_ok=True)
-        ext = ".nsys-rep"
-        nsys_bin = os.environ.get("NSYS_BIN", "nsys")
-        nsys_output_file = nsys_output_dir.joinpath(f"nsys_rep{ext}").resolve()
-        nsys_trace_cmd = [
-            nsys_bin,
-            "profile",
-            "-t",
-            "nvtx,osrt,cuda,cudnn,cublas",
-            "-w",
-            "true",
-            "-f",
-            "true",
-            "-o",
-            str(nsys_output_file),
-        ]
-        nsys_trace_cmd.extend(op_task_args)
-        try:
-            subprocess.check_call(nsys_trace_cmd)
-        except subprocess.CalledProcessError:
-            # FIXME: calling nsys on Tritonbench will throw SIGTERM with error code 143
-            pass
-        return str(nsys_output_file.resolve())
-
-    def ncu_trace(
-        self,
-        input_id: int,
-        fn_name: str,
-        replay: bool = False,
-        profile_ir=False,
-        extend_ncu_args: List[str] = None,
-    ) -> str:
-        extend_ncu_args = (
-            ["--metrics", ",".join(extend_ncu_args)]
-            if extend_ncu_args
-            else [
-                "--set",
-                "full",
-            ]
-        )
-        op_task_args = self._get_op_task_args(input_id, fn_name, "single_run_in_task")
-        # Disable DCGM
-        disable_dyno_dcgm = [
-            "sudo",
-            "dyno",
-            "dcgm_profiling",
-            "--mute=true",
-            "--duration=100000_s",
-        ]
-        disable_dcgm_service = [
-            "sudo",
-            "systemctl",
-            "stop",
-            "nvidia-dcgm",
-        ]
-
-        def service_exists(service_name):
-            try:
-                result = subprocess.run(
-                    ["systemctl", "status", service_name],
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
-                    check=True,
-                )
-                return result.returncode == 0
-            except subprocess.CalledProcessError:
-                return False
-
-        if shutil.which("dyno") or service_exists("nvidia-dcgm"):
-            dyno_result = subprocess.run(disable_dyno_dcgm).returncode
-            systemctl_result = subprocess.run(disable_dcgm_service).returncode
-            if dyno_result != 0 and systemctl_result != 0:
-                logger.warn(
-                    "DCGM may not have been successfully disabled. Proceeding to collect NCU trace anyway..."
-                )
-        ncu_output_dir = self.get_temp_path(fn_name)
-        ncu_output_dir.mkdir(parents=True, exist_ok=True)
-        ext = ".csv" if not replay else ".ncu-rep"
-        ncu_output_file = ncu_output_dir.joinpath(
-            f"ncu_rep{'_ir' if profile_ir else ''}{ext}"
-        ).resolve()
-        ncu_args = [
-            "ncu",
-            "--nvtx",
-            "--nvtx-include",
-            # it is for range_start and range_end. no ending /.
-            f"{_RANGE_NAME}",
-            "--pm-sampling-max-passes",
-            "4",
-            "--warp-sampling-max-passes",
-            "4",
-            "--target-processes",
-            "all",
-            "--import-source",
-            "yes",
-        ]
-        ncu_args.extend(extend_ncu_args)
-        if replay:
-            ncu_args.extend(
-                [
-                    "-f",
-                    "-o",
-                    str(ncu_output_file.resolve()),
-                ]
-            )
-        else:
-            ncu_args.extend(
-                [
-                    "--csv",
-                    "-f",
-                    "--log-file",
-                    str(ncu_output_file.resolve()),
-                ]
-            )
-        ncu_args.extend(op_task_args)
-        logger.info("Running NCU: %s", shlex.join(ncu_args))
-        # Sometimes, `ncu --target-processes all` will fail with the message "Failed to connect to process". Setting
-        # CUDA_INJECTION64_PATH=none seems to fix this issue.
-        env = {**os.environ, "CUDA_INJECTION64_PATH": "none"}
-        if profile_ir:
-            env["USE_TTGIR_LOC"] = "1"
-        subprocess.check_call(ncu_args, env=env)
-        return str(ncu_output_file.resolve())
-
     def att_trace(self, input_id: int, fn_name: str) -> str:
         op_task_args = self._get_op_task_args(input_id, fn_name, "single_run_in_task")
         att_output_dir = self.get_temp_path(fn_name)
@@ -2644,18 +2473,16 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
         device_name = (
             "AMD MI300X"
             if torch.version.hip
-            else _get_mtia_device_name()
-            if is_mtia()
-            else torch.cuda.get_device_name()
+            else _get_mtia_device_name() if is_mtia() else torch.cuda.get_device_name()
         )
-        assert device_name in rooflines, (
-            f"{device_name} is not supported in HW roofline specs."
-        )
+        assert (
+            device_name in rooflines
+        ), f"{device_name} is not supported in HW roofline specs."
         rooflines = rooflines[device_name]
         if self.is_compute_bound:
-            assert self.tb_args.precision in rooflines, (
-                f"{self.tb_args.precision} is not supported by {device_name}."
-            )
+            assert (
+                self.tb_args.precision in rooflines
+            ), f"{self.tb_args.precision} is not supported by {device_name}."
             return rooflines[self.tb_args.precision]
         return rooflines
 


### PR DESCRIPTION
Summary:

Move the NCU and NSYS profiling logic out of `BenchmarkOperator` in `triton_op.py` and into the corresponding analyzer modules (`components/ncu/ncu_analyzer.py` and `components/ncu/nsys_analyzer.py`).

Two pieces moved:

1. Metric orchestration. New `analyze_ncu_metrics(...)` and `analyze_nsys_metrics(...)` encapsulate the per-profiler bookkeeping that previously lived inline in `_do_bench`: deciding which metrics to collect, running the trace, reading the report into `metrics.extra_metrics`, setting `ncu_rep`/`ncu_rep_ir`/`nsys_rep`, and computing `nsys_gpu_speedup`.

2. Trace runners. The `ncu_trace` and `nsys_rep` methods are now module-level functions `ncu_analyzer.ncu_trace(op_task_args, output_dir, range_name, ...)` and `nsys_analyzer.nsys_rep(op_task_args, output_dir)`. They no longer depend on `BenchmarkOperator`; the operator-specific bits (`_get_op_task_args`, `get_temp_path`, the `_RANGE_NAME` NVTX range) are computed by the operator and passed in.

`triton_op.py` now computes `op_task_args` and `output_dir` once and hands them to the two `analyze_*` functions. The `BenchmarkOperatorMetrics` type is imported under `TYPE_CHECKING` only, so there is no circular import. Each analyzer module owns its own module logger. The now-unused `shlex`, `shutil`, and `subprocess` imports were removed from `triton_op.py`.

This is a pure refactor with no behavior change. One incidental cleanup: the deprecated `logger.warn` in the moved NCU code is now `logger.warning`.

Differential Revision: D107893723


