### PR TITLE
[ci] fix broken tests in the CI

### DIFF
--- a/test/test_gpu/skip_tests.yaml
+++ b/test/test_gpu/skip_tests.yaml
@@ -42,8 +42,17 @@ fp8_gemm_rowwise:
 # TODO: embedding, flash_attention will segfault on hip
 embedding:
   report: true
-  devices:
-    - cuda
+  disabled_devices:
+    - hip
+# TODO: welford, jsd will segfault on hip
+welford:
+  report: true
+  disabled_devices:
+    - hip
+jsd:
+  report: true
+  disabled_devices:
+    - hip
 # flash_attention will segfault on hip+triton beta
 flash_attention:
   report: true

--- a/tritonbench/operators/decoding_attention/operator.py
+++ b/tritonbench/operators/decoding_attention/operator.py
@@ -9,6 +9,7 @@ from typing import Callable, Optional, Tuple
 
 import torch
 from tritonbench.utils.env_utils import IS_BLACKWELL, is_cuda
+from tritonbench.utils.python_utils import try_import
 from tritonbench.utils.path_utils import add_ld_library_path
 
 # [Optional] flash_attn v2
@@ -49,13 +50,9 @@ try:
 except (ImportError, IOError, AttributeError):
     HAS_XFORMERS = False
 
-try:
+with try_import("HAS_FB_IMPORT"):
     import mslk.attention.gqa_attn_splitk  # noqa: F401
     from gen_ai.llm_inference.fb.llm.quantization.kv_quantize import quantize_kv_fp8
-
-    HAS_FB_IMPORT = True
-except ImportError:
-    HAS_FB_IMPORT = False
 
 
 from tritonbench.utils.env_utils import is_b200

--- a/tritonbench/operators/decoding_attention/operator.py
+++ b/tritonbench/operators/decoding_attention/operator.py
@@ -9,8 +9,8 @@ from typing import Callable, Optional, Tuple
 
 import torch
 from tritonbench.utils.env_utils import IS_BLACKWELL, is_cuda
-from tritonbench.utils.python_utils import try_import
 from tritonbench.utils.path_utils import add_ld_library_path
+from tritonbench.utils.python_utils import try_import
 
 # [Optional] flash_attn v2
 HAS_FLASH_V2 = True

--- a/tritonbench/operators/fp8_gemm/fp8_gemm.py
+++ b/tritonbench/operators/fp8_gemm/fp8_gemm.py
@@ -269,9 +269,9 @@ class Operator(BenchmarkOperator):
 
     @register_benchmark(baseline=True)
     def torch_fp8_gemm(self, a, b, scale_a, scale_b):
