### PR TITLE
fp32_to_mx4: reproduce production MX4 comm shapes and group sizes (#1170)

### DIFF
--- a/tritonbench/operators/fp32_to_mx4/operator.py
+++ b/tritonbench/operators/fp32_to_mx4/operator.py
@@ -31,6 +31,14 @@ class Operator(BenchmarkOperator):
         for sz in [24048, 1024 * 1024, 64 * 1024 * 1024, 64 * 1024 * 1024 + 16]:
             _input = torch.randn((sz,), device=self.device, dtype=torch.float32)
             yield _input, 32, 2, 1, RoundingMode.even, False
+        # A few large MX4 comm (quantize_comm / All2All_Pooled) production cases that run >10ms
+        for numel, group_size in [
+            (1_409_400_832, 16),  # backward encode, trace 12.09ms
+            (1_409_286_144, 8),  # forward encode, trace 24.16ms
+            (2_421_580_288, 8),  # forward encode, trace 45.80ms
+        ]:
+            _input = torch.randn((numel,), device=self.device, dtype=torch.float32)
+            yield _input, group_size, 2, 1, RoundingMode.even, False
 
     @register_benchmark(baseline=True, fwd_only=True, enabled=HAS_FBGEMM)
     def fbgemm_fp32_to_mx4(self, *args) -> Callable:


### PR DESCRIPTION
Summary:

The `fp32_to_mx4` operator benchmarks the MX4 encode kernel (`_kernel_quantize_mx4`) used inside `quantize_comm` (the `All2All_Pooled` quantized-comm path). Its existing inputs are small synthetic 1D sizes at the default `group_size=32`, which do not exercise the large/slow regime that production hits.

A GB300 trace of the MX4-comm job shows the codec is configured via `QCommsConfig(mx4_quantize_dim=8, mx4_quantize_dim_bwd=16)` — forward encode at `group_size=8`, backward encode at `group_size=16`. `group_size=8` compiles a ~2x slower `_kernel_quantize_mx4` specialization (64 B vs 512 B shared memory) than the default 32, and the large comm tensors run tens of milliseconds.

This keeps the existing microbenchmark cases and adds a few large (>10ms) cases recovered from the trace — one backward (`group_size=16`) and two forward (`group_size=8`, the slow kernels, up to ~46 ms) — so the benchmark also covers the production large/slow regime.

Reviewed By: xuzhao9

Differential Revision: D107566336


