### PR TITLE
[ci] Disable ragged_attn on hip

### DIFF
--- a/test/test_gpu/skip_tests.yaml
+++ b/test/test_gpu/skip_tests.yaml
@@ -38,15 +38,6 @@ mx4_to_fp32:
   devices:
     - cuda
 # ============ TODO: errors in CI ============
-## torch.AcceleratorError: CUDA error: unspecified launch failure
-decoding_attention:
-  report: true
-# TODO: MSLK does not work with meta-triton
-# TypeError: failed to specialize argument of type: KernelParamWrapper
-fp8_gemm_rowwise:
-  report: true
-  channels:
-    - triton-main
 # TODO: embedding, flash_attention will segfault on hip
 embedding:
   report: true

--- a/tritonbench/operators/ragged_attention/operator.py
+++ b/tritonbench/operators/ragged_attention/operator.py
@@ -128,7 +128,7 @@ class Operator(BenchmarkOperator):
         self.sampling_alpha = args.sampling_alpha
         self.requires_grad = not (self.mode == Mode.FWD_NO_GRAD)
 
-    @register_benchmark(baseline=True)
+    @register_benchmark(enabled=is_cuda(), baseline=True)
     def hstu(self, q, k, v, seq_offsets, num_targets, max_seq_len, sparsity):
         # TMA is NVIDIA Hopper+ only; on AMD the backward kernel crashes when
         # tensor-descriptor rewrite and tl.assume (buffer-ops) coexist.


### PR DESCRIPTION
After the kernel upgrade (https://github.com/meta-pytorch/tritonbench/pull/1115/changes), ragged_attn kernel no longer works on AMD:

```
It fails on AMD because the ragged-attention HSTU forward kernel is declared with four required compile-time parameters:
  - NUM_BUFFERS
  - NUM_MMA_WARPS_PER_GROUP
  - NUM_MMA_GROUPS

  See _hstu_attn_fwd (submodules/generative-recommenders/generative_recommenders/ops/triton/triton_hstu_attention.py:1512), especially
  lines 1547-1550 (submodules/generative-recommenders/generative_recommenders/ops/triton/triton_hstu_attention.py:1547).

  Those values are supposed to come from the Triton autotune configs built by _get_fw_configs() in the same file. The bug is that the
  fallback defaults for non-TLX configs are only added in the non-HIP branch, inside else: at lines 278-284 (submodules/generative-
  recommenders/generative_recommenders/ops/triton/triton_hstu_attention.py:278). The HIP branch at lines 81-99 (submodules/generative-
  recommenders/generative_recommenders/ops/triton/triton_hstu_attention.py:81) creates configs with only BLOCK_M, BLOCK_N,
  That is why Triton aborts during autotune with:

  TypeError: dynamic_func() missing 4 required positional arguments:
  'USE_TLX', 'NUM_BUFFERS', 'NUM_MMA_WARPS_PER_GROUP', and 'NUM_MMA_GROUPS'

  So the root cause is not MI350 hardware instability or TMA being disabled. It is a config-construction bug specific to the HIP path.
  NVIDIA does not hit it because the non-HIP configs are patched with defaults (USE_TLX=False, the others =1) before launch. The
  benchmark entrypoint in operator.py (tritonbench/operators/ragged_attention/operator.py:132) just exposes that kernel-path bug on AMD.
```