### PR TITLE
Add persistent AutoWS ragged HSTU backend to TritonBench (#1140)

### DIFF
--- a/tritonbench/operators/ragged_attention/operator.py
+++ b/tritonbench/operators/ragged_attention/operator.py
@@ -18,7 +18,10 @@ from tritonbench.utils.triton_op import (
 )
 
 from .hstu import get_test_inputs, HAS_HAMMER, triton_hstu_mha, triton_ragged_hstu_mha
-from .triton_autows import triton_autows_ragged_hstu
+from .triton_autows import (
+    triton_autows_ragged_hstu,
+    triton_autows_ragged_hstu_persistent,
+)
 
 HAS_CUDA = False
 try:
@@ -184,6 +187,25 @@ class Operator(BenchmarkOperator):
             k=k,
             v=v,
             seq_offsets=seq_offsets,
+        )
+
+    # Persistent AutoWS variant (K-6, D109223946): warp-specializes an outer
+    # persistent tile loop (bounded by each jagged sequence's valid M-tile count)
+    # and handles num_targets clamping; validated ws=pass. Disabled by default
+    # for the same runtime-gate reason; test with `--force` under
+    # TRITON_USE_META_WS=1.
+    @register_benchmark(enabled=False, fwd_only=True)
+    def triton_autows_ragged_hstu_persistent(
+        self, q, k, v, seq_offsets, num_targets, max_seq_len, sparsity
+    ):
+        return lambda: triton_autows_ragged_hstu_persistent(
+            max_seq_len,
+            alpha=self.alpha,
+            q=q,
+            k=k,
+            v=v,
+            seq_offsets=seq_offsets,
+            num_targets=num_targets,
         )
 
     # TODO: remove B200 hacks like these.

--- a/tritonbench/operators/ragged_attention/triton_autows.py
+++ b/tritonbench/operators/ragged_attention/triton_autows.py
@@ -194,3 +194,187 @@ def triton_autows_ragged_hstu(
         num_stages=num_stages,
     )
     return out
