### PR TITLE
Add disabled persistent AutoWS GDPA backend to TritonBench (#1144)

### DIFF
--- a/tritonbench/operators/gdpa/operator.py
+++ b/tritonbench/operators/gdpa/operator.py
@@ -44,7 +44,10 @@ from tritonbench.utils.triton_utils import has_tlx
 if has_tlx():
     from tritonbench.operators.gdpa.gdpa_blackwell_tlx import gdpa_forward_tlx
 
-from tritonbench.operators.gdpa.triton_autows import triton_autows_gdpa
+from tritonbench.operators.gdpa.triton_autows import (
+    triton_autows_gdpa,
+    triton_autows_gdpa_persistent,
+)
 
 from .gdpa import gdpa as gdpa_kernel
 from .gdpa_utils import generate_jagged_data
@@ -225,6 +228,38 @@ class Operator(BenchmarkOperator):
     ):
         def _inner():
             return triton_autows_gdpa(
+                query=jagged_q,
+                key=jagged_k,
+                value=jagged_v,
+                query_offset=jagged_data["q_offsets"],
+                key_offset=jagged_data["k_offsets"],
+                max_seq_len_q=jagged_data["max_seq_len_q"],
+                max_seq_len_kv=jagged_data["max_seq_len_k"],
+                activation=activation,
+                broadcast_q=jagged_data["broadcast_q"],
+                window_size=jagged_data["window_size"],
+            )
+
+        return _inner
+
+    # Persistent AutoWS variant (K-4, D109222272): a jagged-native persistent
+    # kernel that warp-specializes an outer tile loop. Disabled by default: it
+    # currently does NOT compile through Meta AutoWS (NVGPUWarpSpecialization
+    # cross-partition TMEM MMA-operand crash on the QK -> activation -> PV loop).
+    # Carried for coverage; test with `--force` once the compiler issue is fixed.
+    @register_benchmark(enabled=False, fwd_only=True)
+    def triton_autows_gdpa_persistent(
+        self,
+        _config_name,
+        jagged_q,
+        jagged_k,
+        jagged_v,
+        jagged_data,
+        padded_data,
+        activation,
+    ):
+        def _inner():
+            return triton_autows_gdpa_persistent(
                 query=jagged_q,
                 key=jagged_k,
                 value=jagged_v,

--- a/tritonbench/operators/gdpa/triton_autows.py
+++ b/tritonbench/operators/gdpa/triton_autows.py
@@ -265,3 +265,221 @@ def triton_autows_gdpa(
         num_stages=num_stages,
     )
     return _unpack_jagged(dense_out, query_offset, query.shape[0])
+
+
+# Triton TR001: this coverage backend intentionally keeps a fixed config; it is
+# disabled by default because it currently does not compile through Meta AutoWS.
+@triton.jit
+def _gdpa_fwd_persistent_ws(  # noqa: TR001
+    Q,  # packed [total_q, H*DIM] (row-major), head h at cols [h*DIM, (h+1)*DIM)
+    K,  # packed [total_k, Hkv*DIM]
+    V,  # packed [total_k, Hkv*DIM]
+    Out,  # packed [total_q, H*DIM]
+    Q_offsets,  # [Z+1] int32 jagged row offsets for Q/Out
+    K_offsets,  # [Z+1] int32 jagged row offsets for K/V
+    qk_scale,
+    H,  # number of q heads
+    G: tl.constexpr,  # q heads per kv head (H // Hkv)
+    N_CTX: tl.constexpr,  # max_seq_len_q (cap on qlen)
+    DIM: tl.constexpr,  # head_dim
+    NUM_SMS: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    N_TILE_NUM: tl.constexpr,  # cdiv(N_CTX, BLOCK_M)
+    N_KV_BLOCKS: tl.constexpr,  # cdiv(N_CTX_KV, BLOCK_N) -- STATIC inner trip count
+    Z,  # batch count
+):
+    start_pid = tl.program_id(0)
+    # One logical work item per (batch z, head h, M-block). Flattened tile index:
+    #   tile = ((z * H) + h) * N_TILE_NUM + m_block
+    total_tiles = Z * H * N_TILE_NUM
+
+    # Persistent tile loop -- the loop Meta AutoWS specializes. On-device 2D TMA
+    # descriptors are built per tile with the batch's [end_q]/[end_k] extent so the
+    # TMA hardware bounds-checks the ragged tail.
+    for tile_id in tl.range(start_pid, total_tiles, NUM_SMS, warp_specialize=True):
+        m_block = tile_id % N_TILE_NUM
+        off_hz = tile_id // N_TILE_NUM
+        h = off_hz % H
+        z = off_hz // H
+        hkv = h // G
+        Hkv = H // G  # number of kv heads (column width of packed K/V)
+
+        begin_q = tl.load(Q_offsets + z)
+        end_q = tl.load(Q_offsets + z + 1)
+        qlen = tl.minimum(end_q - begin_q, N_CTX)
+
+        begin_k = tl.load(K_offsets + z)
+        end_k = tl.load(K_offsets + z + 1)
+        klen = end_k - begin_k
+
+        start_m = m_block * BLOCK_M
+
+        # Per-tile descriptors bounded to this batch's row extent (end_q / end_k).
+        q_desc = tl.make_tensor_descriptor(
+            Q, shape=[end_q, H * DIM], strides=[H * DIM, 1], block_shape=[BLOCK_M, DIM]
+        )
+        k_desc = tl.make_tensor_descriptor(
+            K,
+            shape=[end_k, Hkv * DIM],
+            strides=[Hkv * DIM, 1],
+            block_shape=[BLOCK_N, DIM],
+        )
+        v_desc = tl.make_tensor_descriptor(
+            V,
+            shape=[end_k, Hkv * DIM],
+            strides=[Hkv * DIM, 1],
+            block_shape=[BLOCK_N, DIM],
+        )
+        o_desc = tl.make_tensor_descriptor(
+            Out,
+            shape=[end_q, H * DIM],
+            strides=[H * DIM, 1],
+            block_shape=[BLOCK_M, DIM],
+        )
+
+        q_row = begin_q + start_m
+        q_col = h * DIM
+        kv_col = hkv * DIM
+
+        # Q tile: [BLOCK_M, DIM]. Scale folded into Q (qk_scale == 1.0 by default).
+        q = q_desc.load([q_row, q_col])
+        if qk_scale != 1.0:
+            q = (q.to(tl.float32) * qk_scale).to(q.dtype)
+
+        acc = tl.zeros([BLOCK_M, DIM], dtype=tl.float32)
+
+        offs_n = tl.arange(0, BLOCK_N)
+        # STATIC inner trip count so the partition scheduler pipelines a
+        # static-bound inner loop. The ragged KV tail is masked. No softmax --
+        # GDPA applies an elementwise activation to the scores and accumulates
+        # act @ v. P is kept register-resident (never TMEM-staged).
+        for kv_blk in range(0, N_KV_BLOCKS):
+            start_n = kv_blk * BLOCK_N
+            k_row = begin_k + start_n
+            k = k_desc.load([k_row, kv_col])  # [BLOCK_N, DIM] (TMA bounds-checked)
+            # Triton TR011: explicit TF32 policy keeps tensor-core behavior stable.
+            qk = tl.dot(q, k.T, allow_tf32=True)  # [BLOCK_M, BLOCK_N], fp32
+
+            n_mask = (start_n + offs_n) < klen
+            act = _fast_gelu(qk)
+            act = tl.where(n_mask[None, :], act, 0.0)
+
+            v = v_desc.load([k_row, kv_col])  # [BLOCK_N, DIM]
+            # Triton TR011: explicit TF32 policy keeps tensor-core behavior stable.
+            acc += tl.dot(act.to(v.dtype), v, allow_tf32=True)
+
+        # Store the output tile. TMA bounds-checks against end_q, so M-tail rows
+        # past the batch are dropped (never written into the next batch).
+        if klen > 0:
+            o_desc.store([q_row, q_col], acc.to(Out.dtype.element_ty))
+
+
+def triton_autows_gdpa_persistent(
+    query: torch.Tensor,  # [total_q, H, DIM]
+    key: torch.Tensor,  # [total_k, Hkv, DIM]
+    value: torch.Tensor,  # [total_k, Hkv, DIM]
+    query_offset: torch.Tensor,  # [Z+1] int32
+    key_offset: torch.Tensor,  # [Z+1] int32
+    *,
+    max_seq_len_q: int,
+    max_seq_len_kv: int,
+    activation: str,
+    broadcast_q: bool,
+    window_size: int | None,
+    qk_scale: float = 1.0,
+    block_m: int = 128,
+    block_n: int = 128,
+    num_warps: int = 4,
+    num_stages: int = 2,
+) -> torch.Tensor:
+    """PERSISTENT AutoWS GDPA forward for the default dense-core GDPA case (K-4).
+
+    Jagged-native variant of ``triton_autows_gdpa`` (no dense pack/unpack): a
+    persistent kernel whose outer tile loop is annotated
+    ``tl.range(..., warp_specialize=True)`` with on-device per-tile TMA
+    descriptors bounded to each batch's extent.
+
+    NOTE: this candidate currently does NOT compile through Meta AutoWS -- the
+    ``NVGPUWarpSpecialization`` pass crashes building the cross-partition TMEM
+    MMA-operand channel for the QK -> activation -> PV two-MMA loop (tracked
+    separately). The source math is correct (it matches ``eager_gdpa`` with
+    ``warp_specialize=False``); the backend is carried disabled for coverage.
+    """
+    if not hasattr(triton, "knobs"):
+        raise NotImplementedError("triton_autows_gdpa_persistent requires Meta Triton")
+    if activation != "fast_gelu":
+        raise NotImplementedError(
+            "triton_autows_gdpa_persistent currently supports fast_gelu"
+        )
+    if broadcast_q:
+        raise NotImplementedError(
+            "triton_autows_gdpa_persistent does not support broadcast_q"
+        )
+    if window_size is not None:
+        raise NotImplementedError(
+            "triton_autows_gdpa_persistent does not support window_size"
+        )
+
+    total_q, heads, head_dim = query.shape
+    total_k, heads_kv, head_dim_k = key.shape
+    if head_dim != head_dim_k or value.shape != key.shape:
+        raise NotImplementedError("triton_autows_gdpa_persistent requires matching K/V")
+    if heads % heads_kv != 0:
+        raise NotImplementedError("triton_autows_gdpa_persistent requires H % Hkv == 0")
+    if head_dim != 128:
+        raise NotImplementedError(
+            "triton_autows_gdpa_persistent currently supports D=128"
+        )
+
+    group = heads // heads_kv
+    batch = query_offset.numel() - 1
+
+    # Pack to 2D [total, H*DIM] contiguous so the on-device TMA descriptors are
+    # simple row-major 2D (head h selected by the h*DIM column offset).
+    q2 = query.reshape(total_q, heads * head_dim).contiguous()
+    k2 = key.reshape(total_k, heads_kv * head_dim).contiguous()
+    v2 = value.reshape(total_k, heads_kv * head_dim).contiguous()
+    o2 = torch.empty(
+        (total_q, heads * head_dim), dtype=query.dtype, device=query.device
+    )
+
+    def alloc_fn(size: int, _alignment: int, _stream) -> torch.Tensor:
+        return torch.empty(size, device=query.device, dtype=torch.int8)
+
+    triton.set_allocator(alloc_fn)
+
+    n_tile_num = triton.cdiv(max_seq_len_q, block_m)
+    n_kv_blocks = triton.cdiv(max_seq_len_kv, block_n)
+    num_sms = torch.cuda.get_device_properties(query.device).multi_processor_count
+
+    def grid(_meta):
+        total_tiles = batch * heads * n_tile_num
+        return (min(num_sms, total_tiles), 1, 1)
+
+    assert triton.knobs.nvidia.use_meta_ws, (
+        "triton_autows_gdpa_persistent requires TRITON_USE_META_WS=1"
+    )
+    # TODO: Tune max registers across partitions.
+    _gdpa_fwd_persistent_ws[grid](
+        q2,
+        k2,
+        v2,
+        o2,
+        query_offset,
+        key_offset,
+        qk_scale,
+        heads,
+        G=group,
+        N_CTX=max_seq_len_q,
+        DIM=head_dim,
+        NUM_SMS=num_sms,
+        BLOCK_M=block_m,
+        BLOCK_N=block_n,
+        N_TILE_NUM=n_tile_num,
+        N_KV_BLOCKS=n_kv_blocks,
+        Z=batch,
+        num_warps=num_warps,
+        num_stages=num_stages,
+    )
+    return o2.reshape(total_q, heads, head_dim)


### PR DESCRIPTION
Summary:

**Context:** D109177040 added the non-persistent `triton_autows_gdpa` coverage backend to TritonBench's `gdpa` operator (it warp-specializes the inner KV loop and is enabled on Blackwell). D109222272 then explored a persistent Meta AutoWS (automatic warp specialization) candidate for the same `tlx_gdpa` math (jagged self-attention with an elementwise `fast_gelu` activation, no softmax).

**Outcome of the candidate:** `compiler_crash`. The source is well-formed and correct (with `warp_specialize=False` it compiles and matches `eager_gdpa` within tolerance), but with `TRITON_USE_META_WS=1` it crashes the `NVGPUWarpSpecialization{capability=100}` pass: `tritongpu-promote-lhs-to-tmem` stages the PV-dot LHS (the in-loop activation `P`) into TMEM in the `computation` partition while the PV `tc_gen5_mma` lands in the `gemm` partition, and WS code-partitioning cannot build the cross-partition TMEM MMA-operand channel. The crash is robust to `num_stages`, `BLOCK_M`/`BLOCK_N`, `num_warps`, and descriptor/control-flow structure.

**Motivation:** Carry the persistent warp-specialization structure as a separate, disabled coverage backend so the GDPA persistent-AutoWS compiler gap is visible from the operator surface while the compiler fix is tracked separately (mirrors the existing disabled crashing AutoWS backends).

**This diff (stacked on D109177040, its non-persistent base):**
- Adds the persistent AutoWS GDPA kernel from K-4 to `gdpa/triton_autows.py` as a new `triton_autows_gdpa_persistent` function (the existing non-persistent `triton_autows_gdpa` is left untouched): a jagged-native persistent kernel (`grid = #SMs`, outer `tl.range(..., warp_specialize=True)` tile loop) with on-device per-tile TMA descriptors bounded to each batch's extent; reuses the file's `_fast_gelu`.
- Registers a new `triton_autows_gdpa_persistent` backend, `enabled=False` (it does not compile through Meta AutoWS yet), alongside the existing `triton_autows_gdpa`.
- Asserts `TRITON_USE_META_WS=1` (the env K-4 was driven under).

Reviewed By: xuzhao9

Differential Revision: D109222900