-        assert (
-            not self.contains_blockwise_scaling or HAS_CUDA_129
-        ), "BlockWise scaling variants for scaled_gemm require CUDA 12.9+"
+        assert not self.contains_blockwise_scaling or HAS_CUDA_129, (
+            "BlockWise scaling variants for scaled_gemm require CUDA 12.9+"
+        )
 
         return lambda: torch._scaled_mm(
             a,

--- a/tritonbench/operators/fp8_gemm/fp8_gemm.py
+++ b/tritonbench/operators/fp8_gemm/fp8_gemm.py
@@ -14,7 +14,7 @@ from tritonbench.operators.fp8_gemm.scaled_mm_autows import (
     scaled_mm_autows,
     TENSORWISE as AUTOWS_TENSORWISE,
 )
-from tritonbench.utils.env_utils import IS_BLACKWELL, is_fbcode
+from tritonbench.utils.env_utils import IS_BLACKWELL, is_cuda, is_fbcode
 from tritonbench.utils.triton_op import (
     BenchmarkOperator,
     BenchmarkOperatorMetrics,
@@ -282,7 +282,9 @@ class Operator(BenchmarkOperator):
             out_dtype=self._get_dtype(),
         )
 
-    @register_benchmark()
+    # On AMD it says:
+    # AttributeError("module 'triton.language' has no attribute 'float8_e4m3fn'")
+    @register_benchmark(enabled=is_cuda())
     def pt2_fp8_gemm(self, a, b, scale_a, scale_b) -> Callable:
         torch._dynamo.reset()
         with inductor_config.patch(
@@ -395,7 +397,9 @@ class Operator(BenchmarkOperator):
 
             return lambda: compiled(a, b)
 
-    @register_benchmark()
+    # This impl is CUDA-specific
+    # AMD error: TypeError: range.__init__() got an unexpected keyword argument 'separate_epilogue_store'
+    @register_benchmark(enabled=is_cuda())
     def triton_autows_fp8_gemm(self, a, b, scale_a, scale_b):
         _SCALING_MAP = {
             ScalingType.TensorWise: AUTOWS_TENSORWISE,

--- a/tritonbench/operators/fp8_gemm/fp8_gemm.py
+++ b/tritonbench/operators/fp8_gemm/fp8_gemm.py
@@ -21,7 +21,7 @@ from tritonbench.utils.triton_op import (
     register_benchmark,
     register_metric,
 )
-from tritonbench.utils.triton_utils import has_experimental_descriptor
+from tritonbench.utils.triton_utils import has_experimental_descriptor, has_tlx
 
 from .tutorial import matmul as tutorial_matmul
 
@@ -269,9 +269,9 @@ class Operator(BenchmarkOperator):
 
     @register_benchmark(baseline=True)
     def torch_fp8_gemm(self, a, b, scale_a, scale_b):
-        assert not self.contains_blockwise_scaling or HAS_CUDA_129, (
-            "BlockWise scaling variants for scaled_gemm require CUDA 12.9+"
-        )
+        assert (
+            not self.contains_blockwise_scaling or HAS_CUDA_129
+        ), "BlockWise scaling variants for scaled_gemm require CUDA 12.9+"
 
         return lambda: torch._scaled_mm(
             a,
@@ -399,7 +399,7 @@ class Operator(BenchmarkOperator):
 
     # This impl is CUDA-specific
     # AMD error: TypeError: range.__init__() got an unexpected keyword argument 'separate_epilogue_store'
-    @register_benchmark(enabled=is_cuda())
+    @register_benchmark(enabled=is_cuda() and has_tlx())
     def triton_autows_fp8_gemm(self, a, b, scale_a, scale_b):
         _SCALING_MAP = {
             ScalingType.TensorWise: AUTOWS_TENSORWISE,

--- a/tritonbench/operators/gemm/operator.py
+++ b/tritonbench/operators/gemm/operator.py
@@ -663,7 +663,7 @@ class Operator(BenchmarkOperator):
         else:
             return lambda: blackwell_matmul_tma_persistent(a, b, warp_specialize=True)
 
-    @register_benchmark(enabled=IS_BLACKWELL or IS_HOPPER, fwd_only=True)
+    @register_benchmark(enabled=IS_BLACKWELL, fwd_only=True)
     def triton_warpspec_tma_persistent_splitk_matmul(self, a, b, bias) -> Callable:
         """Warp-specialized persistent split-K matmul for large-K undersaturated GEMMs.
 
@@ -687,21 +687,21 @@ class Operator(BenchmarkOperator):
         else:
             return lambda: blackwell_matmul_tma_persistent(a, b, warp_specialize=False)
 
-    @register_benchmark(enabled=IS_BLACKWELL or IS_HOPPER)
+    @register_benchmark(enabled=IS_BLACKWELL)
     def triton_warpspec_tma_matmul(self, a, b, bias) -> Callable:
         if bias is not None:
             return lambda: blackwell_matmul_tma(a, b, warp_specialize=True) + bias
         else:
             return lambda: blackwell_matmul_tma(a, b, warp_specialize=True)
 
-    @register_benchmark(enabled=IS_BLACKWELL or IS_HOPPER)
+    @register_benchmark(enabled=IS_BLACKWELL)
     def triton_tma_matmul(self, a, b, bias) -> Callable:
         if bias is not None:
             return lambda: blackwell_matmul_tma(a, b, warp_specialize=False) + bias
         else:
             return lambda: blackwell_matmul_tma(a, b, warp_specialize=False)
 
-    @register_benchmark(enabled=IS_BLACKWELL or IS_HOPPER)
+    @register_benchmark(enabled=IS_BLACKWELL)
     def triton_warpspec_descriptor_persistent_matmul(self, a, b, bias) -> Callable:
         if bias is not None:
             return (
@@ -715,7 +715,7 @@ class Operator(BenchmarkOperator):
                 a, b, warp_specialize=True
             )
 
-    @register_benchmark(enabled=IS_BLACKWELL or IS_HOPPER)
+    @register_benchmark(enabled=IS_BLACKWELL)
     def triton_descriptor_persistent_matmul(self, a, b, bias) -> Callable:
         if bias is not None:
             return (

--- a/tritonbench/operators/gemm/operator.py
+++ b/tritonbench/operators/gemm/operator.py
@@ -653,7 +653,7 @@ class Operator(BenchmarkOperator):
         else:
             return lambda: _tlx_matmul_2cta(a_contig, b_contig).to(target_dtype)
 
-    @register_benchmark(enabled=IS_BLACKWELL or IS_HOPPER)
+    @register_benchmark(enabled=IS_BLACKWELL)
     def triton_warpspec_tma_persistent_matmul(self, a, b, bias) -> Callable:
         if bias is not None:
             return (
@@ -677,7 +677,7 @@ class Operator(BenchmarkOperator):
         else:
             return lambda: blackwell_matmul_tma_persistent_splitk(a, b)
 
-    @register_benchmark(enabled=IS_BLACKWELL or IS_HOPPER)
+    @register_benchmark(enabled=IS_BLACKWELL)
     def triton_tma_persistent_matmul(self, a, b, bias) -> Callable:
         if bias is not None:
             return (

--- a/tritonbench/operators/launch_latency/operator.py
+++ b/tritonbench/operators/launch_latency/operator.py
@@ -7,6 +7,7 @@ from triton.compiler import CompiledKernel
 from tritonbench.utils.env_utils import is_cuda
 from tritonbench.utils.python_utils import try_import
 from tritonbench.utils.triton_op import BenchmarkOperator, register_benchmark
+from tritonbench.utils.triton_utils import has_tlx
 
 with try_import("HAS_TILELANG"):
     import tilelang
@@ -440,7 +441,7 @@ class Operator(BenchmarkOperator):
             BLOCK_C5=kw_vals[4],
         )
 
-    @register_benchmark(enabled=is_cuda())
+    @register_benchmark(enabled=is_cuda() and has_tlx())
     def nop_triton_kernel_autotuned(self, *args):
         """Autotuned kernel with num_ctas — measures autotune + c_cache + cluster."""
         from torch import zeros
@@ -451,7 +452,7 @@ class Operator(BenchmarkOperator):
         nop_autotuned_kernel[(1,)](*kernel_args)
         return lambda: nop_autotuned_kernel[(1,)](*kernel_args)
 
-    @register_benchmark(enabled=is_cuda())
+    @register_benchmark(enabled=is_cuda() and has_tlx())
     def nop_triton_kernel_autotuned_nocache(self, *args):
         """Autotuned kernel without c_cache — baseline for autotune overhead."""
         from torch import zeros


### PR DESCRIPTION
H100: disable gemm/triton_descriptor_/triton_warpspec_* kernels

MI350: disable decoding_attention/{pt2_fp8_gemm, triton_autows_fp8_gemm} on AMD.