### PR TITLE
[TPU] Make peak-memory and roofline metrics TPU-safe

### DIFF
--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -2036,6 +2036,7 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
                     grad_to_none=self.get_grad_to_none(self.example_inputs),
                     required_metrics=self.required_metrics,
                     use_cuda_graphs=self.use_cuda_graphs,
+                    device_type=self.device,
                 )
             if (
                 "mem_footprint_compression_ratio" in self.required_metrics
@@ -2337,17 +2338,24 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
             torch.cuda.synchronize()
 
     def do_bench_mem(self, fn, n_repeat=2, grad_to_none=None, device_type="cuda"):
-        di = torch._dynamo.device_interface.get_interface_for_device(device_type)
+        if device_type == "tpu":
+            # torch's TpuInterface.synchronize() is an unimplemented stub, so the
+            # generic get_interface_for_device path fails on TPU; sync via the
+            # accelerator API instead. See google-pytorch/torch_tpu#2130.
+            sync = torch.accelerator.synchronize
+        else:
+            di = torch._dynamo.device_interface.get_interface_for_device(device_type)
+            sync = di.synchronize
         # warmup
         fn()
-        di.synchronize()
+        sync()
         # benchmark
         for _ in range(n_repeat):
             if grad_to_none is not None:
                 for x in grad_to_none:
                     x.grad = None
             fn()
-        di.synchronize()
+        sync()
 
     def get_peak_mem(
         self,
@@ -2660,8 +2668,12 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
         latency_without_compile = metrics.walltime
         return latency_with_compile - latency_without_compile, None
 
-    def hw_roofline(self) -> float:
+    def hw_roofline(self) -> Optional[float]:
         """Hardware roofline in tflops."""
+        if self.device == "tpu":
+            # No TPU entries in HW_ROOFLINE_SPECS yet (and torch.cuda device
+            # lookup would fail); report no roofline rather than crash.
+            return None
         from tritonbench.utils.gpu_utils import HW_ROOFLINE_SPECS
 
         rooflines = HW_ROOFLINE_SPECS[self.is_compute_bound]


### PR DESCRIPTION
`--device tpu` crashed whenever a peak-memory or roofline metric was requested, because the measurement layer assumes CUDA. This makes those paths device-aware:

- `get_peak_mem` is now called with `device_type=self.device` (it previously passed nothing, defaulting to `"cuda"`). torch_tpu exposes no device memory stats, so `gpu_peak_mem` is reported as `None` on TPU instead of hitting `torch.cuda.*` / a CUDA dynamo interface. **Note:** this also makes `mtia` honor its actual device — `gpu_peak_mem` is now `None` there instead of the old cuda-defaulted value (reporting cuda memory on a non-cuda device was a latent bug). `cpu` is unaffected.
- `do_bench_mem` syncs via `torch.accelerator.synchronize()` on TPU (see note below).
- `hw_roofline` returns `None` on TPU (no TPU entries in `HW_ROOFLINE_SPECS`, and `torch.cuda.get_device_name()` would crash).

`tflops` already works on TPU (its flop-counter path skips the CUDA sync), so it's unchanged.

### Why `torch.accelerator.synchronize()` instead of the dynamo device interface

The other device branches use `torch._dynamo.device_interface.get_interface_for_device(device_type).synchronize()`. That path fails on TPU: `get_interface_for_device("tpu")` *succeeds* and returns torch's built-in `TpuInterface`, but that interface is a stub — `.synchronize()` (and `.device_count()`) raise `NotImplementedError`, and torch_tpu never wires them to its PrivateUse1 device module (verified on TPU with torch `2.13.0.dev20260515`). `torch.accelerator.synchronize()` routes to torch_tpu's device module and is validated to block on TPU, so it's used directly. If the `TpuInterface` stub is implemented upstream, this branch can fold back into the generic path.
