### PR TITLE
Fix fp8_gemm get_x_val reporting K as N

### DIFF
--- a/tritonbench/operators/fp8_gemm/fp8_gemm.py
+++ b/tritonbench/operators/fp8_gemm/fp8_gemm.py
@@ -268,7 +268,8 @@ class Operator(BenchmarkOperator):
     def get_x_val(self, example_inputs) -> float:
         a, b, _, _ = example_inputs
         m, k = a.size()
-        _, n = b.size()
+        # b is built as randn(n, k), so n is dim 0 (dim 1 is the shared k).
+        n, _ = b.size()
         return (m, n, k)
 
     @register_benchmark(baseline=True)


### PR DESCRIPTION
In get_x_val, `b` is built as `torch.randn(n, k, ...)` (fp8_gemm.py:225), so `b.size()` is `(n, k)`. The old `_, n = b.size()` discarded the real N (dim 0) and reassigned n to dim 1 (the shared K), so every non-square shape was mislabeled with N == K. Read dim 0 instead: `n, _ = b.size()`.


https://github.com/meta-pytorch/tritonbench/blob/main/tritonbench/operators/fp8_gemm/fp8_gemm.py#L225