### PR TITLE
[TPU] Pin a per-device default backend for torch.compile

### DIFF
--- a/tritonbench/utils/compile_utils.py
+++ b/tritonbench/utils/compile_utils.py
@@ -1,0 +1,79 @@
+"""Per-device default backend for ``torch.compile``.
+
+``torch_tpu`` autoloads on ``import torch`` and monkeypatches ``torch.compile``
+to default to ``backend="tpu"`` process-globally. That breaks ``torch.compile``
+on cpu/cuda tensors whenever torch_tpu is merely installed
+(google-pytorch/torch_tpu#1912), and it never sets the ``dynamic=False`` that
+the TPU backend requires.
+
+``set_compile_backend_for_device`` wraps ``torch.compile`` so that calls which
+do not pass an explicit ``backend=`` get a device-appropriate default:
+
+- ``tpu``    -> ``backend="tpu"``, ``dynamic=False`` (Inductor-only ``mode`` /
+  ``options`` kwargs are dropped, since the TPU backend rejects them)
+- otherwise  -> ``backend="inductor"`` (undo torch_tpu's global default)
+
+Calls that pass an explicit non-``None`` ``backend`` are left untouched (a
+missing backend, or an explicit ``backend=None``, takes the device default).
+This keeps the ~40 operator ``torch.compile`` call sites working per device
+without editing them.
+"""
+
+import functools
+import importlib.util
+
+import torch
+
+# The torch.compile we wrap (torch_tpu's patched one, or stock torch's),
+# captured once so repeated installs don't stack wrappers.
+_BASE_COMPILE = None
+
+
+def _torch_tpu_installed() -> bool:
+    return importlib.util.find_spec("torch_tpu") is not None
+
+
+def set_compile_backend_for_device(device: str) -> None:
+    """Install a device-appropriate default backend for ``torch.compile``.
+
+    Only intervenes where torch_tpu's global default is actually wrong:
+      - ``tpu``: force ``backend="tpu"`` (the whole point).
+      - ``cpu``/``cuda`` **and** torch_tpu installed: force ``backend="inductor"``
+        to undo torch_tpu's global override.
+    Any other device (e.g. ``mtia``, which registers its own dynamo backend) is
+    left untouched, as is the case where torch_tpu isn't installed. Idempotent.
+    """
+    if device == "tpu":
+        force_backend = "tpu"
+    elif device in ("cpu", "cuda") and _torch_tpu_installed():
+        force_backend = "inductor"
+    else:
+        return
+
+    # Idempotent: _run installs this per op, so skip if already wrapped for
+    # this device (avoids re-wrapping on every call).
+    if getattr(torch.compile, "_tb_compile_device", None) == device:
+        return
+
+    global _BASE_COMPILE
+    if _BASE_COMPILE is None:
+        _BASE_COMPILE = torch.compile
+    base = _BASE_COMPILE
+
+    @functools.wraps(base)
+    def _compile(model=None, **kwargs):
+        # ``backend`` is keyword-only in stock torch.compile (and we assume
+        # torch_tpu's patched version keeps it so), so callers can only pass it
+        # via kwargs; a missing or None backend means "use the default".
+        if kwargs.get("backend") is None:
+            kwargs["backend"] = force_backend
+            if force_backend == "tpu":
+                kwargs.setdefault("dynamic", False)
+                # The TPU backend rejects Inductor-only knobs; drop them so
+                # torch.compile baselines that request them still run on TPU.
+                kwargs.pop("mode", None)
+                kwargs.pop("options", None)
+        return base(model, **kwargs)
+
+    _compile._tb_compile_device = device  # marker for debugging/introspection
+    torch.compile = _compile

--- a/tritonbench/utils/run_utils.py
+++ b/tritonbench/utils/run_utils.py
@@ -20,6 +20,7 @@ from tritonbench.operator_loader import get_op_loader_bench_cls_by_name, is_load
 from tritonbench.operators import load_opbench_by_name
 from tritonbench.operators_collection import list_operators_by_collection
 from tritonbench.utils.ab_test import compare_ab_results, run_ab_test
+from tritonbench.utils.compile_utils import set_compile_backend_for_device
 from tritonbench.utils.env_utils import (
     is_blackwell,
     is_cuda,
@@ -535,6 +536,12 @@ def tritonbench_run(args: Optional[List[str]] = None):
 
     apply_helion_backend_override(getattr(args, "helion_backend", None))
 
+    # Install before any operator import (some operators call torch.compile at
+    # module load, e.g. gemm/partition_k) and before the multi-device probe in
+    # run_multi_device, which imports operators prior to _run. _run installs it
+    # again for the config / per-op subprocess paths (idempotent).
+    set_compile_backend_for_device(args.device)
+
     tritonparse_init(args.tritonparse)
 
     # Strip `--ai-analysis` from sys.argv when in unsupported modes (multi-device,
@@ -659,6 +666,14 @@ def _run(args: argparse.Namespace, extra_args: List[str]) -> BenchmarkOperatorRe
         # Apply before the operator module is imported so the helion.kernel wrap
         # is in effect before any Helion kernel is constructed.
         apply_helion_backend_override(getattr(args, "helion_backend", None))
+        # Pin a device-appropriate default backend for torch.compile before any
+        # operator runs. Done here (the single point every run path funnels
+        # through: normal, A/B, config, and multi-device subprocesses) rather
+        # than in tritonbench_run, whose early returns (e.g. TRITONBENCH_RUN_CONFIG)
+        # would otherwise skip it. torch_tpu globally monkeypatches
+        # torch.compile to default to backend="tpu" whenever installed, which
+        # otherwise breaks cpu/cuda torch.compile baselines.
+        set_compile_backend_for_device(args.device)
         run_timestamp = datetime.fromtimestamp(time.time()).strftime("%Y%m%d%H%M%S")
         if is_loader_op(args.op):
             Opbench = get_op_loader_bench_cls_by_name(args.op)


### PR DESCRIPTION
torch_tpu autoloads on `import torch` and globally monkeypatches `torch.compile` to default to `backend="tpu"` (google-pytorch/torch_tpu#1912). On any machine where torch_tpu is installed this breaks `torch.compile` on CPU/CUDA tensors (`RuntimeError: ... tensor is expected to be on tpu, got cpu`), and it never sets the `dynamic=False` the TPU backend requires.

`set_compile_backend_for_device` (installed in `_run`, the per-op chokepoint all run paths funnel through) wraps `torch.compile` so calls without an explicit `backend=` get a device-appropriate default: `backend="tpu", dynamic=False` on TPU (Inductor-only `mode`/`options` kwargs are dropped, since the TPU backend rejects them), `backend="inductor"` otherwise. Calls passing an explicit backend are untouched, so the ~40 operator `torch.compile` call sites work per device with no per-operator edits. It is a no-op unless targeting TPU or torch_tpu is installed.

Verified on a TPU host (no automated TPU CI yet): `gemm` `pt2_triton_matmul` and `layer_norm` `torch_compile_layer_norm` now produce a `torch.compile` column on `--device tpu`; on CPU/CUDA `torch.compile` continues to route to Inductor.