### PR TITLE
[TPU] Make triton an optional import on the core run path

### DIFF
--- a/tritonbench/components/do_bench/gpu_events.py
+++ b/tritonbench/components/do_bench/gpu_events.py
@@ -7,12 +7,42 @@ import triton.language as tl
 from tritonbench.utils.constants import DEFAULT_N_REP, DEFAULT_N_WARMUP
 from tritonbench.utils.cudagraph_utils import CudaGraphConfig, CudaGraphError
 from tritonbench.utils.env_utils import is_hip
-from tritonbench.utils.gpu_utils import sleep_amd
 
 from .common import summarize_statistics
 from .utils import resolve_warmup_and_rep
 
+AMD_SLEEP_NS_PER_ITERATION = 3870
+
 _kernel_unblock_stream = None
+
+
+@triton.jit
+def sleep_amd(sleep_ns: tl.constexpr = 1000000):
+    """
+    AMD GPU sleep using s_sleep instruction.
+
+    Each iteration of s_sleep 127 sleeps for ~127*64 = 8,128 clock cycles.
+    On MI300X @ 2.1 GHz, this is approximately 3.87 μs per iteration.
+    On MI350X @ 2.2 GHz, this is approximately 3.69 μs per iteration.
+
+    Args:
+        sleep_ns: Target sleep duration in nanoseconds.
+                 Default 1000000 (1ms).
+
+    Note:
+        Timing is approximate and varies with GPU clock frequency.
+    """
+    # Calculate iterations: sleep_ns / 3870 ns per iteration
+    num_iterations: tl.constexpr = max(1, sleep_ns // AMD_SLEEP_NS_PER_ITERATION)
+    for _ in range(num_iterations):
+        tl.inline_asm_elementwise(
+            "s_sleep 127",
+            "=r",
+            args=[],
+            dtype=tl.int32,
+            is_pure=False,
+            pack=1,
+        )
 
 
 def _get_unblocking_stream(device: torch.device):

--- a/tritonbench/components/do_bench/run.py
+++ b/tritonbench/components/do_bench/run.py
@@ -5,16 +5,21 @@ from functools import partial
 from typing import List, Optional
 
 import torch
-import triton
 from torch._inductor.runtime.benchmarking import benchmarker
 from tritonbench.components.do_bench.entropy.entropy_criterion import EntropyCriterion
 from tritonbench.utils.constants import DEFAULT_N_REP, DEFAULT_N_WARMUP
 from tritonbench.utils.cudagraph_utils import CudaGraphConfig
 
 from .common import summarize_statistics
-from .gpu_events import do_bench_events
-from .power import do_bench_power
 from .utils import estimate_cuda_runtime_ms, resolve_warmup_and_rep
+
+# Triton is optional: non-Triton devices (cpu, tpu) can run without it. The
+# Triton-backed timing paths (events, power, cudagraph, the driver benchmarker)
+# import it lazily where used.
+try:
+    import triton
+except ImportError:
+    triton = None
 
 NS_TO_MS = 1e-6
 logger = logging.getLogger(__name__)
@@ -721,6 +726,8 @@ def do_bench_wrapper(
                 )
         elif repcnt:
             # benchmark using repcnt
+            from .power import do_bench_power
+
             return Latency(
                 times=do_bench_power(
                     fn,
@@ -732,6 +739,8 @@ def do_bench_wrapper(
                 remove_outliers=False,
             )
         elif latency_measure_mode == "gpu_events":
+            from .gpu_events import do_bench_events
+
             return Latency(
                 times=do_bench_events(
                     fn,

--- a/tritonbench/utils/env_utils.py
+++ b/tritonbench/utils/env_utils.py
@@ -14,8 +14,14 @@ from functools import lru_cache
 from typing import Optional
 
 import torch
-import triton
 from tritonbench.utils.path_utils import REPO_PATH
+
+# Triton is optional so non-Triton devices (cpu, tpu) can run without it.
+# Helpers that touch triton (e.g. is_mtia) already guard for its absence.
+try:
+    import triton
+except ImportError:
+    triton = None
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.INFO)

--- a/tritonbench/utils/gpu_utils.py
+++ b/tritonbench/utils/gpu_utils.py
@@ -4,16 +4,11 @@ import subprocess
 from contextlib import contextmanager
 from typing import Dict, List, Optional
 
-import triton
-import triton.language as tl
-
 try:
     from tritonbench.utils.env_utils import is_hip, is_mtia
 except ModuleNotFoundError:
     is_hip = lambda: False
     is_mtia = lambda: False
-
-AMD_SLEEP_NS_PER_ITERATION = 3870
 
 # Defer MTIA check to avoid triggering Triton driver initialization at import time
 try:
@@ -429,32 +424,3 @@ def gpu_lockdown(enabled=True, target_clock_mhz: Optional[int] = None):
             else:
                 gpu_name = _get_gpu_name()
                 _reset_clock(gpu_name)
-
-
-@triton.jit
-def sleep_amd(sleep_ns: tl.constexpr = 1000000):
-    """
-    AMD GPU sleep using s_sleep instruction.
-
-    Each iteration of s_sleep 127 sleeps for ~127*64 = 8,128 clock cycles.
-    On MI300X @ 2.1 GHz, this is approximately 3.87 μs per iteration.
-    On MI350X @ 2.2 GHz, this is approximately 3.69 μs per iteration.
-
-    Args:
-        sleep_ns: Target sleep duration in nanoseconds.
-                 Default 1000000 (1ms).
-
-    Note:
-        Timing is approximate and varies with GPU clock frequency.
-    """
-    # Calculate iterations: sleep_ns / 3870 ns per iteration
-    num_iterations: tl.constexpr = max(1, sleep_ns // AMD_SLEEP_NS_PER_ITERATION)
-    for _ in range(num_iterations):
-        tl.inline_asm_elementwise(
-            "s_sleep 127",
-            "=r",
-            args=[],
-            dtype=tl.int32,
-            is_pure=False,
-            pack=1,
-        )

--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -25,9 +25,20 @@ from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, Type, 
 import psutil
 import tabulate
 import torch
-import triton
 from torch.utils._pytree import tree_map
-from triton.runtime.errors import OutOfResources as TritonOutOfResources
+
+# Triton is optional so non-Triton devices (cpu, tpu) can run without it.
+# triton is only used inside Triton/CUDA-specific code paths below.
+try:
+    import triton
+    from triton.runtime.errors import OutOfResources as TritonOutOfResources
+except ImportError:
+    triton = None
+
+    class TritonOutOfResources(Exception):
+        """Placeholder when triton is absent; never raised without triton."""
+
+
 from tritonbench.components.do_bench import do_bench_wrapper, Latency
 from tritonbench.components.do_bench.utils import (
     estimate_cuda_runtime_ms,


### PR DESCRIPTION
Makes the **framework core** import without `triton`, so non-Triton devices (`cpu`, `tpu`) can run operators that do not themselves import triton. `triton` is only used inside Triton/CUDA code paths, so this guards the imports without changing any CUDA/Triton behavior:

- `import triton` → `try/except ImportError: triton = None` in `env_utils`, `triton_op`, and `do_bench/run`.
- The CUDA-only timing backends (`gpu_events`, `power`) are imported lazily inside their `do_bench_wrapper` branches instead of at module top.
- The AMD `sleep_amd` `@triton.jit` kernel moves from `gpu_utils` (broadly imported on the run path) to `gpu_events`, its only consumer (CUDA-only), so `gpu_utils` no longer imports triton.

**Scope:** core only. ~19 operators (e.g. `gemm`, `layer_norm`) still `import triton` at module top and need the same treatment before they load on a no-triton device — that is a separate follow-up, not this PR.

Verified on a TPU host (torch_tpu venv, no triton installed): `python run.py --op test_op --device tpu --metrics latency` imports cleanly and produces a latency. CPU behavior is unchanged when triton is present (ran `test/test_cpu/main.py`; behaves identically to main).