### PR TITLE
Add shared-A mode to fused RMSNorm matmul

### DIFF
--- a/tritonbench/operators/fused_rmsnorm_matmul/operator.py
+++ b/tritonbench/operators/fused_rmsnorm_matmul/operator.py
@@ -19,6 +19,11 @@ def parse_op_args(args: List[str]) -> argparse.Namespace:
     parser.add_argument("--n", type=int, default=12800)
     parser.add_argument("--k", type=int, default=1024)
     parser.add_argument("--eps", type=float, default=1.0e-6)
+    parser.add_argument(
+        "--a-rrms-source",
+        choices=("scalar", "tma"),
+        default="tma",
+    )
     return parser.parse_args(args)
 
 
@@ -46,6 +51,7 @@ class Operator(BenchmarkOperator):
         self.N = args.n
         self.K = args.k
         self.eps = args.eps
+        self.use_shared_a_rrms = args.a_rrms_source == "tma"
 
     @register_x_val(label="(M, N, K)")
     def get_x_val(self, example_inputs) -> Tuple[int, int, int]:
@@ -70,6 +76,7 @@ class Operator(BenchmarkOperator):
                 x,
                 b_weighted_t,
                 self.eps,
+                use_shared_a_rrms=self.use_shared_a_rrms,
             )
 
         return inner

--- a/tritonbench/operators/fused_rmsnorm_matmul/triton_autows.py
+++ b/tritonbench/operators/fused_rmsnorm_matmul/triton_autows.py
@@ -123,7 +123,7 @@ def _subtile_accumulator(
 
 @triton.autotune(
     configs=_get_autotune_configs(),
-    key=["M", "N", "K"],
+    key=["M", "N", "K", "USE_SHARED_A_RRMS"],
     prune_configs_by={"early_config_prune": _prune_configs},
 )
 @triton.jit
@@ -146,6 +146,7 @@ def _gemm_rmsnorm_kernel(
     DATA_PARTITION_FACTOR: tl.constexpr,
     GROUP_SIZE: tl.constexpr,
     GROUP_BY_N: tl.constexpr,
+    USE_SHARED_A_RRMS: tl.constexpr,
     NUM_SMS: tl.constexpr,
 ):
     start_pid = tl.program_id(0)
@@ -187,12 +188,15 @@ def _gemm_rmsnorm_kernel(
             rows = offs_am + tl.arange(0, BLOCK_M)
             cols_k = offs_k + tl.arange(0, BLOCK_K)
             a = a_desc.load([offs_am, offs_k])
-            a_rms = tl.load(
-                a_ptr + rows[:, None] * stride_am + cols_k[None, :] * stride_ak,
-                mask=(rows[:, None] < M) & (cols_k[None, :] < K),
-                other=0.0,
-            )
             b = b_desc.load([offs_bn, offs_k])
+            if USE_SHARED_A_RRMS:
+                a_rms = a
+            else:
+                a_rms = tl.load(
+                    a_ptr + rows[:, None] * stride_am + cols_k[None, :] * stride_ak,
+                    mask=(rows[:, None] < M) & (cols_k[None, :] < K),
+                    other=0.0,
+                )
             a_f32 = a_rms.to(tl.float32)
             row_sumsq += tl.sum(a_f32 * a_f32, axis=1)
             accumulator += tl.dot(
@@ -221,6 +225,7 @@ def triton_autows_fused_rmsnorm_gemm(
     b_weighted_t: torch.Tensor,
     eps: float,
     *,
+    use_shared_a_rrms: bool = False,
     num_sms: int = 148,
 ) -> torch.Tensor:
     m, k = x.shape
@@ -250,6 +255,7 @@ def triton_autows_fused_rmsnorm_gemm(
         x.stride(0),
         x.stride(1),
         eps,
+        USE_SHARED_A_RRMS=use_shared_a_rrms,
         NUM_SMS=num_sms,
     )
     return out


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #1152
* #1151

Add operator flag `--a-rrms-source` to choose load type for A tile feeding RRMS (default: TMA load). The shared-A TMA path provides ~5% speedup on the tested shape `(M, N, K) = (1024, 12800, 1024)`.

Differential Revision: [D109720367](https://our.internmc.facebook.com/intern/diff/D109720367)