### PR TITLE
Add Blackwell AutoWS SwiGLU backend to TritonBench (#1137)

### DIFF
--- a/tritonbench/operators/swiglu/operator.py
+++ b/tritonbench/operators/swiglu/operator.py
@@ -4,6 +4,8 @@ from typing import Callable, Generator, List, Optional, Tuple
 import torch
 from transformers.models.llama.configuration_llama import LlamaConfig
 from transformers.models.llama.modeling_llama import LlamaMLP
+from tritonbench.operators.swiglu.triton_autows import triton_autows_swiglu
+from tritonbench.utils.env_utils import is_blackwell
 from tritonbench.utils.triton_op import (
     BenchmarkOperator,
     Mode,
@@ -68,6 +70,15 @@ class Operator(BenchmarkOperator):
     @register_benchmark(enabled=LigerSwiGLUMLP is not None)
     def liger_swiglu(self, input) -> Callable:
         return lambda: self.liger_op(input)
+
+    @register_benchmark(enabled=is_blackwell(), fwd_only=True)
+    def triton_autows_swiglu(self, input) -> Callable:
+        def fn():
+            gate = self.baseline_op.gate_proj(input)
+            up = self.baseline_op.up_proj(input)
+            return self.baseline_op.down_proj(triton_autows_swiglu(gate, up))
+
+        return fn
 
     @register_benchmark()
     def torch_compile_swiglu(self, input) -> Callable:

--- a/tritonbench/operators/swiglu/triton_autows.py
+++ b/tritonbench/operators/swiglu/triton_autows.py
@@ -1,0 +1,143 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+import torch
+
+# @manual=//triton:triton
+import triton
+
+# @manual=//triton:triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+
+@triton.jit
+def _silu(x):
+    return x * tl.sigmoid(x)
+
+
+@triton.jit
+def _swiglu_tile_body(
+    gate_desc,
+    up_desc,
+    out_desc,
+    tile_id,
+    num_n_tiles,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tile_id // num_n_tiles
+    pid_n = tile_id % num_n_tiles
+    offs_m = pid_m * BLOCK_M
+    offs_n = pid_n * BLOCK_N
+
+    gate = gate_desc.load([offs_m, offs_n])
+    up = up_desc.load([offs_m, offs_n])
+    out = _silu(gate.to(tl.float32)).to(up.dtype) * up
+    out_desc.store([offs_m, offs_n], out)
+
+
+# Triton TR001: this coverage backend intentionally keeps a fixed config while
+# proper runtime gates for Meta Triton + Blackwell + AutoWS are validated.
+@triton.jit
+def _swiglu_fwd_ws_kernel(  # noqa: TR001
+    gate_desc,
+    up_desc,
+    out_desc,
+    n_rows,
+    n_cols,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    NUM_SMS: tl.constexpr,
+):
+    start_pid = tl.program_id(axis=0)
+    num_m_tiles = tl.cdiv(n_rows, BLOCK_M)
+    num_n_tiles = tl.cdiv(n_cols, BLOCK_N)
+    num_tiles = num_m_tiles * num_n_tiles
+
+    for tile_id in tl.range(
+        start_pid,
+        num_tiles,
+        NUM_SMS,
+        warp_specialize=True,
+        num_stages=2,
+    ):
+        _swiglu_tile_body(
+            gate_desc,
+            up_desc,
+            out_desc,
+            tile_id,
+            num_n_tiles,
+            BLOCK_M,
+            BLOCK_N,
+        )
+
+
+def triton_autows_swiglu(
+    gate: torch.Tensor,
+    up: torch.Tensor,
+    *,
+    block_m: int = 8,
+    block_n: int = 1024,
+    num_warps: int = 4,
+) -> torch.Tensor:
+    """AutoWS fused SwiGLU activation: ``silu(gate).to(up.dtype) * up``."""
+    if not hasattr(triton, "knobs"):
+        raise NotImplementedError("triton_autows_swiglu requires Meta Triton")
+    if gate.shape != up.shape:
+        raise NotImplementedError("triton_autows_swiglu requires matching inputs")
+
+    original_shape = gate.shape
+    n_cols = original_shape[-1]
+    gate_2d = gate.reshape(-1, n_cols).contiguous()
+    up_2d = up.reshape(-1, n_cols).contiguous()
+    n_rows = gate_2d.shape[0]
+    out_2d = torch.empty_like(gate_2d)
+
+    block_n = min(block_n, triton.next_power_of_2(n_cols))
+    block_m = min(block_m, max(1, triton.next_power_of_2(n_rows)))
+
+    gate_desc = TensorDescriptor(
+        gate_2d,
+        shape=gate_2d.shape,
+        strides=gate_2d.stride(),
+        block_shape=[block_m, block_n],
+    )
+    up_desc = TensorDescriptor(
+        up_2d,
+        shape=up_2d.shape,
+        strides=up_2d.stride(),
+        block_shape=[block_m, block_n],
+    )
+    out_desc = TensorDescriptor(
+        out_2d,
+        shape=out_2d.shape,
+        strides=out_2d.stride(),
+        block_shape=[block_m, block_n],
+    )
+
+    def alloc_fn(size: int, _alignment: int, _stream) -> torch.Tensor:
+        return torch.empty(size, device=gate.device, dtype=torch.int8)
+
+    triton.set_allocator(alloc_fn)
+
+    num_sms = torch.cuda.get_device_properties(gate.device).multi_processor_count
+
+    assert triton.knobs.nvidia.use_meta_ws, (
+        "triton_autows_swiglu requires TRITON_USE_META_WS=1"
+    )
+    assert triton.knobs.nvidia.disable_wsbarrier_reorder, (
+        "triton_autows_swiglu currently requires TRITON_DISABLE_WSBARRIER_REORDER=1"
+    )
+    # TODO: Tune max registers across partitions.
+    _swiglu_fwd_ws_kernel[(num_sms,)](
+        gate_desc,
+        up_desc,
+        out_desc,
+        n_rows,
+        n_cols,
+        BLOCK_M=block_m,
+        BLOCK_N=block_n,
+        NUM_SMS=num_sms,
+        num_warps=num_warps,
+    )
+    return out_2d.reshape(original_shape)


### PR DESCRIPTION
Summary:

**Context:** D109177735 validated a standalone Meta AutoWS implementation for the TritonBench `swiglu` coverage gap.

**Motivation:** TritonBench needs the candidate exported as a real operator backend so Blackwell AutoWS coverage for the SwiGLU activation path can be tracked alongside the existing torch, Liger, and torch.compile implementations.

**This diff:**
- Adds `triton_autows.py` with the fixed-config Blackwell Meta AutoWS fused SwiGLU activation kernel using TMA descriptors and an inner `tl.range(..., warp_specialize=True)` tile loop.
- Registers `triton_autows_swiglu` as a Blackwell forward-only backend that runs the existing Llama MLP gate/up projections, applies the AutoWS fused activation, then runs the existing down projection.
- Requires Triton's `TensorDescriptor` import directly because this backend is only intended for Meta Triton environments.
- Asserts that `TRITON_USE_META_WS=1` and `TRITON_DISABLE_WSBARRIER_REORDER=1` are provided by the environment, and leaves register allocation for follow-up partition tuning.

Differential Revision: D109216422


