### PR TITLE
Fix blackwell_attentions autows updated forward signature

### DIFF
--- a/test/test_gpu/skip_tests.yaml
+++ b/test/test_gpu/skip_tests.yaml
@@ -28,6 +28,9 @@ flash_attention:
 blackwell_attentions:
   devices:
     - b200
+blackwell_attentions_mxfp8:
+  devices:
+    - b200
 nvfp4_gemm:
   devices:
     - b200

--- a/tritonbench/operators/blackwell_attentions/operator.py
+++ b/tritonbench/operators/blackwell_attentions/operator.py
@@ -750,7 +750,6 @@ class Operator(BenchmarkOperator):
                 True,  # SUBTILING for fwd, EPILOGUE_SUBTILE for bwd is tunable
                 1,  # VECT_MUL for fwd [0, 1]
                 False,  # FADD2_REDUCE for fwd
-                False,  # early_tma_store_lowering for bwd
             )
 
         return preproc_noop, fn


### PR DESCRIPTION
Remove the extra early_tma_store_lowering argument from the triton_autows_flash_persistent_blackwell call. The upstream _attention_opt.forward() no longer accepts it, causing: TypeError: _attention_opt.forward() takes 10 positional arguments but 11 were given.

Also, skip [blackwell_attentions_mxfp8](https://github.com/meta-pytorch/tritonbench/tree/main/tritonbench/operators/blackwell_attentions_mxfp8) on H100.

After this update, there is a new error:

```
INFO:tritonbench.utils.triton_op:Took 0.13ms to get benchmark function for triton_autows_flash_persistent_blackwell
python: /home/runner/work/triton/triton/llvm-project/mlir/lib/IR/Types.cpp:125: unsigned int mlir::Type::getIntOrFloatBitWidth() const: Assertion `isIntOrFloat() && "only integers and floats have a bitwidth"' failed.
module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, ttg.early_tma_store_lowering = true, ttg.maxnreg = 128 : i32, ttg.min_reg_auto_ws = 24 : i32} {
  tt.func public @_attn_fwd_persist(%arg0: f32, %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg2: i32, %arg3: i32 {tt.divisibility = 16 : i32}, %arg4: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %arg5: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %arg6: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %arg7: !tt.ptr<bf16> {tt.divisibility = 16 : i32}) attributes {noinline = false} {
    %cst = arith.constant 1.44269502 : f32
    %cst_0 = arith.constant dense<0.000000e+00> : tensor<256x128xf32>
    %cst_1 = arith.constant dense<0xFF800000> : tensor<256xf32>
    %cst_2 = arith.constant dense<0.000000e+00> : tensor<256x64x2xf32>
    %c0_i32 = arith.constant 0 : i32
    %c1_i64 = arith.constant 1 : i64
    %c128_i64 = arith.constant 128 : i64
    %c128_i32 = arith.constant 128 : i32
    %c1_i32 = arith.constant 1 : i32
    %0 = tt.get_program_id x : i32
    %1 = tt.get_num_programs x : i32
    %2 = arith.muli %arg2, %arg3 : i32
    %3 = arith.divsi %2, %1 : i32
    %4 = arith.remsi %2, %1 : i32
    %5 = arith.cmpi slt, %0, %4 : i32
    %6 = scf.if %5 -> (i32) {
      %13 = arith.addi %3, %c1_i32 : i32
      scf.yield %13 : i32
    } else {
      scf.yield %3 : i32
    }
    %7 = arith.muli %2, %c128_i32 : i32
    %8 = tt.make_tensor_descriptor %arg4, [%7, %c128_i32], [%c128_i64, %c1_i64] : !tt.ptr<bf16>, !tt.tensordesc<tensor<256x128xbf16>>
    %9 = tt.make_tensor_descriptor %arg5, [%7, %c128_i32], [%c128_i64, %c1_i64] : !tt.ptr<bf16>, !tt.tensordesc<tensor<128x128xbf16>>
    %10 = tt.make_tensor_descriptor %arg6, [%7, %c128_i32], [%c128_i64, %c1_i64] : !tt.ptr<bf16>, !tt.tensordesc<tensor<128x128xbf16>>
    %11 = tt.make_tensor_descriptor %arg7, [%7, %c128_i32], [%c128_i64, %c1_i64] : !tt.ptr<bf16>, !tt.tensordesc<tensor<256x128xbf16>>
    %12 = scf.for %arg8 = %c0_i32 to %6 step %c1_i32 iter_args(%arg9 = %0) -> (i32)  : i32 {
      %13 = arith.divsi %arg9, %arg3 : i32
      %14 = arith.remsi %arg9, %arg3 : i32
      %15 = arith.muli %arg3, %c128_i32 : i32
      %16 = arith.muli %13, %15 : i32
      %17 = arith.muli %14, %c128_i32 : i32
      %18 = arith.addi %16, %17 : i32
      %19 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
      %20 = arith.mulf %arg0, %cst : f32
      %21 = tt.descriptor_load %8[%18, %c0_i32] : !tt.tensordesc<tensor<256x128xbf16>> -> tensor<256x128xbf16>
      %22 = tt.descriptor_load %9[%18, %c0_i32] : !tt.tensordesc<tensor<128x128xbf16>> -> tensor<128x128xbf16>
      %23 = tt.trans %22 {order = array<i32: 1, 0>} : tensor<128x128xbf16> -> tensor<128x128xbf16>
      %24 = tt.descriptor_load %10[%18, %c0_i32] : !tt.tensordesc<tensor<128x128xbf16>> -> tensor<128x128xbf16>
      %25 = tt.dot %21, %23, %cst_0, inputPrecision = tf32 : tensor<256x128xbf16> * tensor<128x128xbf16> -> tensor<256x128xf32>
      %26 = "tt.reduce"(%25) <{axis = 1 : i32, reduction_ordering = "unordered"}> ({
      ^bb0(%arg10: f32, %arg11: f32):
        %60 = arith.maxnumf %arg10, %arg11 : f32
        tt.reduce.return %60 : f32
      }) : (tensor<256x128xf32>) -> tensor<256xf32>
      %27 = tt.splat %20 : f32 -> tensor<256xf32>
      %28 = arith.mulf %26, %27 : tensor<256xf32>
      %29 = arith.maxnumf %28, %cst_1 : tensor<256xf32>
      %30 = tt.splat %20 : f32 -> tensor<256x128xf32>
      %31 = arith.mulf %25, %30 : tensor<256x128xf32>
      %32 = tt.expand_dims %29 {axis = 1 : i32} : tensor<256xf32> -> tensor<256x1xf32>
      %33 = tt.broadcast %32 : tensor<256x1xf32> -> tensor<256x128xf32>
      %34 = arith.subf %31, %33 : tensor<256x128xf32>
      %35 = math.exp2 %34 : tensor<256x128xf32>
      %36 = arith.subf %cst_1, %29 : tensor<256xf32>
      %37 = math.exp2 %36 : tensor<256xf32>
      %38 = "tt.reduce"(%35) <{axis = 1 : i32, reduction_ordering = "unordered"}> ({
      ^bb0(%arg10: f32, %arg11: f32):
        %60 = arith.addf %arg10, %arg11 : f32
        tt.reduce.return %60 : f32
      }) : (tensor<256x128xf32>) -> tensor<256xf32>
      %outLHS, %outRHS = tt.split %cst_2 : tensor<256x64x2xf32> -> tensor<256x64xf32>
      %39 = tt.expand_dims %37 {axis = 1 : i32} : tensor<256xf32> -> tensor<256x1xf32>
      %40 = tt.broadcast %39 : tensor<256x1xf32> -> tensor<256x64xf32>
      %41 = tt.elementwise_inline_asm "\0A        {\0A            .reg .b64 ra, rb, rc;\0A            mov.b64 ra, { $2, $3 };\0A            mov.b64 rb, { $4, $5 };\0A            mul.f32x2 rc, ra, rb;\0A            mov.b64 { $0, $1 }, rc;\0A        }\0A        " {constraints = "=r,=r,r,r,r,r", packed_element = 2 : i32, pure = true} %outLHS, %40 : tensor<256x64xf32>, tensor<256x64xf32> -> tensor<256x64xf32>
      %42 = tt.elementwise_inline_asm "\0A        {\0A            .reg .b64 ra, rb, rc;\0A            mov.b64 ra, { $2, $3 };\0A            mov.b64 rb, { $4, $5 };\0A            mul.f32x2 rc, ra, rb;\0A            mov.b64 { $0, $1 }, rc;\0A        }\0A        " {constraints = "=r,=r,r,r,r,r", packed_element = 2 : i32, pure = true} %outRHS, %40 : tensor<256x64xf32>, tensor<256x64xf32> -> tensor<256x64xf32>
      %43 = tt.join %41, %42 : tensor<256x64xf32> -> tensor<256x64x2xf32>
      %44 = tt.trans %43 {order = array<i32: 0, 2, 1>} : tensor<256x64x2xf32> -> tensor<256x2x64xf32>
      %45 = tt.reshape %44 : tensor<256x2x64xf32> -> tensor<256x128xf32>
      %46 = arith.truncf %35 : tensor<256x128xf32> to tensor<256x128xbf16>
      %47 = tt.dot %46, %24, %45, inputPrecision = tf32 : tensor<256x128xbf16> * tensor<128x128xbf16> -> tensor<256x128xf32>
      %48 = arith.addf %37, %38 : tensor<256xf32>
      %49 = math.log2 %48 : tensor<256xf32>
      %50 = arith.addf %29, %49 : tensor<256xf32>
      %51 = tt.expand_dims %48 {axis = 1 : i32} : tensor<256xf32> -> tensor<256x1xf32>
      %52 = tt.broadcast %51 : tensor<256x1xf32> -> tensor<256x128xf32>
      %53 = arith.divf %47, %52 : tensor<256x128xf32>
      %54 = arith.muli %arg9, %c128_i32 : i32
      %55 = tt.addptr %arg1, %54 : !tt.ptr<f32>, i32
      %56 = tt.splat %55 : !tt.ptr<f32> -> tensor<256x!tt.ptr<f32>>
      %57 = tt.addptr %56, %19 : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
      tt.store %57, %50 : tensor<256x!tt.ptr<f32>>
      %58 = arith.truncf %53 : tensor<256x128xf32> to tensor<256x128xbf16>
      tt.descriptor_store %11[%18, %c0_i32], %58 : !tt.tensordesc<tensor<256x128xbf16>>, tensor<256x128xbf16>
      %59 = arith.addi %arg9, %1 : i32
      scf.yield %59 : i32
    } {tt.data_partition_factor = 2 : i32, tt.merge_epilogue = true, tt.separate_epilogue_store = true, tt.warp_specialize}
    tt.return
  }
}

