### PR TITLE
Add disabled AutoWS HSTU backend to TritonBench (#1134)

### DIFF
--- a/tritonbench/operators/blackwell_attentions/operator.py
+++ b/tritonbench/operators/blackwell_attentions/operator.py
@@ -16,6 +16,9 @@ import torch
 from torch.nn.attention import sdpa_kernel, SDPBackend
 from torch.nn.functional import scaled_dot_product_attention as sdpa
 from tritonbench.kernels.attention_utils import SUPPORT_GLUON
+from tritonbench.operators.blackwell_attentions.triton_autows import (
+    autows_hstu_attention,
+)
 from tritonbench.utils.python_utils import try_import
 
 try:
@@ -840,6 +843,33 @@ class Operator(BenchmarkOperator):
                 seq_offsets=seq_offsets,
                 attn_scale=torch.tensor(1.0 / max_seq_len, device=q.device),
                 sort_by_length=False,
+            )
+
+        return preproc_hstu, fn
+
+    # This backend currently does not work: the Meta AutoWS compiler path
+    # crashes in NVGPUWarpSpecialization for the HSTU loop. Test with `--force`
+    # after the compiler task is fixed.
+    # TODO: Enable once the compiler issue is fixed and Meta Triton + Blackwell
+    # + AutoWS runtime gates are validated.
+    @register_benchmark(enabled=False, fwd_only=True, label="triton-autows-hstu")
+    @multi_input_wrapper
+    def triton_autows_hstu(self, *args) -> Tuple[Callable, Callable]:
+        if self.varlen:
+            raise NotImplementedError("AutoWS HSTU does not support varlen interface")
+        if self.local:
+            raise NotImplementedError("AutoWS HSTU does not support local attention")
+
+        alpha = 1.0 / self.D_HEAD
+
+        def fn(q, k, v, seq_offsets, max_seq_len):
+            return autows_hstu_attention(
+                q,
+                k,
+                v,
+                seq_offsets,
+                max_seq_len,
+                alpha=alpha,
             )
 
         return preproc_hstu, fn

