### PR TITLE
Add flag to make addmm kernel accurate relative to ATen (#1112)

### DIFF
--- a/tritonbench/operators/addmm/data_io.py
+++ b/tritonbench/operators/addmm/data_io.py
@@ -15,6 +15,7 @@ def parse_args(args: List[str]) -> argparse.Namespace:
     parser.add_argument("--col-major", action="store_true", default=False)
     parser.add_argument("--large-k-shapes", action="store_true", default=False)
     parser.add_argument("--bias-1D-y", action="store_true", default=False)
+    parser.add_argument("--add-in-bias-dtype", action="store_true", default=False)
     parser.add_argument("--batch-scaling-shapes", action="store_true", default=False)
     parser.add_argument(
         "--config",

--- a/tritonbench/operators/addmm/hstu.py
+++ b/tritonbench/operators/addmm/hstu.py
@@ -26,5 +26,11 @@ def triton_addmm_fwd_b200_direct(
     input: torch.Tensor,
     mat1: torch.Tensor,
     mat2: torch.Tensor,
+    add_in_bias_dtype: bool = False,
 ) -> torch.Tensor:
-    return triton_addmm_fwd_tma_persistent(mat1, mat2, input)
+    return triton_addmm_fwd_tma_persistent(
+        mat1,
+        mat2,
+        input,
+        add_in_bias_dtype=add_in_bias_dtype,
+    )

--- a/tritonbench/operators/addmm/operator.py
+++ b/tritonbench/operators/addmm/operator.py
@@ -132,6 +132,7 @@ class Operator(BenchmarkOperator):
         if addmm_args.bias_1D_y:
             self.shapes = [(m, k, n, True) for m, k, n, _ in self.shapes]
         self.col_major = addmm_args.col_major
+        self.add_in_bias_dtype = addmm_args.add_in_bias_dtype
 
     @register_benchmark(enabled=HAS_HSTU)  # type: ignore # noqa: F821
     def triton_addmm(self, a, mat1, mat2) -> Callable:
@@ -139,7 +140,12 @@ class Operator(BenchmarkOperator):
 
     @register_benchmark(enabled=HAS_HSTU and IS_BLACKWELL)  # type: ignore # noqa: F821
     def triton_b200_ws(self, a, mat1, mat2) -> Callable:
-        return lambda: triton_addmm_fwd_b200_direct(a, mat1, mat2)
+        return lambda: triton_addmm_fwd_b200_direct(
+            a,
+            mat1,
+            mat2,
+            add_in_bias_dtype=self.add_in_bias_dtype,
+        )
 
     # FIXME: bwd has some problem, need to re-enable it
     @register_benchmark(enabled=False)


### PR DESCRIPTION
Summary:
X-link: https://github.com/meta-recsys/generative-recommenders/pull/540


Add `--add-in-bias-dtype`, defaulting to `False` (more accurate FP32 accumulation), which enables the user to make the TritonBench `addmm` kernel accurate relative to ATen. When `True`, the kernel epilogue adds in the bias dtype rather than in FP32.

Reviewed By: rafaykhurram

Differential Revision: D107964104


