### PR TITLE
Add persistent AutoWS flex_attention backend to TritonBench (#1142)

### DIFF
--- a/tritonbench/operators/flex_attention/operator.py
+++ b/tritonbench/operators/flex_attention/operator.py
@@ -26,7 +26,10 @@ try:
 except ImportError:
     pass
 
-from tritonbench.operators.flex_attention.triton_autows import autows_flex_attention
+from tritonbench.operators.flex_attention.triton_autows import (
+    autows_flex_attention,
+    autows_flex_attention_persistent,
+)
 from tritonbench.utils.env_utils import is_hip
 from tritonbench.utils.input import input_filter
 from tritonbench.utils.triton_op import (
@@ -342,6 +345,25 @@ class Operator(BenchmarkOperator):
         if mod_type not in ("noop", "causal"):
             return unsupported_fn
         return lambda: autows_flex_attention(q, k, v, causal=mod_type == "causal")
+
+    # Persistent AutoWS variant (K-3, D109219053): warp-specializes an outer
+    # persistent tile loop instead of the inner KV loop. Validated for the noop
+    # (full SDPA) path only. Disabled by default for the same runtime-gate
+    # reason; test with `--force` under TRITON_USE_META_WS=1.
+    @register_benchmark(enabled=False, fwd_only=True)
+    def triton_autows_flex_attention_persistent(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        score_mod: Optional[_score_mod_signature],
+        block_mask: Optional[BlockMask],
+        mod_type: str,
+        kernel_options: dict[str, Any],
+    ) -> Optional[Callable]:
+        if mod_type != "noop":
+            return unsupported_fn
+        return lambda: autows_flex_attention_persistent(q, k, v)
 
     @register_benchmark(enabled=HAS_FLASH_V3)
     def flash_v3(

--- a/tritonbench/operators/flex_attention/triton_autows.py
+++ b/tritonbench/operators/flex_attention/triton_autows.py
@@ -214,3 +214,182 @@ def autows_flex_attention(
         num_stages=num_stages,
     )
     return o
+
+
+# Triton TR001: this coverage backend intentionally keeps a fixed config while
+# it is disabled by default pending proper runtime gates.
+@triton.jit
+def _flex_attn_fwd_persistent_ws(  # noqa: TR001
+    desc_q,  # [B*Hq*M, DIM] row-major (M-blocked tiles)
+    desc_k,  # [B*Hkv*N, DIM]
+    desc_v,  # [B*Hkv*N, DIM]
+    desc_o,  # [B*Hq*M, DIM]
+    scale,
+    N,
+    Hq,
+    GROUP: tl.constexpr,  # Hq // Hkv (query heads per kv head)
+    NUM_SMS: tl.constexpr,
+    DIM: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    NUM_M_BLOCKS: tl.constexpr,  # M // BLOCK_M
+    NUM_BHQ: tl.constexpr,  # B * Hq (flattened batch*q_head count)
+    M: tl.constexpr,
+):
+    start_pid = tl.program_id(0)
+    # One output tile per (batch, q_head, M-block). The (batch, q_head) index is
+    # tile_id // NUM_M_BLOCKS; the M-block within that head is the remainder.
+    total_tiles = NUM_BHQ * NUM_M_BLOCKS
+
+    # Persistent tile loop: this is the loop Meta AutoWS specializes.
+    for tile_id in tl.range(start_pid, total_tiles, NUM_SMS, warp_specialize=True):
+        bhq = tile_id // NUM_M_BLOCKS  # flattened (batch, q_head)
+        m_block = tile_id % NUM_M_BLOCKS
+        start_m = m_block * BLOCK_M
+
+        # GQA: kv head for this q head. bhq = b*Hq + hq.
+        b = bhq // Hq
+        hq = bhq % Hq
+        hkv = hq // GROUP
+        bhkv = b * (Hq // GROUP) + hkv
+
+        q_row = bhq * M + start_m
+        kv_row = bhkv * N
+
+        # Q for this tile: [BLOCK_M, DIM]. Scale folded into Q (matches SDPA).
+        q = desc_q.load([q_row, 0])
+        q = (q.to(tl.float32) * scale).to(q.dtype)
+
+        m_i = tl.full([BLOCK_M], -float("inf"), dtype=tl.float32)
+        l_i = tl.zeros([BLOCK_M], dtype=tl.float32)
+        acc = tl.zeros([BLOCK_M, DIM], dtype=tl.float32)
+
+        # Full (non-causal) attention over all N keys (noop mask).
+        for start_n in range(0, N, BLOCK_N):
+            k = desc_k.load([kv_row + start_n, 0])  # [BLOCK_N, DIM]
+            # Triton TR011: explicit TF32 policy keeps tensor-core behavior stable.
+            qk = tl.dot(q, k.T, allow_tf32=True)  # [BLOCK_M, BLOCK_N] (q pre-scaled)
+
+            m_ij = tl.maximum(m_i, tl.max(qk, axis=1))
+            p = tl.exp(qk - m_ij[:, None])
+            alpha = tl.exp(m_i - m_ij)
+
+            l_i = l_i * alpha + tl.sum(p, axis=1)
+            acc = acc * alpha[:, None]
+
+            v = desc_v.load([kv_row + start_n, 0])  # [BLOCK_N, DIM]
+            # Triton TR011: explicit TF32 policy keeps tensor-core behavior stable.
+            acc += tl.dot(p.to(v.dtype), v, allow_tf32=True)
+            m_i = m_ij
+
+        l_safe = tl.where(l_i > 0.0, l_i, 1.0)
+        acc = acc / l_safe[:, None]
+
+        desc_o.store([q_row, 0], acc.to(desc_o.dtype))
+
+
+def autows_flex_attention_persistent(
+    q: torch.Tensor,  # [B, Hq, M, D]
+    k: torch.Tensor,  # [B, Hkv, N, D]
+    v: torch.Tensor,  # [B, Hkv, N, D]
+    *,
+    block_m: int = 128,
+    block_n: int = 128,
+    num_warps: int = 4,
+    num_stages: int = 2,
+) -> torch.Tensor:
+    """PERSISTENT AutoWS FlexAttention (noop / full SDPA) forward (K-3).
+
+    Same noop (non-causal SDPA) math as ``autows_flex_attention`` but expressed
+    as a persistent kernel (``grid = #SMs`` with an outer warp-specialized tile
+    loop over (batch, q_head, M-block)) so Meta AutoWS has a loop to specialize.
+    """
+    if not hasattr(triton, "knobs"):
+        raise NotImplementedError(
+            "autows_flex_attention_persistent requires Meta Triton"
+        )
+
+    batch, heads_q, q_ctx, head_dim = q.shape
+    _, heads_kv, kv_ctx, _ = k.shape
+    if heads_q % heads_kv != 0:
+        raise NotImplementedError(
+            "autows_flex_attention_persistent requires Hq % Hkv == 0"
+        )
+    if head_dim != 128:
+        raise NotImplementedError(
+            "autows_flex_attention_persistent currently supports D=128"
+        )
+    if q_ctx % block_m != 0:
+        raise NotImplementedError(
+            f"autows_flex_attention_persistent requires M % {block_m} == 0"
+        )
+    group = heads_q // heads_kv
+
+    q2 = q.reshape(batch * heads_q * q_ctx, head_dim).contiguous()
+    k2 = k.reshape(batch * heads_kv * kv_ctx, head_dim).contiguous()
+    v2 = v.reshape(batch * heads_kv * kv_ctx, head_dim).contiguous()
+    o2 = torch.empty(
+        (batch * heads_q * q_ctx, head_dim), dtype=q.dtype, device=q.device
+    )
+
+    def alloc_fn(size: int, _alignment: int, _stream) -> torch.Tensor:
+        return torch.empty(size, device=q.device, dtype=torch.int8)
+
+    triton.set_allocator(alloc_fn)
+
+    desc_q = TensorDescriptor(
+        q2,
+        shape=[batch * heads_q * q_ctx, head_dim],
+        strides=[head_dim, 1],
+        block_shape=[block_m, head_dim],
+    )
+    desc_k = TensorDescriptor(
+        k2,
+        shape=[batch * heads_kv * kv_ctx, head_dim],
+        strides=[head_dim, 1],
+        block_shape=[block_n, head_dim],
+    )
+    desc_v = TensorDescriptor(
+        v2,
+        shape=[batch * heads_kv * kv_ctx, head_dim],
+        strides=[head_dim, 1],
+        block_shape=[block_n, head_dim],
+    )
+    desc_o = TensorDescriptor(
+        o2,
+        shape=[batch * heads_q * q_ctx, head_dim],
+        strides=[head_dim, 1],
+        block_shape=[block_m, head_dim],
+    )
+
+    scale = head_dim**-0.5
+    num_m_blocks = q_ctx // block_m
+    num_bhq = batch * heads_q
+    num_sms = torch.cuda.get_device_properties(q.device).multi_processor_count
+    grid = (num_sms,)
+
+    assert triton.knobs.nvidia.use_meta_ws, (
+        "autows_flex_attention_persistent requires TRITON_USE_META_WS=1"
+    )
+    # TODO: Tune max registers across partitions.
+    _flex_attn_fwd_persistent_ws[grid](
+        desc_q,
+        desc_k,
+        desc_v,
+        desc_o,
+        scale,
+        kv_ctx,
+        heads_q,
+        GROUP=group,
+        NUM_SMS=num_sms,
+        DIM=head_dim,
+        BLOCK_M=block_m,
+        BLOCK_N=block_n,
+        NUM_M_BLOCKS=num_m_blocks,
+        NUM_BHQ=num_bhq,
+        M=q_ctx,
+        num_warps=num_warps,
+        num_stages=num_stages,
+    )
+
+    return o2.reshape(batch, heads_q, q_ctx, head_dim)


### PR DESCRIPTION
Summary:

**Context:** D109067833 added the non-persistent `triton_autows_flex_attention` coverage backend to TritonBench's `flex_attention` operator (it warp-specializes the inner KV loop, noop + causal). D109219053 then explored a persistent Meta AutoWS (automatic warp specialization) candidate for the `compiled` FlexAttention coverage gap and validated `ws=pass` (a real `ttg.warp_specialize` op with the full Blackwell 5-way partition, `ttng.tc_gen5_mma`, and async TMA in the load producer) and correctness (max abs error `3.91e-3` across 4 shapes vs eager `flex_attention` and a pure-torch SDPA reference, at the operator's bf16 tolerance `rtol=1.6e-2, atol=1e-5`).

**Motivation:** Carry both AutoWS warp-specialization structures as separate coverage backends. The non-persistent variant (the base diff) specializes the inner KV loop; this diff adds the persistent variant (`grid = #SMs` with an outer warp-specialized tile loop over (batch, q_head, M-block)), which is the structure K-3 actually validated.

**This diff (stacked on D109067833, its non-persistent base):**
- Adds the persistent AutoWS FlexAttention kernel from K-3 to `flex_attention/triton_autows.py` as a new `autows_flex_attention_persistent` function (the existing non-persistent `autows_flex_attention` is left untouched): outer persistent `tl.range(..., warp_specialize=True)` tile loop, TMA `TensorDescriptor` Q/K/V loads, online (flash) softmax. The candidate validated the `noop` (full SDPA) path, so this variant supports `noop` only.
- Registers a new `triton_autows_flex_attention_persistent` backend alongside the existing `triton_autows_flex_attention` (both `enabled=False`, `fwd_only=True`; test with `--force`); it returns `unsupported_fn` for any non-`noop` mod type.
- The persistent path asserts only `TRITON_USE_META_WS=1` (the env K-3 validated under).

Reviewed By: manman-ren

Differential Revision: D109222799


