### PR TITLE
[TPU] Make cross_entropy/embedding/fused_linear_jsd shape-configurable and TPU-dtype-safe

### DIFF
--- a/tritonbench/operators/cross_entropy/operator.py
+++ b/tritonbench/operators/cross_entropy/operator.py
@@ -53,14 +53,17 @@ class Operator(BenchmarkOperator):
                 requires_grad=True,
                 device=self.device,
             )
-            target = torch.randint(V, (self.B * self.T, 1), device=self.device).squeeze(
-                1
-            )
+            # Pallas/TPU does not support int64 tensors; use int32 indices there.
+            target_dtype = torch.int32 if self.device == "tpu" else torch.int64
+            target = torch.randint(
+                V, (self.B * self.T, 1), device=self.device, dtype=target_dtype
+            ).squeeze(1)
             yield _input, target
 
     @register_benchmark(baseline=True)
     def cross_entropy_loss(self, input, target) -> Callable:
-        return lambda: self.baseline_model(input, target)
+        # nn.CrossEntropyLoss requires Long targets; inputs may be int32 on TPU.
+        return lambda: self.baseline_model(input, target.long())
 
     @register_benchmark(enabled=LigerCrossEntropyLoss is not None)
     def liger_cross_entropy_loss(self, input, target) -> Callable:
@@ -71,7 +74,7 @@ class Operator(BenchmarkOperator):
         compiled = torch.compile(
             self.baseline_model, dynamic=False, mode="max-autotune-no-cudagraphs"
         )
-        return lambda: compiled(input, target)
+        return lambda: compiled(input, target.long())
 
     @register_x_val(label="(B, T, V)")
     def get_x_val(self, example_inputs) -> Tuple[int, int, int]:

--- a/tritonbench/operators/embedding/operator.py
+++ b/tritonbench/operators/embedding/operator.py
@@ -18,6 +18,23 @@ except ModuleNotFoundError:
 # blob/main/benchmark/scripts/benchmark_embedding.py
 
 
+def parse_op_args(args: List[str]):
+    parser = argparse.ArgumentParser()
+    # When any of --B/--T/--D is given, a single (B, T, D) shape is used instead
+    # of the default two; --v-range overrides the vocab sweep. Defaults preserve
+    # the original behavior.
+    parser.add_argument("--B", type=int, default=None, help="Batch size")
+    parser.add_argument("--T", type=int, default=None, help="Sequence length")
+    parser.add_argument("--D", type=int, default=None, help="Embedding dim")
+    parser.add_argument(
+        "--v-range",
+        type=str,
+        default="10,18",
+        help="Vocab size range 'start,end' -> V=2^start..2^(end-1)",
+    )
+    return parser.parse_args(args)
+
+
 class Operator(BenchmarkOperator):
     def __init__(
         self, tb_args: argparse.Namespace, extra_args: Optional[List[str]] = None
@@ -27,11 +44,29 @@ class Operator(BenchmarkOperator):
         self.baseline_op = None
         self.liger_op = None
         self.reset_dynamo = True
+        args = parse_op_args(self.extra_args)
+        start, end = map(int, args.v_range.split(","))
+        self._v_range = range(start, end)
+        # Override the default (B, T, D) sweep only when explicitly requested.
+        if args.B is not None or args.T is not None or args.D is not None:
+            self._btd_shapes = [
+                (
+                    args.B if args.B is not None else 32,
+                    args.T if args.T is not None else 512,
+                    args.D if args.D is not None else 768,
+                )
+            ]
+        else:
+            self._btd_shapes = [(32, 512, 768), (8, 2048, 4096)]
 
     def get_input_iter(self) -> Generator:
-        for B, T, D in [(32, 512, 768), (8, 2048, 4096)]:
-            for V in [2**i for i in range(10, 18)]:
-                _input = torch.randint(0, V, (B, T), device=self.device)
+        for B, T, D in self._btd_shapes:
+            for V in [2**i for i in self._v_range]:
+                # Pallas/TPU does not support int64 tensors; use int32 indices there.
+                idx_dtype = torch.int32 if self.device == "tpu" else torch.int64
+                _input = torch.randint(
+                    0, V, (B, T), device=self.device, dtype=idx_dtype
+                )
                 tmp_embed = Embedding(V, D).to(self.device).to(self.dtype)
                 shared_weight = tmp_embed.weight.data
                 yield V, D, _input, shared_weight

--- a/tritonbench/operators/fused_linear_jsd/operator.py
+++ b/tritonbench/operators/fused_linear_jsd/operator.py
@@ -125,13 +125,21 @@ class LigerLMHeadJSD(torch.nn.Module):
         )
 
 
+def parse_op_args(args: List[str]):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--H", type=int, default=4096, help="Hidden size")
+    parser.add_argument("--V", type=int, default=128256, help="Vocabulary size")
+    return parser.parse_args(args)
+
+
 class Operator(BenchmarkOperator):
     def __init__(
         self, tb_args: argparse.Namespace, extra_args: Optional[List[str]] = None
     ):
         super().__init__(tb_args, extra_args)
-        self.H = 4096
-        self.V = 128256
+        args = parse_op_args(self.extra_args)
+        self.H = args.H
+        self.V = args.V
         self.baseline_op = TorchLMHeadJSD(
             H=self.H, V=self.V, dtype=self.dtype, device=self.device
         )


### PR DESCRIPTION
Enables `cross_entropy`, `embedding`, and `fused_linear_jsd` to run on TPU (via the Helion bridge / `--device tpu`), where tritonbench's large default shapes exceed TPU vmem and Pallas rejects int64 index tensors.

- **embedding**: add `--B/--T/--D/--v-range` shape args (defaults reproduce the existing two-shape × 8-vocab sweep) and generate int32 indices on TPU. **Now runs on TPU.**
- **cross_entropy**: generate int32 targets on TPU (Pallas rejects int64) and cast targets to Long in the torch baselines (`nn.CrossEntropyLoss` requires Long). This removes the int64 blocker; the Helion cross_entropy kernel then hits a separate Mosaic codegen limitation (Helion-side, tracked as a TODO), so it stays on `run_tpu.py` for now.
- **fused_linear_jsd**: add `--H/--V` shape args (defaults preserve `H=4096`/`V=128256`) so a TPU-sized vocab can be selected. The Helion example kernel still has a fp32-vs-bf16 `mm` dtype bug on TPU (Helion-side TODO), so it also stays on `run_tpu.py` for now.

int32 conversion is gated on `device == "tpu"` and all shape-arg defaults are unchanged, so CUDA behavior is identical. The shape args are also generally useful for benchmarking these ops at custom sizes on any device.
