### PR TITLE
[ci] add more amd skips

### DIFF
--- a/test/test_gpu/skip_tests.yaml
+++ b/test/test_gpu/skip_tests.yaml
@@ -43,3 +43,7 @@ flash_attention:
   report: true
   disabled_devices:
     - hip
+embedding:
+  report: true
+  disabled_devices:
+    - hip


### PR DESCRIPTION
embedding and flash_attention are still unstable and will segfault on AMD (non-deterministically)