### PR TITLE
Fix test_gpu skip-file load under reactor-ci standalone import

### DIFF
--- a/test/test_gpu/main.py
+++ b/test/test_gpu/main.py
@@ -34,7 +34,17 @@ elif is_fbcode():
     import importlib
 
     fbcode_skip_file_path = "fb/skip_tests.yaml"
-    SKIP_FILE = importlib.resources.files(__package__).joinpath(fbcode_skip_file_path)
+    # The reactor-ci runner imports this file standalone via
+    # spec_from_file_location(), which leaves __package__ == "" and makes
+    # importlib.resources.files("") raise "Empty module name". Fall back to a
+    # __file__-relative path in that case (the file is on disk in the staged
+    # test rootdir alongside main.py).
+    if __package__:
+        SKIP_FILE = importlib.resources.files(__package__).joinpath(
+            fbcode_skip_file_path
+        )
+    else:
+        SKIP_FILE = os.path.join(os.path.dirname(__file__), fbcode_skip_file_path)
 else:
     SKIP_FILE = os.path.abspath(
         os.path.join(os.path.dirname(__file__), "skip_tests.yaml")


### PR DESCRIPTION
Summary:
`test_gpu/main.py` resolved its fbcode skip list with `importlib.resources.files(__package__)`. The reactor-ci runner imports test files standalone via `spec_from_file_location()` (see `reactor_ci/test_runner.py:_load_module_from_file`), which leaves `__package__ == ""`, so `importlib.resources.files("")` raised `ValueError: Empty module name` and the whole `test_gpu_triton_beta` target crashed at import on the downstream H100 reactor-ci workload.

Guard for the empty-`__package__` case and fall back to a `__file__`-relative path (`fb/skip_tests.yaml` is on disk next to `main.py`). Normal packaged imports are unchanged.

Reviewed By: dshi7

Differential Revision: D109055059


