### PR TITLE
fp8_gemm: add 2-CTA for TensorWise/RowWise

### DIFF
--- a/tritonbench/operators/fp8_gemm/scaled_mm_autows.py
+++ b/tritonbench/operators/fp8_gemm/scaled_mm_autows.py
@@ -233,9 +233,7 @@ def _prune_configs(configs, named_args, **kwargs):
             continue
         # 2-CTA (cta_group::2): a tuning option for the epilogue-scaled modes
         # (TensorWise, RowWise) -- like CUTLASS, which uses the same 2-SM cluster
-        # for per-tensor and per-token/-channel (the per-row/col scale is applied
-        # in the epilogue by global coordinate, so the cluster split is
-        # transparent). MXFP8 / in-loop fp32 modes don't support 2-CTA.
+        # for per-tensor and per-token/-channel.
         # Requires Blackwell + Meta-WS + BLOCK_M >= 128.
         if config.kwargs.get("TWO_CTAS", False):
             if not (is_tensorwise or is_rowwise):

--- a/tritonbench/operators/fp8_gemm/scaled_mm_autows.py
+++ b/tritonbench/operators/fp8_gemm/scaled_mm_autows.py
@@ -176,10 +176,15 @@ def _get_autotune_configs():
     # the plain-tl.dot path. _prune_configs offers it as a tuning option for
     # TensorWise/RowWise on Blackwell + Meta-WS, BM>=128 (see the RowWise caveat
     # there: the autotuner can mis-pick the 2-CTA RowWise config).
+    #
+    # ctas_per_cga is an FBTriton/Meta-WS-only triton.Config arg, so only emit the
+    # 2-CTA configs when Meta-WS is available -- on OSS Triton _use_meta_ws() is
+    # False and no ctas_per_cga config is ever constructed.
+    two_cta_options = [False, True] if _use_meta_ws() else [False]
     for num_stages in [3, 4, 5]:
         for BLOCK_M, BLOCK_N, BLOCK_K in block_configs:
             for EPILOGUE_SUBTILE in [1, 2, 4]:
