### PR TITLE
Fix scaled_mm eval coverage (#1160)

### DIFF
--- a/benchmarks/compare_benchmarks/run.py
+++ b/benchmarks/compare_benchmarks/run.py
@@ -79,8 +79,14 @@ def build_op_args(
     config: BenchmarkConfig,
     benchmark_name: str,
     input_loader: Optional[str] = None,
+    scaling_pair: Optional[str] = None,
 ) -> List[str]:
-    """Build command-line arguments for a single operator benchmark."""
+    """Build command-line arguments for a single operator benchmark.
+
+    ``scaling_pair`` is the per-shape-set recipe derived from the shape source
+    (e.g. ``RowWise,RowWise``). An explicit ``--scaling-pair`` flag
+    (``config.scaling_pair``) overrides it.
+    """
     tritonbench_op = OP_TO_TRITONBENCH_OP.get(op, op)
     args = [
         "--op",
@@ -95,6 +101,10 @@ def build_op_args(
         "--input-loader",
         input_loader,
     ]
+
+    effective_scaling_pair = getattr(config, "scaling_pair", None) or scaling_pair
+    if op == "scaled_mm" and effective_scaling_pair:
+        args.extend(["--scaling-pair", effective_scaling_pair])
 
     if config.custom_bench == "diode" and "diode" in benchmark_name:
         if config.diode_model_config is not None:
@@ -113,13 +123,14 @@ def run_benchmark_with_logs(
     output_dir: Path,
     workload: str,
     input_loader: str,
+    scaling_pair: Optional[str] = None,
 ) -> Optional[Path]:
     """
     Run a benchmark in a subprocess and capture autotune logs for parsing.
     Uses run_in_task to isolate each operator in its own subprocess.
     """
     log_file = output_dir / f"{op}_{benchmark_name}_{workload}.log"
-    op_args = build_op_args(op, config, benchmark_name, input_loader)
+    op_args = build_op_args(op, config, benchmark_name, input_loader, scaling_pair)
 
     print(f"[Compare Benchmarks] Running {benchmark_name} on {op}")
     print(f"[Compare Benchmarks] Args: {' '.join(str(arg) for arg in op_args)}")
@@ -222,11 +233,13 @@ def _resolve_input_loaders(
     op: str,
     gpu: str,
     output_dir: Path,
-) -> list[tuple[str, str]]:
+) -> list[tuple[str, str, Optional[str]]]:
     """Resolve input loader paths for a given op.
 
-    Returns a list of (label, path) tuples. The label is used for the
-    workload column in Scuba logging and log file naming.
+    Returns a list of (label, path, scaling_pair) tuples. The label is used for
+    the workload column in Scuba logging and log file naming. scaling_pair is
+    the fp8 recipe to evaluate the shapes under (scaled_mm Hive shapes only;
+    None otherwise).
 
     Priority:
       1. --input-loader <file>  -> single file
@@ -238,14 +251,14 @@ def _resolve_input_loaders(
 
         if loader_path.is_file():
             print(f"[Compare Benchmarks] Shape source: file '{config.input_loader}'")
-            return [(loader_path.stem, config.input_loader)]
+            return [(loader_path.stem, config.input_loader, None)]
 
         if loader_path.is_dir():
             results = []
             for json_file in sorted(loader_path.glob("*.json")):
                 if config.input_filter and config.input_filter not in json_file.name:
                     continue
-                results.append((json_file.stem, str(json_file)))
+                results.append((json_file.stem, str(json_file), None))
             if results:
                 print(
                     f"[Compare Benchmarks] Shape source: directory '{config.input_loader}' "
@@ -277,13 +290,21 @@ def _resolve_input_loaders(
         get_shapes_from_hive,
     )
 
-    hive_path = get_shapes_from_hive(
+    hive_results = get_shapes_from_hive(
         gpu, op, output_dir, config.hive_job_filter, config.hive_max_shapes
     )
-    if not hive_path:
+    if not hive_results:
         return []
-    label = config.hive_job_filter or "inductor_mm_shapes"
-    return [(label, hive_path)]
+    base_label = config.hive_job_filter or "inductor_mm_shapes"
+    loaders: list[tuple[str, str, Optional[str]]] = []
+    for scaling_pair, path in hive_results:
+        label = (
+            f"{base_label}_{scaling_pair.replace(',', '_')}"
+            if scaling_pair
+            else base_label
+        )
+        loaders.append((label, path, scaling_pair))
+    return loaders
 
 
 def run_benchmarks(config: BenchmarkConfig) -> None:
@@ -294,6 +315,7 @@ def run_benchmarks(config: BenchmarkConfig) -> None:
     print(f"[Compare Benchmarks] Ops: {config.ops}")
 
     all_dfs: List[pd.DataFrame] = []
+    op_row_counts: dict[str, int] = {op: 0 for op in config.ops}
 
     with tempfile.TemporaryDirectory() as tmpdir:
         output_dir = Path(tmpdir)
@@ -312,17 +334,18 @@ def run_benchmarks(config: BenchmarkConfig) -> None:
                 )
                 continue
 
-            for label, input_loader in input_loaders:
+            for label, input_loader, scaling_pair in input_loaders:
                 print(
                     f"[Compare Benchmarks] Running {op} ({label}): "
                     f"LHS={lhs_benchmark}, RHS={rhs_benchmark}"
+                    + (f", scaling_pair={scaling_pair}" if scaling_pair else "")
                 )
 
                 lhs_log = run_benchmark_with_logs(
-                    op, lhs_benchmark, config, output_dir, label, input_loader
+                    op, lhs_benchmark, config, output_dir, label, input_loader, scaling_pair
                 )
                 rhs_log = run_benchmark_with_logs(
-                    op, rhs_benchmark, config, output_dir, label, input_loader
+                    op, rhs_benchmark, config, output_dir, label, input_loader, scaling_pair
                 )
 
                 if not lhs_log or not rhs_log:
@@ -345,6 +368,15 @@ def run_benchmarks(config: BenchmarkConfig) -> None:
                         comparison_df["lhs_benchmark_name"] = lhs_benchmark
                         comparison_df["rhs_benchmark_name"] = rhs_benchmark
                         all_dfs.append(comparison_df)
+                        op_row_counts[op] += len(comparison_df)
+                    else:
+                        print(
+                            f"[Compare Benchmarks] WARNING: op={op} ({label}) "
+                            f"produced 0 comparison rows "
+                            f"(LHS={lhs_benchmark}, RHS={rhs_benchmark}). "
+                            "Benchmarks ran but the autotune parser found no "
+                            "matching results to compare."
+                        )
 
     combined_df = pd.concat(all_dfs, ignore_index=True) if all_dfs else pd.DataFrame()
 
@@ -361,6 +393,18 @@ def run_benchmarks(config: BenchmarkConfig) -> None:
 
         if config.parse_autotune_logs and config.log_scuba and is_fbcode():
             log_scuba(combined_df, config)
+
+    print(f"[Compare Benchmarks] Per-op comparison row counts for gpu={gpu}:")
+    for op in config.ops:
+        print(f"[Compare Benchmarks]   {op}: {op_row_counts.get(op, 0)} rows")
+    zero_ops = [op for op in config.ops if op_row_counts.get(op, 0) == 0]
+    if zero_ops:
+        print(
+            "[Compare Benchmarks] WARNING: the following ops produced 0 rows "
+            f"on gpu={gpu} (nothing logged): {', '.join(zero_ops)}. This "
+            "usually means a missing/disabled baseline, an unsupported op/GPU "
+            "combination, or an autotune-parser mismatch."
+        )
 
 
 def parse_args(args: List[str] = None) -> BenchmarkConfig:
@@ -438,6 +482,14 @@ def parse_args(args: List[str] = None) -> BenchmarkConfig:
         default=None,
         help=f"Custom experiment name to log to Scuba. Default: gpu_timestamp (printed at the end of the run)",
     )
+    parser.add_argument(
+        "--scaling-pair",
+        type=str,
+        default=None,
+        help="fp8/scaled_mm scaling recipe pair forwarded to the fp8_gemm "
+        "operator, e.g. 'RowWise,RowWise'. Only applies to --ops scaled_mm. "
+        "Default: None (operator default TensorWise,TensorWise).",
+    )
 
     if is_fbcode():
         parser.add_argument(
@@ -486,6 +538,7 @@ def parse_args(args: List[str] = None) -> BenchmarkConfig:
         "parse_autotune_logs": args.parse_autotune_logs,
         "log_scuba": args.log_scuba,
         "scuba_eval_id": args.scuba_eval_id,
+        "scaling_pair": args.scaling_pair,
     }
 
     if is_fbcode():

--- a/benchmarks/compare_benchmarks/utils.py
+++ b/benchmarks/compare_benchmarks/utils.py
@@ -45,6 +45,7 @@ class BenchmarkConfig:
     parse_autotune_logs: bool = False
     log_scuba: bool = False
     scuba_eval_id: str = None
+    scaling_pair: Optional[str] = None
 
 
 @dataclass
@@ -197,19 +198,13 @@ def log_benchmark(
             batch = safe_int(row.get("B"), default=None)
             op = safe_str(row.get("Operation"))
 
-            scale_a_row = safe_int(row.get("scale_a_row_dim"), default=None)
-            scale_a_col = safe_int(row.get("scale_a_col_dim"), default=None)
-            scale_b_row = safe_int(row.get("scale_b_row_dim"), default=None)
-            scale_b_col = safe_int(row.get("scale_b_col_dim"), default=None)
+            scale_a_row = safe_int(row.get("scale_a_row_dim"), default=1)
+            scale_a_col = safe_int(row.get("scale_a_col_dim"), default=1)
+            scale_b_row = safe_int(row.get("scale_b_row_dim"), default=1)
+            scale_b_col = safe_int(row.get("scale_b_col_dim"), default=1)
             scale_a_recipe = None
             scale_b_recipe = None
-            if (
-                op == "scaled_mm"
-                and scale_a_row is not None
-                and scale_a_col is not None
-                and scale_b_row is not None
-                and scale_b_col is not None
-            ):
+            if op == "scaled_mm":
                 from torch._inductor.fb.shape_logging import _scale_recipe
 
                 dtype_str = safe_str(row.get("Dtype"))
@@ -221,19 +216,13 @@ def log_benchmark(
                 scale_dtype = torch.float32
                 scale_a_recipe = (
                     _scale_recipe(
-                        (m_dim, k_dim),
-                        mat_dtype,
-                        (scale_a_row, scale_a_col),
-                        scale_dtype,
+                        (m_dim, k_dim), mat_dtype, (scale_a_row, scale_a_col), scale_dtype
                     )
                     or None
                 )
                 scale_b_recipe = (
                     _scale_recipe(
-                        (k_dim, n_dim),
-                        mat_dtype,
-                        (scale_b_row, scale_b_col),
-                        scale_dtype,
+                        (k_dim, n_dim), mat_dtype, (scale_b_row, scale_b_col), scale_dtype
                     )
                     or None
                 )

--- a/tritonbench/operators/fp8_gemm/fp8_gemm.py
+++ b/tritonbench/operators/fp8_gemm/fp8_gemm.py
@@ -28,6 +28,25 @@ from tritonbench.utils.triton_utils import has_experimental_descriptor, has_tlx
 
 from .tutorial import matmul as tutorial_matmul
 
+# Warp-specialized FP8 scaled_mm TLX kernel (BlockWise + RowWise), imported straight
+# from the triton source tree (the source of truth) rather than a fork in this operator.
+# The HAS_TLX_SCALED_MM guard is still required: has_tlx() only says TLX exists, not that
+# this specific kernel imports cleanly (missing file / syntax error / dep) -- without it a
+# broken kernel would crash benchmark registration instead of just disabling the backend.
+if has_tlx():
+    try:
+        from triton.language.extra.tlx.tutorials.blackwell_scaled_mm_ws import (
+            blackwell_scaled_mm_ws as tlx_scaled_mm,
+        )
+
+        HAS_TLX_SCALED_MM = True
+    except Exception:
+        tlx_scaled_mm = None
+        HAS_TLX_SCALED_MM = False
+else:
+    tlx_scaled_mm = None
+    HAS_TLX_SCALED_MM = False
+
 with try_import("HAS_VLLM_CUTLASS"):
     from vllm import _custom_ops as vllm_ops
 
@@ -460,6 +479,45 @@ class Operator(BenchmarkOperator):
         sb = scale_b.squeeze()
         return lambda: scaled_mm_autows(
             a, b, sa, sb, a_mode, b_mode, out_dtype=self._get_dtype()
+        )
+
+    # Hand-written warp-specialized TLX scaled_mm (CUTLASS SM100 mirror). Supports the
+    # asymmetric BlockWise (BlockWise1x128 activations + BlockWise128x128 weights,
+    # DeepSeek) recipe and RowWise. Inputs pass straight through -- scale layouts are
+    # exactly what get_scale() produces (blockwise: scale_a M-major, scale_b
+    # [N/128,K/128] row-major; rowwise: scale_a [M,1], scale_b [1,N]).
+    @register_benchmark(enabled=is_cuda() and has_tlx() and HAS_TLX_SCALED_MM)
+    def tlx_scaled_mm_fp8_gemm(self, a, b, scale_a, scale_b):
+        ra, rb = self.scaling_recipe_a, self.scaling_recipe_b
+        if ra == ScalingType.BlockWise1x128 and rb == ScalingType.BlockWise128x128:
+            return lambda: tlx_scaled_mm(
+                a, b, scale_a, scale_b, out_dtype=self._get_dtype()
+            )
+        # RowWise: K-independent per-row/per-col scales -> rowwise mode (accumulate all K
+        # in one accumulator, single scaled epilogue). Kernel reshapes scales to [M]/[N].
+        if ra == ScalingType.RowWise and rb == ScalingType.RowWise:
+            return lambda: tlx_scaled_mm(
+                a,
+                b,
+                scale_a,
+                scale_b,
+                out_dtype=self._get_dtype(),
+                scale_mode="rowwise",
+            )
+        # TensorWise: scalar scales -> tensorwise mode (same K-independent mainloop, single
+        # scalar-scaled epilogue). Kernel reshapes scale_a/scale_b to 1-element tensors.
+        if ra == ScalingType.TensorWise and rb == ScalingType.TensorWise:
+            return lambda: tlx_scaled_mm(
+                a,
+                b,
+                scale_a,
+                scale_b,
+                out_dtype=self._get_dtype(),
+                scale_mode="tensorwise",
+            )
+        raise NotImplementedError(
+            "tlx_scaled_mm supports --scaling-pair BlockWise1x128,BlockWise128x128, "
+            f"RowWise,RowWise, or TensorWise,TensorWise; got {ra},{rb}"
         )
 
     @register_benchmark(enabled=HAS_VLLM_CUTLASS)

--- a/tritonbench/operators/fp8_gemm/fp8_gemm.py
+++ b/tritonbench/operators/fp8_gemm/fp8_gemm.py
@@ -16,7 +16,7 @@ from tritonbench.operators.fp8_gemm.scaled_mm_autows import (
     scaled_mm_autows,
     TENSORWISE as AUTOWS_TENSORWISE,
 )
-from tritonbench.utils.env_utils import IS_BLACKWELL, is_cuda, is_fbcode
+from tritonbench.utils.env_utils import has_meta_ws, IS_BLACKWELL, is_cuda, is_fbcode
 from tritonbench.utils.python_utils import try_import
 from tritonbench.utils.triton_op import (
     BenchmarkOperator,
@@ -416,8 +416,7 @@ class Operator(BenchmarkOperator):
             return lambda: compiled(a, b)
 
     # This impl is CUDA-specific
-    # AMD error: TypeError: range.__init__() got an unexpected keyword argument 'separate_epilogue_store'
-    @register_benchmark(enabled=is_cuda() and has_tlx())
+    @register_benchmark(enabled=is_cuda() and has_tlx() and has_meta_ws())
     def triton_autows_fp8_gemm(self, a, b, scale_a, scale_b):
         # Per-operand recipe -> autows kernel mode. The kernel dispatches on the
         # (scale_a_mode, scale_b_mode) pair, so A and B are passed independently.

--- a/tritonbench/operators/fp8_gemm/fp8_gemm.py
+++ b/tritonbench/operators/fp8_gemm/fp8_gemm.py
@@ -166,6 +166,12 @@ def get_scale(
     def _get_scale_per_block(
         x: torch.Tensor, block_outer: int, block_inner: int
     ) -> (torch.Tensor, torch.Tensor):
+        M, K = x.shape
+        pad_outer = (-M) % block_outer
+        pad_inner = (-K) % block_inner
+        if pad_outer or pad_inner:
+            x = torch.nn.functional.pad(x, (0, pad_inner, 0, pad_outer))
+
         x = x.unflatten(1, (-1, block_inner)).unflatten(0, (-1, block_outer))
         amax = x.abs().amax(dim=[1, 3], keepdim=True).float()
         quant_scale = torch.finfo(torch.float8_e4m3fn).max / amax
@@ -174,6 +180,7 @@ def get_scale(
         )  # scale input UP to the dynamic range of float8_e4m3fn
         # Return the reciprocal (dequant) scale for _scaled_mm to recover real units.
         scale = quant_scale.reciprocal().flatten(2, 3).flatten(0, 1)
+        x = x[:M, :K]  # drop padding from the fp8 data; scale stays ceil_div-sized
 
         if block_outer == 1 and block_inner == 128:
             scale = (

--- a/tritonbench/utils/env_utils.py
+++ b/tritonbench/utils/env_utils.py
@@ -59,6 +59,13 @@ def is_meta_triton() -> bool:
     return spec is not None
 
 
+def has_meta_ws():
+    """
+    Returns whether Meta WS is enabled.
+    """
+    return os.environ.get("TRITON_USE_META_WS", "0") == "1"
+
+
 def is_triton_main():
     return not is_fbcode() and not is_meta_triton()
 


### PR DESCRIPTION
Summary:

Fixes `scaled_mm` `compare_benchmarks` evals on Nvidia hardware:

- `diode/config.py`: allowlist `scaled_mm` (`aten::*`, `triton::*`)
- `compare_benchmarks/run.py`, `utils.py`: `--scaling-pair` passthrough
- `compare_benchmarks/fb/hive_shapes.py`, `run.py`: partition scaled_mm shapes by their real `(scale_x_recipe, scale_w_recipe)` from `inductor_mm_shapes` and thread the matching `--scaling-pair` through the eval, so shapes run under their real recipe instead of always tensor-wise
- `fp8_gemm.py`: pad block-scale construction so blockwise handles non-128-aligned shapes (Inductor/eager already use ceil_div; only the benchmark builder required exact divisibility)

Reviewed By: xuzhao9

Differential Revision: D109644490