+
+
+# Triton TR001: this coverage backend intentionally keeps a fixed config while
+# it is disabled by default pending proper runtime gates.
+@triton.jit
+def _ragged_hstu_fwd_persistent_ws(  # noqa: TR001
+    desc_q,
+    desc_k,
+    desc_v,
+    desc_o,
+    seq_offsets,
+    num_targets,
+    alpha,
+    scale,
+    H,
+    NUM_SMS: tl.constexpr,
+    DIM_Q: tl.constexpr,
+    DIM_V: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    HAS_MULTIPLE_TARGETS: tl.constexpr,
+):
+    start_pid = tl.program_id(0)
+    # Grid axis 0 is the persistent dimension (#SMs); axis 1 is (Z * H). Each
+    # program strides over the M-tiles of its (z, h) row group via the
+    # warp-specialized tl.range; this is the loop Meta AutoWS specializes.
+    off_zh = tl.program_id(1)
+
+    # Loop-invariant per-(z, h) setup is hoisted OUT of the warp-specialized
+    # loop (off_zh is constant per program), so the WS loop body has no
+    # pointer-typed cross-partition channels.
+    off_z = off_zh // H
+    off_h = off_zh % H
+    seq_start = tl.load(seq_offsets + off_z).to(tl.int32)
+    seq_end = tl.load(seq_offsets + off_z + 1).to(tl.int32)
+    seq_len = seq_end - seq_start
+    if HAS_MULTIPLE_TARGETS:
+        n_targets = tl.load(num_targets + off_z).to(tl.int32)
+    else:
+        n_targets = 0
+
+    # Bound the persistent loop by the valid M-tile count for this jagged
+    # sequence (instead of a data-dependent `if start_m < seq_len:` inside the
+    # loop body) so the WS loop body stays straight-line and the partition
+    # scheduler does not collapse into a single partition.
+    num_m_blocks = (seq_len + BLOCK_M - 1) // BLOCK_M
+
+    for tile_id in tl.range(start_pid, num_m_blocks, NUM_SMS, warp_specialize=True):
+        start_m = tile_id * BLOCK_M
+        offs_m = start_m + tl.arange(0, BLOCK_M)
+
+        q = desc_q.load([seq_start + start_m, off_h * DIM_Q])  # [BLOCK_M, DIM_Q]
+        acc = tl.zeros([BLOCK_M, DIM_V], dtype=tl.float32)
+
+        # Lower-triangular causal: only KV blocks up to the diagonal block.
+        hi = start_m + BLOCK_M
+        for start_n in range(0, hi, BLOCK_N):
+            offs_n = start_n + tl.arange(0, BLOCK_N)
+
+            k = desc_k.load([seq_start + start_n, off_h * DIM_Q])  # [BLOCK_N, DIM_Q]
+            # Triton TR011: explicit TF32 policy keeps tensor-core behavior stable.
+            qk = tl.dot(q, k.T, allow_tf32=True) * alpha  # [BLOCK_M, BLOCK_N]
+
+            # invalid_mask exactly per the reference SiLU / non-softmax path.
+            cur_offs_m = offs_m
+            cur_offs_n = offs_n
+            max_ids = seq_len
+            if HAS_MULTIPLE_TARGETS:
+                max_ids = max_ids - n_targets
+                cur_offs_m = tl.where(cur_offs_m < max_ids, cur_offs_m, max_ids)
+                cur_offs_n = tl.where(cur_offs_n < max_ids, cur_offs_n, max_ids)
+
+            offs_n_minus_m = cur_offs_n[None, :] - cur_offs_m[:, None]
+            invalid_mask = (cur_offs_m[:, None] == cur_offs_n[None, :]) | (
+                offs_n_minus_m < 0
+            )
+            invalid_mask = invalid_mask & (offs_n[None, :] < seq_len)
+
+            qkf = qk.to(tl.float32)
+            silu = (qkf * tl.sigmoid(qkf)) * scale
+            act = tl.where(invalid_mask, silu, 0.0)
+
+            v = desc_v.load([seq_start + start_n, off_h * DIM_V])  # [BLOCK_N, DIM_V]
+            # Triton TR011: explicit TF32 policy keeps tensor-core behavior stable.
+            acc += tl.dot(act.to(v.dtype), v, allow_tf32=True)
+
+        desc_o.store([seq_start + start_m, off_h * DIM_V], acc.to(desc_o.dtype))
+
+
+def triton_autows_ragged_hstu_persistent(
+    max_seq_len: int,
+    alpha: float,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    seq_offsets: torch.Tensor,
+    num_targets: torch.Tensor | None = None,
+    *,
+    block_m: int = 64,
+    block_n: int = 64,
+    num_warps: int = 4,
+    num_stages: int = 2,
+) -> torch.Tensor:
+    """PERSISTENT AutoWS ragged HSTU forward (K-6).
+
+    Same ragged HSTU SiLU math (lower-triangular causal + num_targets clamping)
+    as ``triton_autows_ragged_hstu`` but expressed as a persistent kernel
+    (``grid = (#SMs, Z*H)`` with an outer warp-specialized tile loop bounded by
+    each jagged sequence's valid M-tile count) so Meta AutoWS has a loop to
+    specialize. Inputs are jagged/packed ``q, k : [L, H, DIM_Q]``,
+    ``v : [L, H, DIM_V]``; returns ``[L, H, DIM_V]``.
+    """
+    if not hasattr(triton, "knobs"):
+        raise NotImplementedError(
+            "triton_autows_ragged_hstu_persistent requires Meta Triton"
+        )
+
+    total_seq, heads, dim_q = q.shape
+    _, _, dim_v = v.shape
+    batch = seq_offsets.shape[0] - 1
+    scale = 1.0 / max_seq_len
+
+    q = q.contiguous()
+    k = k.contiguous()
+    v = v.contiguous()
+    seq_offsets = seq_offsets.to(torch.int64).contiguous()
+    out = torch.empty((total_seq, heads, dim_v), dtype=v.dtype, device=q.device)
+
+    q2 = q.view(total_seq, heads * dim_q)
+    k2 = k.view(total_seq, heads * dim_q)
+    v2 = v.view(total_seq, heads * dim_v)
+    o2 = out.view(total_seq, heads * dim_v)
+
+    def alloc_fn(size: int, _alignment: int, _stream) -> torch.Tensor:
+        return torch.empty(size, device=q.device, dtype=torch.int8)
+
+    triton.set_allocator(alloc_fn)
+
+    desc_q = TensorDescriptor(
+        q2, shape=q2.shape, strides=q2.stride(), block_shape=[block_m, dim_q]
+    )
+    desc_k = TensorDescriptor(
+        k2, shape=k2.shape, strides=k2.stride(), block_shape=[block_n, dim_q]
+    )
+    desc_v = TensorDescriptor(
+        v2, shape=v2.shape, strides=v2.stride(), block_shape=[block_n, dim_v]
+    )
+    desc_o = TensorDescriptor(
+        o2, shape=o2.shape, strides=o2.stride(), block_shape=[block_m, dim_v]
+    )
+
+    num_sms = torch.cuda.get_device_properties(q.device).multi_processor_count
+    grid = (num_sms, batch * heads)
+
+    has_multiple_targets = num_targets is not None
+    if num_targets is None:
+        # dummy tensor so the kernel signature stays uniform; size by batch so
+        # indexing num_targets + off_z stays in bounds if targets are ever enabled
+        num_targets = torch.zeros(batch, dtype=torch.int32, device=q.device)
+
+    assert triton.knobs.nvidia.use_meta_ws, (
+        "triton_autows_ragged_hstu_persistent requires TRITON_USE_META_WS=1"
+    )
+    # TODO: Tune max registers across partitions.
+    _ragged_hstu_fwd_persistent_ws[grid](
+        desc_q,
+        desc_k,
+        desc_v,
+        desc_o,
+        seq_offsets,
+        num_targets,
+        alpha,
+        scale,
+        heads,
+        NUM_SMS=num_sms,
+        DIM_Q=dim_q,
+        DIM_V=dim_v,
+        BLOCK_M=block_m,
+        BLOCK_N=block_n,
+        HAS_MULTIPLE_TARGETS=has_multiple_targets,
+        num_warps=num_warps,
+        num_stages=num_stages,
+    )
+    return out


