### PR TITLE
Add Blackwell AutoWS tlx_hstu backend to TritonBench (#1139)

### DIFF
--- a/tritonbench/operators/blackwell_attentions/operator.py
+++ b/tritonbench/operators/blackwell_attentions/operator.py
@@ -18,6 +18,7 @@ from torch.nn.functional import scaled_dot_product_attention as sdpa
 from tritonbench.kernels.attention_utils import SUPPORT_GLUON
 from tritonbench.operators.blackwell_attentions.triton_autows import (
     autows_hstu_attention,
+    autows_hstu_attention_persistent,
 )
 from tritonbench.utils.python_utils import try_import
 
@@ -864,6 +865,38 @@ class Operator(BenchmarkOperator):
 
         def fn(q, k, v, seq_offsets, max_seq_len):
             return autows_hstu_attention(
+                q,
+                k,
+                v,
+                seq_offsets,
+                max_seq_len,
+                alpha=alpha,
+            )
+
+        return preproc_hstu, fn
+
+    # Persistent AutoWS variant (K-1, D109218027): warp-specializes an outer
+    # persistent tile loop instead of the inner KV loop, which validated
+    # ws=pass. Disabled by default for the same runtime-gate reason; test with
+    # `--force` under TRITON_USE_META_WS=1.
+    @register_benchmark(
+        enabled=False, fwd_only=True, label="triton-autows-hstu-persistent"
+    )
+    @multi_input_wrapper
+    def triton_autows_hstu_persistent(self, *args) -> Tuple[Callable, Callable]:
+        if self.varlen:
+            raise NotImplementedError("AutoWS HSTU does not support varlen interface")
+        if self.local:
+            raise NotImplementedError("AutoWS HSTU does not support local attention")
+
+        alpha = 1.0 / self.D_HEAD
+
+        def fn(q, k, v, seq_offsets, max_seq_len):
+            if q.shape != k.shape or q.shape != v.shape:
+                raise NotImplementedError(
+                    "AutoWS HSTU only supports non-GQA MHA inputs"
+                )
+            return autows_hstu_attention_persistent(
                 q,
                 k,
                 v,

--- a/tritonbench/operators/blackwell_attentions/triton_autows.py
+++ b/tritonbench/operators/blackwell_attentions/triton_autows.py
@@ -193,3 +193,175 @@ def autows_hstu_attention(
         num_stages=num_stages,
     )
     return o
+
+
+# Triton TR001: this coverage backend intentionally keeps a fixed config while
+# it is disabled by default pending proper runtime gates.
+@triton.jit
+def _hstu_fwd_persistent_ws(  # noqa: TR001
+    desc_q,
+    desc_k,
+    desc_v,
+    desc_o,
+    alpha,
+    attn_scale,
+    seq_len,
+    NUM_SMS: tl.constexpr,
+    DIM: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    # Grid is flat over #SMs (axis 0); (batch*head) is grid axis 1. Each program
+    # walks a strided set of M-tiles within its (batch*head) row group.
+    start_pid = tl.program_id(0)
+    num_tiles = tl.cdiv(seq_len, BLOCK_M)  # M-tiles per (batch*head)
+
+    bh = tl.program_id(1)
+    q_row_off = bh * seq_len
+
+    # Persistent tile loop: this is the loop Meta AutoWS specializes.
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, warp_specialize=True):
+        start_m = tile_id * BLOCK_M
+        offs_m = start_m + tl.arange(0, BLOCK_M)
+
+        q = desc_q.load([q_row_off + start_m, 0])  # [BLOCK_M, DIM]
+        acc = tl.zeros([BLOCK_M, DIM], dtype=tl.float32)
+
+        # Causal: only need KV blocks up to and including the diagonal block.
+        hi = start_m + BLOCK_M
+        for start_n in range(0, hi, BLOCK_N):
+            offs_n = start_n + tl.arange(0, BLOCK_N)
+            k = desc_k.load([q_row_off + start_n, 0])  # [BLOCK_N, DIM]
+            # Triton TR011: explicit TF32 policy keeps tensor-core behavior stable.
+            qk = tl.dot(q, k.T, allow_tf32=True)  # [BLOCK_M, BLOCK_N]
+
+            qk = qk.to(tl.float32) * alpha
+            # SiLU activation: x * sigmoid(x)
+            silu = qk * tl.sigmoid(qk)
+            act = silu * attn_scale
+            # causal mask + seq_len bound
+            causal = offs_m[:, None] >= offs_n[None, :]
+            valid = causal & (offs_n[None, :] < seq_len)
+            act = tl.where(valid, act, 0.0)
+
+            v = desc_v.load([q_row_off + start_n, 0])  # [BLOCK_N, DIM]
+            # Triton TR011: explicit TF32 policy keeps tensor-core behavior stable.
+            acc += tl.dot(act.to(v.dtype), v, allow_tf32=True)
+
+        desc_o.store([q_row_off + start_m, 0], acc.to(desc_o.dtype))
+
+
+def autows_hstu_attention_persistent(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    seq_offsets: torch.Tensor,
+    max_seq_len: int,
+    *,
+    alpha: float,
+    block_m: int = 128,
+    block_n: int = 128,
+    num_warps: int = 4,
+    num_stages: int = 2,
+) -> torch.Tensor:
+    """PERSISTENT AutoWS HSTU forward for the blackwell_attentions tlx_hstu shape (K-1).
+
+    Same HSTU SiLU math as ``autows_hstu_attention`` but expressed as a persistent
+    kernel (``grid = (#SMs, Z*H)`` with an outer warp-specialized tile loop) so
+    Meta AutoWS has a loop to specialize. Inputs are packed with all sequences
+    full length ``max_seq_len`` (the layout produced by ``preproc_hstu``):
+    q, k, v : [Z * max_seq_len, H, DIM]; returns [Z * max_seq_len, H, DIM].
+    """
+    if not hasattr(triton, "knobs"):
+        raise NotImplementedError(
+            "autows_hstu_attention_persistent requires Meta Triton"
+        )
+    if q.shape != k.shape or q.shape != v.shape:
+        raise NotImplementedError(
+            "autows_hstu_attention_persistent requires matching Q/K/V"
+        )
+
+    total_tokens, heads, head_dim = q.shape
+    if head_dim != 128:
+        raise NotImplementedError(
+            "autows_hstu_attention_persistent currently supports D=128"
+        )
+    if total_tokens % max_seq_len != 0:
+        raise NotImplementedError(
+            "autows_hstu_attention_persistent requires uniform full-length sequences"
+        )
+    Z = total_tokens // max_seq_len
+    if seq_offsets.numel() != Z + 1:
+        raise NotImplementedError(
+            "autows_hstu_attention_persistent requires per-batch seq_offsets"
+        )
+
+    # View as [Z, H, max_seq_len, DIM] contiguous so TMA descriptors are 2D
+    # row-major: row (z*H + h)*max_seq_len + s maps to q[z*max_seq_len + s, h, :].
+    q4 = q.view(Z, max_seq_len, heads, head_dim).permute(0, 2, 1, 3).contiguous()
+    k4 = k.view(Z, max_seq_len, heads, head_dim).permute(0, 2, 1, 3).contiguous()
+    v4 = v.view(Z, max_seq_len, heads, head_dim).permute(0, 2, 1, 3).contiguous()
+    o4 = torch.empty_like(q4)
+
+    bh = Z * heads
+    q2 = q4.view(bh * max_seq_len, head_dim)
+    k2 = k4.view(bh * max_seq_len, head_dim)
+    v2 = v4.view(bh * max_seq_len, head_dim)
+    o2 = o4.view(bh * max_seq_len, head_dim)
+
+    desc_q = TensorDescriptor(
+        q2,
+        shape=[bh * max_seq_len, head_dim],
+        strides=[head_dim, 1],
+        block_shape=[block_m, head_dim],
+    )
+    desc_k = TensorDescriptor(
+        k2,
+        shape=[bh * max_seq_len, head_dim],
+        strides=[head_dim, 1],
+        block_shape=[block_n, head_dim],
+    )
+    desc_v = TensorDescriptor(
+        v2,
+        shape=[bh * max_seq_len, head_dim],
+        strides=[head_dim, 1],
+        block_shape=[block_n, head_dim],
+    )
+    desc_o = TensorDescriptor(
+        o2,
+        shape=[bh * max_seq_len, head_dim],
+        strides=[head_dim, 1],
+        block_shape=[block_m, head_dim],
+    )
+
+    def alloc_fn(size: int, _alignment: int, _stream) -> torch.Tensor:
+        return torch.empty(size, device=q.device, dtype=torch.int8)
+
+    triton.set_allocator(alloc_fn)
+
+    num_sms = torch.cuda.get_device_properties(q.device).multi_processor_count
+    grid = (num_sms, bh)
+    attn_scale = 1.0 / max_seq_len
+
+    assert triton.knobs.nvidia.use_meta_ws, (
+        "autows_hstu_attention_persistent requires TRITON_USE_META_WS=1"
+    )
+    # TODO: Tune max registers across partitions.
+    _hstu_fwd_persistent_ws[grid](
+        desc_q,
+        desc_k,
+        desc_v,
+        desc_o,
+        alpha,
+        attn_scale,
+        max_seq_len,
+        NUM_SMS=num_sms,
+        DIM=head_dim,
+        BLOCK_M=block_m,
+        BLOCK_N=block_n,
+        num_warps=num_warps,
+        num_stages=num_stages,
+    )
+
+    # repack o4 [Z, H, max_seq_len, DIM] -> [Z*max_seq_len, H, DIM]
+    return o4.permute(0, 2, 1, 3).contiguous().view(total_tokens, heads, head_dim)


### PR DESCRIPTION
Summary:

**Context:** D109218027 explored a standalone persistent Meta AutoWS (automatic warp specialization) forward for the TritonBench `blackwell_attentions` `tlx_hstu` coverage gap (HSTU SiLU attention, causal) on Blackwell `b200a` (sm_100) and validated `ws=pass` (a real `ttg.warp_specialize` op with the 4-way `["epilogue", "gemm", "load", "computation"]` partition split) and correctness (`max_abs_err` `9.36e-06` vs the `tlx_hstu` kernel output and `1.19e-07` vs a pure-torch HSTU reference, at `atol=1e-2`).

**Motivation:** Transfer that validated candidate into TritonBench as a real backend on the `blackwell_attentions` operator surface so the AutoWS HSTU coverage is exercisable from the operator instead of living only in a standalone candidate file.

**This diff:**
- Adds `triton_autows.py` with the persistent AutoWS HSTU forward transferred from the K-1 candidate: `grid = (#SMs, Z*H)`, an outer persistent tile loop annotated `tl.range(..., warp_specialize=True)` so Meta AutoWS has a loop to specialize, TMA `TensorDescriptor` loads for Q/K/V, and the SiLU + causal-mask activation.
- Registers `triton_autows_tlx_hstu` as a forward-only `blackwell_attentions` backend, disabled by default because TritonBench does not yet have runtime gates for Meta Triton + Blackwell + AutoWS. Test with `--force` under `TRITON_USE_META_WS=1`.
- Reuses the operator's `preproc_hstu` input layout (matching the existing `tlx_hstu` backend), asserts `TRITON_USE_META_WS=1`, and guards the Meta-Triton-only TMA `TensorDescriptor` import so the operator stays importable elsewhere.

Reviewed By: xuzhao9

Differential Revision: D109222270