--- a/tritonbench/operators/blackwell_attentions/triton_autows.py
+++ b/tritonbench/operators/blackwell_attentions/triton_autows.py
@@ -1,0 +1,195 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+import torch
+
+# @manual=//triton:triton
+import triton
+
+# @manual=//triton:triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+
+@triton.jit
+def _hstu_kv_step(
+    q,
+    desc_k,
+    desc_v,
+    seq_start,
+    start_n,
+    col,
+    offs_m,
+    alpha,
+    scale,
+    acc,
+    BLOCK_N: tl.constexpr,
+):
+    start_n = tl.multiple_of(start_n, BLOCK_N)
+    offs_n = start_n + tl.arange(0, BLOCK_N)
+
+    k = desc_k.load([seq_start + start_n, col])
+    # Triton TR011: explicit TF32 policy keeps tensor-core behavior stable.
+    qk = tl.dot(q, k.T, allow_tf32=True)
+
+    qk = qk * alpha
+    silu = (qk / (1.0 + tl.exp(-qk))) * scale
+    p = tl.where(offs_m[:, None] >= offs_n[None, :], silu, 0.0)
+
+    v = desc_v.load([seq_start + start_n, col])
+    # Triton TR011: explicit TF32 policy keeps tensor-core behavior stable.
+    acc = tl.dot(p.to(v.dtype), v, acc, allow_tf32=True)
+    return acc
+
+
+# Triton TR001: this coverage backend intentionally keeps a fixed config while
+# it is disabled by default pending compiler fixes and proper runtime gates.
+@triton.jit
+def _autows_hstu_fwd_kernel(  # noqa: TR001
+    desc_q,
+    desc_k,
+    desc_v,
+    desc_o,
+    seq_offsets,
+    alpha,
+    scale,
+    H,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    out_dtype: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    off_hz = tl.program_id(1)
+    off_z = off_hz // H
+    off_h = off_hz % H
+
+    seq_start = tl.load(seq_offsets + off_z).to(tl.int32)
+    seq_end = tl.load(seq_offsets + off_z + 1).to(tl.int32)
+    seq_len = seq_end - seq_start
+
+    start_m = pid_m * BLOCK_M
+    if start_m >= seq_len:
+        return
+
+    col = off_h * HEAD_DIM
+    offs_m = start_m + tl.arange(0, BLOCK_M)
+    q = desc_q.load([seq_start + start_m, col])
+    acc = tl.zeros([BLOCK_M, HEAD_DIM], dtype=tl.float32)
+
+    hi = tl.minimum(start_m + BLOCK_M, seq_len)
+    for start_n in tl.range(0, hi, BLOCK_N, warp_specialize=True):
+        acc = _hstu_kv_step(
+            q,
+            desc_k,
+            desc_v,
+            seq_start,
+            start_n,
+            col,
+            offs_m,
+            alpha,
+            scale,
+            acc,
+            BLOCK_N,
+        )
+
+    desc_o.store([seq_start + start_m, col], acc.to(out_dtype))
+
+
+def _triton_dtype(tensor: torch.Tensor):
+    return getattr(tl, str(tensor.dtype).split(".")[1])
+
+
+def autows_hstu_attention(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    seq_offsets: torch.Tensor,
+    max_seq_len: int,
+    *,
+    alpha: float,
+    block_m: int = 128,
+    block_n: int = 64,
+    num_warps: int = 4,
+    num_stages: int = 3,
+) -> torch.Tensor:
+    """AutoWS HSTU forward for the blackwell_attentions tlx_hstu shape.
+
+    This backend currently does not work: the Meta AutoWS compiler path crashes
+    in NVGPUWarpSpecialization for this HSTU loop. The non-WS source math was
+    validated separately, but the exported TritonBench backend is intentionally
+    disabled until the compiler issue is fixed.
+    """
+    total_seq, heads, head_dim = q.shape
+    if q.shape != k.shape or q.shape != v.shape:
+        raise NotImplementedError("autows_hstu_attention requires matching Q/K/V")
+    if head_dim != 128:
+        raise NotImplementedError("autows_hstu_attention currently supports D=128")
+
+    q = q.contiguous()
+    k = k.contiguous()
+    v = v.contiguous()
+    seq_offsets = seq_offsets.to(torch.int64).contiguous()
+    o = torch.empty_like(q)
+
+    q2 = q.view(total_seq, heads * head_dim)
+    k2 = k.view(total_seq, heads * head_dim)
+    v2 = v.view(total_seq, heads * head_dim)
+    o2 = o.view(total_seq, heads * head_dim)
+
+    desc_q = TensorDescriptor(
+        q2,
+        shape=[total_seq, heads * head_dim],
+        strides=[heads * head_dim, 1],
+        block_shape=[block_m, head_dim],
+    )
+    desc_k = TensorDescriptor(
+        k2,
+        shape=[total_seq, heads * head_dim],
+        strides=[heads * head_dim, 1],
+        block_shape=[block_n, head_dim],
+    )
+    desc_v = TensorDescriptor(
+        v2,
+        shape=[total_seq, heads * head_dim],
+        strides=[heads * head_dim, 1],
+        block_shape=[block_n, head_dim],
+    )
+    desc_o = TensorDescriptor(
+        o2,
+        shape=[total_seq, heads * head_dim],
+        strides=[heads * head_dim, 1],
+        block_shape=[block_m, head_dim],
+    )
+
+    def alloc_fn(size: int, _alignment: int, _stream) -> torch.Tensor:
+        return torch.empty(size, device=q.device, dtype=torch.int8)
+
+    triton.set_allocator(alloc_fn)
+
+    grid = (triton.cdiv(max_seq_len, block_m), heads * (seq_offsets.numel() - 1), 1)
+    scale = 1.0 / max_seq_len
+
+    assert triton.knobs.nvidia.use_meta_ws, (
+        "autows_hstu_attention requires TRITON_USE_META_WS=1"
+    )
+    assert triton.knobs.nvidia.disable_wsbarrier_reorder, (
+        "autows_hstu_attention currently requires TRITON_DISABLE_WSBARRIER_REORDER=1"
+    )
+    # TODO: Tune max registers across partitions.
+    _autows_hstu_fwd_kernel[grid](
+        desc_q,
+        desc_k,
+        desc_v,
+        desc_o,
+        seq_offsets,
+        alpha,
+        scale,
+        heads,
+        HEAD_DIM=head_dim,
+        BLOCK_M=block_m,
+        BLOCK_N=block_n,
+        out_dtype=_triton_dtype(q),
+        num_warps=num_warps,
+        num_stages=num_stages,
+    )
+    return o


### PR DESCRIPTION
Summary:

**Context:** D108728934 explored a standalone Meta AutoWS implementation for the TritonBench `blackwell_attentions` `tlx_hstu` specialization gap and found a compiler crash in `NVGPUWarpSpecialization`.

**Motivation:** TritonBench should still carry the candidate as a real, disabled backend so the coverage gap and compiler failure are visible from the operator surface while the compiler fix is tracked separately.

**This diff:**
- Adds `triton_autows.py` with the HSTU AutoWS candidate for the `tlx_hstu` math and input layout.
- Registers `triton_autows_hstu` as a forward-only `blackwell_attentions` backend, disabled by default because it currently does not compile through Meta AutoWS.
- Requires Triton's `TensorDescriptor` import directly because this backend is only intended for Meta Triton environments.
- Asserts that `TRITON_USE_META_WS=1` and `TRITON_DISABLE_WSBARRIER_REORDER=1` are provided by the environment, and leaves register allocation for follow-up partition tuning.

Differential Revision: D109171798


