### PR TITLE
[TPU] Make device-hardcoded operators/kernels honor --device

### DIFF
--- a/tritonbench/kernels/triton_fused_attention.py
+++ b/tritonbench/kernels/triton_fused_attention.py
@@ -38,7 +38,12 @@ except ImportError:
 
 
 def is_cuda():
-    return triton.runtime.driver.active.get_current_target().backend == "cuda"
+    try:
+        return triton.runtime.driver.active.get_current_target().backend == "cuda"
+    except (RuntimeError, AttributeError):
+        # No active Triton driver (e.g. on TPU, where these kernels never run) ->
+        # not CUDA. Avoids a hard crash at import time.
+        return False
 
 
 def is_hip_async_copy_enabled():

--- a/tritonbench/operators/low_mem_dropout/operator.py
+++ b/tritonbench/operators/low_mem_dropout/operator.py
@@ -90,4 +90,4 @@ class Operator(BenchmarkOperator):
     def get_input_iter(self) -> Generator:
         p = 0.25
         for size in self.get_x_vals():
-            yield p, torch.randn(size=(size,)).cuda()
+            yield p, torch.randn(size=(size,), device=self.device)

--- a/tritonbench/operators/welford/operator.py
+++ b/tritonbench/operators/welford/operator.py
@@ -12,6 +12,7 @@ from tritonbench.utils.triton_op import (
 from .triton_welford import (
     fused_native_layer_norm as triton_welford_kernel,
     fused_native_layer_norm_no_welford as triton_no_welford_kernel,
+    HAS_CUDA_LAUNCH_HELPERS,
 )
 
 
@@ -39,11 +40,11 @@ class Operator(BenchmarkOperator):
         super().__init__(tb_args, extra_args)
         self.shapes = BUILDIN_SHAPES
 
-    @register_benchmark()
+    @register_benchmark(enabled=HAS_CUDA_LAUNCH_HELPERS)
     def triton_welford(self, p1, p2, p3) -> Callable:
         return lambda: triton_welford_kernel(p1, p2, p3)
 
-    @register_benchmark()
+    @register_benchmark(enabled=HAS_CUDA_LAUNCH_HELPERS)
     def test_no_welford(self, p1, p2, p3) -> Callable:
         return lambda: triton_no_welford_kernel(p1, p2, p3)
 
@@ -124,9 +125,9 @@ class Operator(BenchmarkOperator):
     def get_input_iter(self) -> Generator:
         for shape in self.shapes:
             s, d = shape
-            p1 = rand_strided((d,), (1,), device="cuda:0", dtype=torch.bfloat16)
-            p2 = rand_strided((d,), (1,), device="cuda:0", dtype=torch.bfloat16)
-            p3 = rand_strided((s, d), (d, 1), device="cuda:0", dtype=torch.bfloat16)
+            p1 = rand_strided((d,), (1,), device=self.device, dtype=torch.bfloat16)
+            p2 = rand_strided((d,), (1,), device=self.device, dtype=torch.bfloat16)
+            p3 = rand_strided((s, d), (d, 1), device=self.device, dtype=torch.bfloat16)
             yield p1, p2, p3
 
     def accuracy(self, fn: Callable, baseline_fn: Callable) -> bool:

--- a/tritonbench/operators/welford/triton_welford.py
+++ b/tritonbench/operators/welford/triton_welford.py
@@ -6,12 +6,25 @@ Generated from Inductor for forward layernorm with and without welford
 import torch
 import triton
 import triton.language as tl
-from torch._C import _cuda_getCurrentRawStream as get_raw_stream
+
+try:
+    from torch._C import _cuda_getCurrentRawStream as get_raw_stream
+except ImportError:
+    # CUDA-only symbol, absent on cpu/TPU torch builds. Only used by the Triton
+    # kernel-launch path below, which never runs on TPU.
+    get_raw_stream = None
 from torch._inductor.runtime import triton_helpers, triton_heuristics
 from torch._inductor.runtime.triton_helpers import libdevice
 
-empty_strided_cuda = torch._C._dynamo.guards._empty_strided_cuda
+try:
+    empty_strided_cuda = torch._C._dynamo.guards._empty_strided_cuda
+except AttributeError:
+    empty_strided_cuda = None
 reinterpret_tensor = torch.ops.inductor._reinterpret_tensor
+
+# These Triton kernel-launch paths require the CUDA-only helpers above; when
+# they're absent (cpu/TPU torch builds) the triton_welford backends can't run.
+HAS_CUDA_LAUNCH_HELPERS = get_raw_stream is not None and empty_strided_cuda is not None
 
 
 @triton.autotune(


### PR DESCRIPTION
Four operators/kernels assumed CUDA and crashed at import or input generation under `--device tpu` (running Helion's benchmark bridge on TPU), which blocked their eager/Helion baselines from loading at all:

- `kernels/triton_fused_attention.py`: `is_cuda()` queried Triton's active-driver at import and raised on TPU (no active driver) — now returns `False` when there's no driver, fixing flash_attention + fp8_attention import.
- `operators/welford/`: the generated Triton file imported CUDA-only inductor symbols (`_cuda_getCurrentRawStream`, `_empty_strided_cuda`) absent on cpu/TPU torch builds; guarded them (used only by the Triton launch path) and gated the two Triton welford backends off when they're unavailable.
- input generators hardcoded the device (`welford` → `device="cuda:0"`, `low_mem_dropout` → `.cuda()`) — now use `self.device`.

Triton-only backends remain selected via `--only` as before (the established TPU strategy); this change only makes the operators loadable and their eager/Helion baselines runnable on TPU. On CUDA, behavior is unchanged (`self.device` is `cuda`; the guarded imports succeed).

Validated on a TPU v7 pod via the Helion bridge: flash_attention, fp8_attention, low_mem_dropout run; welford imports and reaches Pallas autotuning.
