### PR TITLE
[TPU] Add --device tpu option and torch_tpu init

### DIFF
--- a/tritonbench/utils/parser.py
+++ b/tritonbench/utils/parser.py
@@ -53,7 +53,7 @@ def get_parser(args=None):
         "--device",
         "-d",
         default="cuda",
-        choices=["cuda", "cpu", "mtia"],
+        choices=["cuda", "cpu", "mtia", "tpu"],
         help="Device to benchmark.",
     )
     parser.add_argument(

--- a/tritonbench/utils/run_utils.py
+++ b/tritonbench/utils/run_utils.py
@@ -555,6 +555,14 @@ def tritonbench_run(args: Optional[List[str]] = None):
         torch.mtia.init()
         mtia_triton_launcher.init()
 
+    if args.device == "tpu":
+        # torch_tpu registers the "tpu" PrivateUse1 backend; it usually
+        # autoloads on `import torch`, but import explicitly so failures are
+        # loud and hardware init happens here rather than mid-benchmark.
+        import torch_tpu  # noqa: F401
+
+        assert torch.tpu.is_available(), "No TPU device available for --device tpu"
+
     if args.op:
         ops = args.op.split(",")
     else:


### PR DESCRIPTION
First step toward running tritonbench's non-Triton baselines (eager ATen / PyTorch) on TPU via the out-of-tree `torch_tpu` backend. Plumbing only — no TPU timing path yet (follow-up).

- Adds `tpu` to the `--device` choices.
- Initializes the `torch_tpu` backend in `tritonbench_run` (explicit import + availability assert, so failures are loud and device init happens up front).

Synchronization needs no change: the per-benchmark sync already uses `torch.accelerator.synchronize()`, which was verified on TPU hardware to wait for all in-flight tensors on torch_tpu >= 2026-06-05 (the supported floor). CUDA behavior is unchanged.