### PR DESCRIPTION
Summary:

**Context:** D109217204 added the non-persistent `triton_autows_ragged_hstu` coverage backend to TritonBench's `ragged_attention` operator (it warp-specializes the inner KV loop and is disabled because that non-persistent ragged HSTU candidate crashed Meta AutoWS). D109223946 then explored a persistent Meta AutoWS (automatic warp specialization) candidate for the same `hammer_hstu` math (ragged/jagged HSTU SiLU attention, lower-triangular causal + num_targets clamping) and validated `ws=pass` (a real `ttg.warp_specialize` op with the canonical 4-way `["epilogue","gemm","load","computation"]` split, `tc_gen5_mma`, async TMA in the load producer) and correctness at `atol=1e-2` across seq_len 256/512/1024 (`max_abs_err ~3.7e-10` vs the hammer `triton_ragged_hstu_mha` kernel, `~1.5e-11` vs a pure-torch ragged HSTU reference).

**Motivation:** Carry both AutoWS warp-specialization structures as separate coverage backends. The non-persistent variant (the base diff) specializes the inner KV loop and does not compile; this diff adds the persistent variant (`grid = (#SMs, Z*H)` with an outer warp-specialized tile loop bounded by each jagged sequence's valid M-tile count), which is the structure K-6 actually validated.

**This diff (stacked on D109217204, its non-persistent base):**
- Adds the persistent AutoWS ragged HSTU kernel from K-6 to `ragged_attention/triton_autows.py` as a new `triton_autows_ragged_hstu_persistent` function (the existing non-persistent `triton_autows_ragged_hstu` is left untouched): TMA `TensorDescriptor` Q/K/V loads over the packed `[L, H*DIM]` layout, SiLU + causal + num_targets `invalid_mask`, register-resident PV-dot LHS. Loop-invariant jagged setup is hoisted out of the WS loop and the loop is bounded by `num_m_blocks` (straight-line body) to keep partition scheduling from collapsing.
- Registers a new `triton_autows_ragged_hstu_persistent` backend that, unlike the non-persistent one, forwards `num_targets` (both `enabled=False`, `fwd_only=True`; test with `--force`).
- Asserts only `TRITON_USE_META_WS=1` (the env K-6 validated under).

Reviewed By: xuzhao9

Differential Revision: D109226912


