### PR TITLE
[bisect] correctly handle baseline run failure

### DIFF
--- a/.ci/bisect/regression_detector.py
+++ b/.ci/bisect/regression_detector.py
@@ -64,10 +64,14 @@ if __name__ == "__main__":
             exit(e.returncode)
         exit(0)
 
-    assert BASELINE_LOG and os.path.exists(BASELINE_LOG), (
-        f"BASELINE_LOG is not set or to a non-exist location: {BASELINE_LOG}."
-    )
-    baseline_signal = get_baseline(BASELINE_LOG)
+    assert BASELINE_LOG and os.path.exists(
+        BASELINE_LOG
+    ), f"BASELINE_LOG is not set or to a non-exist location: {BASELINE_LOG}."
+    try:
+        baseline_signal = get_baseline(BASELINE_LOG)
+    except Exception as e:
+        print(f"baseline run failed: {e}")
+        exit(0)
     p = subprocess.Popen(cmdline, cwd=REPO_DIR, stdout=subprocess.PIPE, stderr=None)
     assert p.stdout is not None
     stdout_lines = []

--- a/.ci/bisect/regression_detector.py
+++ b/.ci/bisect/regression_detector.py
@@ -70,7 +70,7 @@ if __name__ == "__main__":
     try:
         baseline_signal = get_baseline(BASELINE_LOG)
     except Exception as e:
-        print(f"baseline run failed: {e}")
+        print(f"baseline run failed in {BASELINE_LOG}: {e}")
         exit(0)
     p = subprocess.Popen(cmdline, cwd=REPO_DIR, stdout=subprocess.PIPE, stderr=None)
     assert p.stdout is not None

--- a/.ci/bisect/run.sh
+++ b/.ci/bisect/run.sh
@@ -132,8 +132,8 @@ PREFLIGHT_RC=$?
 set -e
 # if no regression, exit early and report error: this shouldn't happen
 if [ ${PREFLIGHT_RC} -eq 0 ]; then
-    echo "ERROR: No regression detected on bad commit (${BAD_COMMIT}) relative to good commit (${GOOD_COMMIT})."
-    echo "The regression detector exited with 0, meaning the bad commit behaves the same as the good commit."
+    echo "ERROR: No regression detected on bad commit (${BAD_COMMIT}) relative to good commit (${GOOD_COMMIT}), or baseline fails to run."
+    echo "The regression detector exited with 0, meaning the bad commit behaves the same as the good commit, or baseline fails to run."
     echo "Please verify that your good_commit and bad_commit are correct, or adjust the REGRESSION_THRESHOLD (currently ${REGRESSION_THRESHOLD}%)."
     exit 1
 elif [ ${PREFLIGHT_RC} -ne 1 ] && [ ${FUNCTIONAL} -ne 1 ]; then


### PR DESCRIPTION
In preflight check, if the baseline run fails in non-functional regression, correctly handle the failure by returning 0.

Test workflow (expect failure):

https://github.com/meta-pytorch/tritonbench/actions/runs/27428607046