### PR TITLE
Bump quack SHA to 9ebd44a for cutlass-dsl 4.6.0 compatibility

### DIFF
--- a/tools/quack/install.py
+++ b/tools/quack/install.py
@@ -10,7 +10,7 @@ REPO_PATH = Path(os.path.abspath(__file__)).parent.parent.parent
 CURRENT_DIR = Path(os.path.abspath(__file__)).parent
 
 QUACK_REPO = "https://github.com/Dao-AILab/quack.git"
-QUACK_SHA = "5e4d024e839bf851b820887c4c5b9656f206fa08"
+QUACK_SHA = "9ebd44a1bc527984cef47efe48c03388553c7ae4"
 
 QUACK_INSTALL_PATH = REPO_PATH.joinpath(".install")
 BUILD_CONSTRAINTS_FILE = REPO_PATH.joinpath("build", "constraints.txt")


### PR DESCRIPTION
The pinned quack commit (5e4d024e) referenced cute.core.ThrMma and declared nvidia-cutlass-dsl>=4.5.1 with no upper bound. When nvidia-cutlass-dsl 4.6.0 was released (2026-07-02), it removed cute.core.ThrMma, breaking CI with:

  AttributeError: module 'cutlass.cute.core' has no attribute 'ThrMma'

Bump to quack 9ebd44a, which uses cute.ThrMma and pins nvidia-cutlass-dsl==4.6.0.

Docker build:

https://github.com/meta-pytorch/tritonbench/actions/runs/28810592301