{-#
  external_resources: {
    mlir_reproducer: {
      pipeline: "builtin.module(convert-triton-to-tritongpu{enable-source-remat=false num-ctas=1 num-warps=4 target=cuda:100 threads-per-warp=32}, tritongpu-coalesce, tlx-propagate-layout, tlx-resolve-placeholder-layouts, tlx-rewrite-local-alias, tritongpu-F32DotTC{emu-tf32=true}, triton-nvidia-gpu-plan-cta, tritongpu-remove-layout-conversions{smem-budget=0}, tritongpu-optimize-thread-locality, tritongpu-accelerate-matmul, tritongpu-remove-layout-conversions{smem-budget=0}, tritongpu-optimize-dot-operands{hoist-layout-conversion=true}, triton-nvidia-optimize-descriptor-encoding, triton-loop-aware-cse, tritongpu-fuse-nested-loops, canonicalize{cse-between-iterations=false    max-iterations=10 max-num-rewrites=-1 region-simplify=normal test-convergence=false top-down=true}, triton-licm, tritongpu-optimize-accumulator-init, tritongpu-hoist-tmem-alloc{hoist-out-of-if=false}, tritongpu-promote-lhs-to-tmem, nvgpu-ws-data-partition{num-warp-groups=1}, tritongpu-assign-latencies{num-stages=3 use-meta-ws=true}, tritongpu-schedule-loops{num-stages=3 use-meta-ws=true}, nvgpu-ws-tma-store-lowering, nvgpu-sink-broadcast, nvgpu-partition-scheduling-meta{merge-correction=false merge-epilogue=false merge-epilogue-to-computation=false merge-reduction=false separate-epilogue-store=false}, nvgpu-warp-specialization{capability=100 dump-intermediate-steps=false generate-subtiled-region=false num-stages=3 pingpong-auto-ws=false smem-budget=232448 tile-prefetch-depth=1}, tritongpu-pipeline{dump-intermediate-steps=false num-stages=3}, tritongpu-optimize-partition-warps, tritongpu-combine-tensor-select-and-if, tritongpu-hoist-tmem-alloc{hoist-out-of-if=true}, triton-nvidia-gpu-remove-tmem-tokens, canonicalize{cse-between-iterations=false    max-iterations=10 max-num-rewrites=-1 region-simplify=normal test-convergence=false top-down=true}, triton-loop-aware-cse, tritongpu-prefetch, tritongpu-optimize-dot-operands{hoist-layout-conversion=true}, tritongpu-coalesce-async-copy, triton-nvidia-optimize-tmem-layouts, triton-nvidia-tma-lowering, triton-nvidia-tma-store-buffer-reuse, tritongpu-remove-layout-conversions{smem-budget=0}, nvgpu-multi-cta-reduction, triton-nvidia-gpu-prune-unused-barriers, triton-nvidia-interleave-tmem, tritongpu-reduce-data-duplication, tritongpu-reorder-instructions, triton-loop-aware-cse, symbol-dce, tritongpu-optimize-partition-warps, triton-nvidia-gpu-fence-insertion{compute-capability=100}, triton-nvidia-mma-lowering, sccp, cse, canonicalize{cse-between-iterations=false    max-iterations=10 max-num-rewrites=-1 region-simplify=normal test-convergence=false top-down=true}, tritongpu-remove-layout-conversions{smem-budget=232448})",
      disable_threading: true,
      verify_each: true
    }
  }
#-}
/home/nvadmin/git/meta-triton/python/triton/language/extra/tlx/tutorials/fused_attention_ws_device_tma.py:447:1: error: Failures have been detected while processing an MLIR pass pipeline
def _attn_fwd_persist(
^
/home/nvadmin/git/meta-triton/python/triton/language/extra/tlx/tutorials/fused_attention_ws_device_tma.py:447:1: note: Pipeline failed while executing [`NVGPUWarpSpecialization` on 'builtin.module' operation]: reproducer generated at `std::errs, please share the reproducer above with Triton project.`
  0%|                                                                                                                                                        | 0/8 [00:00<?, ?it/s]
WARNING:tritonbench.utils.triton_op:Caught exception on backend triton_autows_flash_persistent_blackwell, terminating early with partial results
```