### PR TITLE
fp8_gemm: fix quantization scale direction so accuracy checks are meaningful

### DIFF
--- a/tritonbench/operators/fp8_gemm/fp8_gemm.py
+++ b/tritonbench/operators/fp8_gemm/fp8_gemm.py
@@ -115,25 +115,32 @@ def get_scale(
         # For tensor-wise scaling, kernel requires a float32 scale tensor
         if custom_scale:
             return torch.tensor(custom_scale, dtype=torch.float32, device=x.device)
-        scale = (torch.finfo(torch.float8_e4m3fn).max / x.abs().max()).reciprocal()
-        x *= scale
-        return x, scale.to(torch.float32)
+        # Scale x UP into the fp8 dynamic range so the stored fp8 values use the
+        # full range (absmax ~= fp8 max), then return the reciprocal (dequant)
+        # scale that _scaled_mm multiplies the accumulator by to recover real units.
+        quant_scale = torch.finfo(torch.float8_e4m3fn).max / x.abs().max()
+        x = x.mul(quant_scale)
+        dequant_scale = quant_scale.reciprocal()
+        return x, dequant_scale.to(torch.float32)
 
     def _get_scale_per_row(
         x: torch.Tensor, transpose: bool = False
     ) -> (torch.Tensor, torch.Tensor):
         if transpose:  # scale_b.shape should be [1, N]
-            scale = (
+            quant_scale = (
                 torch.finfo(torch.float8_e4m3fn).max
                 / x.abs().max(dim=0, keepdim=True).values
-            ).reciprocal()
+            )
         else:  # scale_a.shape should be [M, 1]
-            scale = (
+            quant_scale = (
                 torch.finfo(torch.float8_e4m3fn).max
                 / x.abs().max(dim=1, keepdim=True).values
-            ).reciprocal()
-        x = x.mul(scale)
-        return x, scale.to(
+            )
+        # Scale x UP into the fp8 dynamic range, then return the reciprocal
+        # (dequant) scale for _scaled_mm to recover real units.
+        x = x.mul(quant_scale)
+        dequant_scale = quant_scale.reciprocal()
+        return x, dequant_scale.to(
             torch.float32
         )  # For row-wise scaling, kernel requires a float32 scale tensor
 
@@ -142,13 +149,12 @@ def get_scale(
     ) -> (torch.Tensor, torch.Tensor):
         x = x.unflatten(1, (-1, block_inner)).unflatten(0, (-1, block_outer))
         amax = x.abs().amax(dim=[1, 3], keepdim=True).float()
-        scale = (
-            torch.finfo(torch.float8_e4m3fn).max / amax
-        ).reciprocal()  # keeps scale small enough such that scaling doesn't cause inf values
+        quant_scale = torch.finfo(torch.float8_e4m3fn).max / amax
         x = (
-            x.mul(scale).flatten(2, 3).flatten(0, 1)
-        )  # scale input up to dynamic range of float8_e4m3fn
-        scale = scale.flatten(2, 3).flatten(0, 1)
+            x.mul(quant_scale).flatten(2, 3).flatten(0, 1)
+        )  # scale input UP to the dynamic range of float8_e4m3fn
+        # Return the reciprocal (dequant) scale for _scaled_mm to recover real units.
+        scale = quant_scale.reciprocal().flatten(2, 3).flatten(0, 1)
 
         if block_outer == 1 and block_inner == 128:
             scale = (


### PR DESCRIPTION
The `get_scale` helpers in the fp8_gemm operator quantized in the wrong direction, producing fp8 inputs whose values sat far below the fp8 dynamic range. The resulting GEMM outputs were numerically ~zero, which silently defeated the operator's accuracy metric: when the reference output is ~1e-6, `torch.testing.assert_close` (bf16 default atol=1e-5) passes for essentially any implementation -- including numerically wrong ones -- because both tensors fall below atol.

Root cause
----------
All three helpers (`_get_scale_per_tensor`, `_get_scale_per_row`, `_get_scale_per_block`) computed:

    scale = (fp8_max / x.abs().max()).reciprocal()   # = amax / fp8_max  (~0.01)
    x = x.mul(scale)                                  # shrinks x DOWN
    return x, scale

`scale` here is the small *dequant* factor. Multiplying x by it before the later `.to(fp8)` cast (in `get_input_iter`) left the stored fp8 values with absmax ~0.06 instead of ~448 (the e4m3 max). `torch._scaled_mm` then multiplies the accumulator by `scale` a second time, so the output was shrunk by an extra factor of scale^2 and collapsed to ~1e-6.

Fix
---
Scale x UP into the fp8 dynamic range using the large quant scale (`fp8_max / amax`), so the stored fp8 values use the full range, and return the reciprocal (dequant) scale that `_scaled_mm` applies to recover real units:

    quant_scale = fp8_max / x.abs().max()
    x = x.mul(quant_scale)              # fills fp8 range, absmax ~= fp8_max
    return x, quant_scale.reciprocal()  # dequant scale for _scaled_mm

This keeps the dequantized result mathematically correct (out ~= a_fp32 @ b_fp32^T in real units) while making it non-degenerate. The BlockWise path no longer needs its "keeps scale small enough such that scaling doesn't cause inf" comment: scaling by quant_scale yields absmax exactly fp8_max per block, which is representable.

Verification (B200)
-------------------
Before the fix, stored fp8 absmax = 0.06, output norm ~1.5e-4, and a deliberately wrong (1.5x) output PASSED assert_close against the baseline. After the fix, stored fp8 absmax = 448, output norm ~1.1e4, and the same 1.5x-wrong output FAILS assert_close -- the accuracy metric now discriminates correct from incorrect implementations. Dequantized output matches a float32 matmul reference within expected fp8 quantization error (TensorWise ~0.04, RowWise ~0.15 rel err).