### PR TITLE
tritonbench: overridable `_measure_latency` seam + grouped_gemm un-throttled pooled latency

### DIFF
--- a/tritonbench/operators/grouped_gemm/operator.py
+++ b/tritonbench/operators/grouped_gemm/operator.py
@@ -1,4 +1,5 @@
 import logging
+import time
 from importlib.metadata import PackageNotFoundError, version
 from itertools import accumulate
 from typing import Any, Generator, List, Tuple
@@ -8,6 +9,7 @@ import torch
 logger = logging.getLogger(__name__)
 from torch._inductor import config as inductor_config
 from torch._inductor.utils import ensure_cute_available
+from tritonbench.components.do_bench.run import Latency
 from tritonbench.utils.env_utils import IS_BLACKWELL, is_cuda, is_fbcode
 from tritonbench.utils.path_utils import add_path, REPO_PATH
 from tritonbench.utils.triton_op import (
@@ -92,6 +94,13 @@ class Operator(BenchmarkOperator):
     DEFAULT_METRICS = ["latency", "speedup", "accuracy", "tflops"]
     FWD_ONLY = True
 
+    # Latency knobs for _measure_latency (see its docstring for the rationale).
+    # _LATENCY_COOLDOWN_S tuned on aten_grouped_mm: clock recovery saturates by
+    # ~0.5-1s, so 1.0s keeps full fidelity at a third of the 3.0s downtime.
+    _LATENCY_REPLICAS = 5
+    _LATENCY_COOLDOWN_S = 1.0
+    _LATENCY_REPCNT = 10
+
     def __init__(self, tb_args, extra_args: List[str] | None = None):
         super().__init__(tb_args, extra_args)
         self.only_fb_shapes = False
@@ -100,6 +109,23 @@ class Operator(BenchmarkOperator):
         # Only use FB shapes when --only-fb-shapes is passed
         if self.only_fb_shapes and not is_fbcode():
             raise ValueError("--only-fb-shapes requires running in fbcode")
+
+    def _measure_latency(self, fn, warmup, rep, repcnt):
+        """Pool several short, cooled-down measurements for a robust, un-throttled p50.
+
+        Prolonged run throttle performance by ~15-20% on compute-bound GEMMs,
+        while a single short measurement is noisy. Instead, alternate short bursts
+        of GEMMs with long sleeps to allow clocks to recover.
+        """
+        per_replica = repcnt if repcnt is not None else self._LATENCY_REPCNT
+        pooled: List[float] = []
+        _ = super()._measure_latency(fn, warmup, rep, per_replica)  # Warmup
+        for i in range(self._LATENCY_REPLICAS):
+            time.sleep(self._LATENCY_COOLDOWN_S)
+            lat = super()._measure_latency(fn, warmup, rep, per_replica)
+            if lat is not None:
+                pooled.extend(lat.times)
+        return Latency(times=pooled) if pooled else None
 
     @staticmethod
     def parse_op_args(extra_args: List[str]):

--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -1944,6 +1944,33 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
                     self.baseline_fn = self.baseline_fns[bl]
                     break
 
+    def _measure_latency(self, fn, warmup, rep, repcnt):
+        """Allow operators to add custom measurement logic.
+
+        Some operators need special handling to properly measure performance. For
+        example, heavy compute operators may throttle at a hardware level, and it
+        it more representative to alternate with low compute ops to better represent
+        model steady state.
+        """
+        return do_bench_wrapper(
+            fn,
+            warmup,
+            rep,
+            repcnt,
+            grad_to_none=self.get_grad_to_none(self.example_inputs),
+            device=self.device,
+            use_cuda_graphs=self.use_cuda_graphs,
+            bypass_fail=self.tb_args.bypass_fail,
+            latency_measure_mode=self.tb_args.latency_measure_mode,
+            skip_cache_clearing=self.tb_args.skip_cache_clearing,
+            entropy_criterion=getattr(self.tb_args, "entropy_criterion", False),
+            entropy_max_angle=getattr(self.tb_args, "entropy_max_angle", 0.048),
+            entropy_min_r2=getattr(self.tb_args, "entropy_min_r2", 0.36),
+            entropy_window_size=getattr(self.tb_args, "entropy_window_size", 299),
+            entropy_max_samples=getattr(self.tb_args, "entropy_max_samples", 10000),
+            cudagraph_config=self.cudagraph_config,
+        )
+
     def _do_bench(
         self,
         input_id: int,
@@ -1985,28 +2012,7 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
                     self.cudagraph_config.num_inputs_per_iter = (
                         self.get_num_inputs_per_iter(self.example_inputs)
                     )
-                metrics.latency = do_bench_wrapper(
-                    fn,
-                    warmup,
-                    rep,
-                    repcnt,
-                    grad_to_none=self.get_grad_to_none(self.example_inputs),
-                    device=self.device,
-                    use_cuda_graphs=self.use_cuda_graphs,
-                    bypass_fail=self.tb_args.bypass_fail,
-                    latency_measure_mode=self.tb_args.latency_measure_mode,
-                    skip_cache_clearing=self.tb_args.skip_cache_clearing,
-                    entropy_criterion=getattr(self.tb_args, "entropy_criterion", False),
-                    entropy_max_angle=getattr(self.tb_args, "entropy_max_angle", 0.048),
-                    entropy_min_r2=getattr(self.tb_args, "entropy_min_r2", 0.36),
-                    entropy_window_size=getattr(
-                        self.tb_args, "entropy_window_size", 299
-                    ),
-                    entropy_max_samples=getattr(
-                        self.tb_args, "entropy_max_samples", 10000
-                    ),
-                    cudagraph_config=self.cudagraph_config,
-                )
+                metrics.latency = self._measure_latency(fn, warmup, rep, repcnt)
                 if metrics.latency is not None:
                     metrics.latency.scale(self.get_latency_scale(self.example_inputs))
             if {


### PR DESCRIPTION
Summary:
This diff is motivated by the observation that Mi350 is heavily power throttled, and as a result steady state measurements do not reflect real model perf. Here I'm proposing a mechanism whereby operators can take control direct control of the timing loop to override behavior. (I wasn't able to come up with a clean way to integrate fine grained cooldown into the existing do_bench variants.) That said, I'm not set on the design and am open if you think there is a better way to go about this.

Extracts the inline `do_bench_wrapper` call in `_do_bench` into an overridable `BenchmarkOperator._measure_latency(fn, warmup, rep, repcnt)` seam (default body unchanged), and uses it in the grouped_gemm operator to get a robust un-throttled p50. A single long do_bench heats the GPU and droops clocks ~15-20% on these compute-bound GEMMs; grouped_gemm overrides `_measure_latency` to take `_LATENCY_REPLICAS` short measurements (per-replica rep count `_LATENCY_REPCNT`), sleeping `_LATENCY_COOLDOWN_S` between them so clocks recover, and pools every rep time into one `Latency` so the downstream p50/tflops path is unchanged. An explicit `--repcnt` overrides the per-replica count.

Reviewed By: xuzhao9

Differential Revision: D109464260