-                for TWO_CTAS in [False, True]:
+                for TWO_CTAS in two_cta_options:
                     extras = {"ctas_per_cga": (2, 1, 1)} if TWO_CTAS else {}
                     configs.append(
                         triton.Config(
@@ -536,14 +541,26 @@ def scaled_mm_autows_kernel(
                 a_tile = a_desc.load([offs_am, offs_k])
                 b_tile = b_desc.load([offs_bn, offs_k])
                 # Triton TR011: keep Tensor Core TF32 behavior explicit.
-                accumulator = tl.dot(
-                    a_tile,
-                    b_tile.T,
-                    accumulator,
-                    out_dtype=tl.float32,
-                    allow_tf32=True,
-                    two_ctas=TWO_CTAS,
-                )
+                # two_ctas is an FBTriton-only tl.dot kwarg -- only pass it on the
+                # 2-CTA path (TWO_CTAS is set only under Meta-WS) so OSS Triton,
+                # which has no such kwarg, never receives it.
+                if TWO_CTAS:
+                    accumulator = tl.dot(
+                        a_tile,
+                        b_tile.T,
+                        accumulator,
+                        out_dtype=tl.float32,
+                        allow_tf32=True,
+                        two_ctas=True,
+                    )
+                else:
+                    accumulator = tl.dot(
+                        a_tile,
+                        b_tile.T,
+                        accumulator,
+                        out_dtype=tl.float32,
+                        allow_tf32=True,
+                    )
 
             if IS_ROWWISE:
                 if USE_SCALE_TMA:

--- a/tritonbench/operators/fp8_gemm/scaled_mm_autows.py
+++ b/tritonbench/operators/fp8_gemm/scaled_mm_autows.py
@@ -172,23 +172,31 @@ def _get_autotune_configs():
         (256, 128, 128),
     ]
 
+    # TWO_CTAS=True enables 2-CTA (cta_group::2) MMA via ctas_per_cga=(2,1,1) on
+    # the plain-tl.dot path. _prune_configs offers it as a tuning option for
+    # TensorWise/RowWise on Blackwell + Meta-WS, BM>=128 (see the RowWise caveat
+    # there: the autotuner can mis-pick the 2-CTA RowWise config).
     for num_stages in [3, 4, 5]:
         for BLOCK_M, BLOCK_N, BLOCK_K in block_configs:
             for EPILOGUE_SUBTILE in [1, 2, 4]:
-                configs.append(
-                    triton.Config(
-                        {
-                            "BLOCK_SIZE_M": BLOCK_M,
-                            "BLOCK_SIZE_N": BLOCK_N,
-                            "BLOCK_SIZE_K": BLOCK_K,
-                            "GROUP_SIZE_M": 8,
-                            "EPILOGUE_SUBTILE": EPILOGUE_SUBTILE,
-                        },
-                        num_stages=num_stages,
-                        num_warps=4,
-                        pre_hook=_host_descriptor_pre_hook,
+                for TWO_CTAS in [False, True]:
+                    extras = {"ctas_per_cga": (2, 1, 1)} if TWO_CTAS else {}
+                    configs.append(
+                        triton.Config(
+                            {
+                                "BLOCK_SIZE_M": BLOCK_M,
+                                "BLOCK_SIZE_N": BLOCK_N,
+                                "BLOCK_SIZE_K": BLOCK_K,
+                                "GROUP_SIZE_M": 8,
+                                "EPILOGUE_SUBTILE": EPILOGUE_SUBTILE,
+                                "TWO_CTAS": TWO_CTAS,
+                            },
+                            num_stages=num_stages,
+                            num_warps=4,
+                            pre_hook=_host_descriptor_pre_hook,
+                            **extras,
+                        )
                     )
-                )
 
     return configs
 
@@ -203,6 +211,8 @@ def _prune_configs(configs, named_args, **kwargs):
     b_mode = kwargs.get("SCALE_B_MODE", named_args.get("SCALE_B_MODE", TENSORWISE))
     vec_size = kwargs.get("VEC_SIZE", named_args.get("VEC_SIZE", 0))
     is_blackwell = _is_blackwell()
+    is_tensorwise = a_mode == TENSORWISE and b_mode == TENSORWISE
+    is_rowwise = a_mode == ROWWISE and b_mode == ROWWISE
     is_mxfp8 = a_mode == MXFP8 and b_mode == MXFP8
     is_blockwise_1x128 = a_mode == BLOCKWISE_1x128 and b_mode == BLOCKWISE_1x128
     is_deepseek = a_mode == BLOCKWISE_1x128 and b_mode == BLOCKWISE_128x128
@@ -216,6 +226,19 @@ def _prune_configs(configs, named_args, **kwargs):
             continue
         if N and config.kwargs["BLOCK_SIZE_N"] > N * 2:
             continue
+        # 2-CTA (cta_group::2): a tuning option for the epilogue-scaled modes
+        # (TensorWise, RowWise) -- like CUTLASS, which uses the same 2-SM cluster
+        # for per-tensor and per-token/-channel (the per-row/col scale is applied
+        # in the epilogue by global coordinate, so the cluster split is
+        # transparent). MXFP8 / in-loop fp32 modes don't support 2-CTA.
+        # Requires Blackwell + Meta-WS + BLOCK_M >= 128.
+        if config.kwargs.get("TWO_CTAS", False):
+            if not (is_tensorwise or is_rowwise):
+                continue
+            if not (is_blackwell and _use_meta_ws()):
+                continue
+            if config.kwargs["BLOCK_SIZE_M"] < 128:
+                continue
         # MXFP8 block scaling requires BLOCK_K >= VEC_SIZE * 4
         if is_mxfp8 and vec_size > 0:
             if config.kwargs["BLOCK_SIZE_K"] < vec_size * 4:
@@ -351,6 +374,12 @@ def scaled_mm_autows_kernel(
     FLATTEN: tl.constexpr = True,
     WARP_SPECIALIZE: tl.constexpr = True,
     SEPARATE_EPILOGUE_STORE: tl.constexpr = True,
+    # 2-CTA (cta_group::2) tcgen05 MMA across a contiguous CTA pair. Set by
+    # autotune configs that also carry ctas_per_cga=(2,1,1); only the plain
+    # tl.dot path uses it (compiler splits B per CTA + inserts cross-CTA sync).
+    # _prune_configs offers it as a tuning option for TensorWise/RowWise on
+    # Blackwell + Meta-WS, BM>=128.
+    TWO_CTAS: tl.constexpr = False,
 ):
     """
     Persistent TMA matmul kernel for FP8 scaled_mm with warp specialization.
@@ -371,6 +400,9 @@ def scaled_mm_autows_kernel(
 
     start_pid = tl.program_id(axis=0)
     num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    # 2-CTA pairs tile the M axis, so round the M tile count up to even.
+    if TWO_CTAS:
+        num_pid_m = (num_pid_m + 1) // 2 * 2
     num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
     k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
     num_tiles = num_pid_m * num_pid_n
@@ -510,6 +542,7 @@ def scaled_mm_autows_kernel(
                     accumulator,
                     out_dtype=tl.float32,
                     allow_tf32=True,
+                    two_ctas=TWO_CTAS,
                 )
 
             if IS_ROWWISE:
@@ -653,9 +686,10 @@ def scaled_mm_autows(
         scale_b_arg = scale_b
 
     def grid(META):
-        num_tiles = triton.cdiv(M, META["BLOCK_SIZE_M"]) * triton.cdiv(
-            N, META["BLOCK_SIZE_N"]
-        )
+        num_pid_m = triton.cdiv(M, META["BLOCK_SIZE_M"])
+        if META.get("TWO_CTAS", False):
+            num_pid_m = triton.cdiv(num_pid_m, 2) * 2
+        num_tiles = num_pid_m * triton.cdiv(N, META["BLOCK_SIZE_N"])
         return (min(num_sms, num_tiles),)
 
     _ensure_triton_allocator(a.device)


### PR DESCRIPTION
## Summary
Adds Blackwell 2-CTA to the autows fp8 GEMM kernel as an autotune option for the epilogue-scaled modes (TensorWise, RowWise) — matching CUTLASS, which uses the same 2-SM cluster for per-tensor and per-token/-channel scaling.

A TWO_CTAS constexpr threads tl.dot(..., two_ctas=...) and rounds the M tile count to even; autotune configs carry ctas_per_cga=(2,1,1) to form the CTA pair (the Meta-WS pipeline splits B per CTA and inserts the cross-CTA sync).
_prune_configs gates 2-CTA to TensorWise/RowWise on Blackwell + Meta-WS with BLOCK_M≥128. MXFP8 and the in-loop fp32 blockwise modes (DeepSeek / symmetric-1×128) are excluded. 

Adding 2-CTA makes our Triton autoWS kernel performance on par with vllm CUTLASS kernel.

## Test Plan
### On Blackwell:
**TensorWise Accuracy:**
```
CUDA_VISIBLE_DEVICES=4 TRITON_ALWAYS_COMPILE=1 TRITON_KERNEL_DUMP=1 TRITON_DUMP_DIR=/tmp/triton_dumps TRITON_USE_META_WS=1 python run.py --op fp8_gemm --scaling-pair TensorWise,TensorWise --m 4096 --n 4096 --k 4096 --only triton_autows_fp8_gemm,torch_fp8_gemm,vllm_cutlass_fp8_gemm --metrics accuracy --simple-output --baseline torch_fp8_gemm
```
outputs
```
             x_val    triton_autows_fp8_gemm-accuracy    vllm_cutlass_fp8_gemm-accuracy
------------------  ---------------------------------  --------------------------------
(4096, 4096, 4096)                                  1                                 1
           1.0,1.0
```
**TensorWise Performance:**
```
CUDA_VISIBLE_DEVICES=6 TRITON_ALWAYS_COMPILE=1 TRITON_KERNEL_DUMP=1 TRITON_DUMP_DIR=/tmp/triton_dumps TRITON_USE_META_WS=1 python run.py --op fp8_gemm --scaling-pair TensorWise,TensorWise --m 4096 --n 4096 --k 4096 --rep 3000 --sleep 1.0 --only triton_autows_fp8_gemm,torch_fp8_gemm,vllm_cutlass_fp8_gemm --metrics tflops
```
shows
```
             x_val    torch_fp8_gemm-tflops    triton_autows_fp8_gemm-tflops    vllm_cutlass_fp8_gemm-tflops
------------------  -----------------------  -------------------------------  ------------------------------
(4096, 4096, 4096)                   2131.5                           1944.3                         1943.42
           average                   2131.5                           1944.3                         1943.42
```
**RowWise Accuracy:**
```
CUDA_VISIBLE_DEVICES=4 TRITON_ALWAYS_COMPILE=1 TRITON_KERNEL_DUMP=1 TRITON_DUMP_DIR=/tmp/triton_dumps TRITON_USE_META_WS=1 python run.py --op fp8_gemm --scaling-pair RowWise,RowWise --m 4096 --n 4096 --k 4096 --only triton_autows_fp8_gemm,torch_fp8_gemm,vllm_cutlass_fp8_gemm --metrics accuracy --simple-output --baseline torch_fp8_gemm
```
outputs
```
             x_val    triton_autows_fp8_gemm-accuracy    vllm_cutlass_fp8_gemm-accuracy
------------------  ---------------------------------  --------------------------------
(4096, 4096, 4096)                                  1                                 1
           1.0,1.0
```
**RowWise Performance:**
```
CUDA_VISIBLE_DEVICES=6 TRITON_ALWAYS_COMPILE=1 TRITON_KERNEL_DUMP=1 TRITON_DUMP_DIR=/tmp/triton_dumps TRITON_USE_META_WS=1 python run.py --op fp8_gemm --scaling-pair RowWise,RowWise --m 4096 --n 4096 --k 4096 --rep 3000 --sleep 1.0 --only triton_autows_fp8_gemm,torch_fp8_gemm,vllm_cutlass_fp8_gemm --metrics tflops
```
shows
```
             x_val    torch_fp8_gemm-tflops    triton_autows_fp8_gemm-tflops    vllm_cutlass_fp8_gemm-tflops
------------------  -----------------------  -------------------------------  ------------------------------
(4096, 4096, 4096)                  1791.06                           1944.3                         1945.18
           average                  1791.06                           1944.3                         1945.18
```
### On Hopper:
**TensorWise Accuracy:**
```
             x_val    triton_autows_fp8_gemm-accuracy    vllm_cutlass_fp8_gemm-accuracy
------------------  ---------------------------------  --------------------------------
(4096, 4096, 4096)                                  1                                 1
           1.0,1.0
```
**TensorWise performance:**
```
             x_val    torch_fp8_gemm-tflops    triton_autows_fp8_gemm-tflops    vllm_cutlass_fp8_gemm-tflops
------------------  -----------------------  -------------------------------  ------------------------------
(4096, 4096, 4096)                  1238.46                          1109.24                         1192.72
           average                  1238.46                          1109.24                         1192.72
```
**RowWise Accuracy:**
```
             x_val    triton_autows_fp8_gemm-accuracy    vllm_cutlass_fp8_gemm-accuracy
------------------  ---------------------------------  --------------------------------
(4096, 4096, 4096)                                  1                                 1
           1.0,1.0
```
**RowWise Performance:**
```
             x_val    torch_fp8_gemm-tflops    triton_autows_fp8_gemm-tflops    vllm_cutlass_fp8_gemm-tflops
------------------  -----------------------  -------------------------------  ------------------------------
(4096, 4096, 4096)                  1217.74                          1058.66                         1191.39
           average                  1217.74                          1058.66                         1191.39
```