### PR TITLE
tritonbench: fix Latency.to_str("min") returning the max

### DIFF
--- a/tritonbench/components/do_bench/run.py
+++ b/tritonbench/components/do_bench/run.py
@@ -138,7 +138,7 @@ class Latency:
         elif mode == "max":
             return str(self.max)
         elif mode == "min":
-            return str(self.max)
+            return str(self.min)
         elif mode == "mean":
             return str(statistics.mean(self.times))
         else:


### PR DESCRIPTION
Summary: `Latency.to_str(mode="min")` returned `str(self.max)` instead of `str(self.min)` -- a copy-paste bug, so the "min" latency string reported the slowest rep rather than the fastest. The `.min` property itself is correct; only the `to_str` formatter was wrong. TFLOPs and speedup are unaffected (they derive from `p50` via the `Latency` arithmetic operators), so this only corrects the `min` display / `to_float("min")` path.

Reviewed By: xuzhao9

Differential Revision: D109445444


