### PR TITLE
fp8_gemm: Add TLX warp-specialized scaled_mm backend

### DIFF
--- a/tritonbench/operators/fp8_gemm/fp8_gemm.py
+++ b/tritonbench/operators/fp8_gemm/fp8_gemm.py
@@ -498,13 +498,23 @@ class Operator(BenchmarkOperator):
         # in one accumulator, single scaled epilogue). Kernel reshapes scales to [M]/[N].
         if ra == ScalingType.RowWise and rb == ScalingType.RowWise:
             return lambda: tlx_scaled_mm(
-                a, b, scale_a, scale_b, out_dtype=self._get_dtype(), scale_mode="rowwise"
+                a,
+                b,
+                scale_a,
+                scale_b,
+                out_dtype=self._get_dtype(),
+                scale_mode="rowwise",
             )
         # TensorWise: scalar scales -> tensorwise mode (same K-independent mainloop, single
         # scalar-scaled epilogue). Kernel reshapes scale_a/scale_b to 1-element tensors.
         if ra == ScalingType.TensorWise and rb == ScalingType.TensorWise:
             return lambda: tlx_scaled_mm(
-                a, b, scale_a, scale_b, out_dtype=self._get_dtype(), scale_mode="tensorwise"
+                a,
+                b,
+                scale_a,
+                scale_b,
+                out_dtype=self._get_dtype(),
+                scale_mode="tensorwise",
             )
         raise NotImplementedError(
             "tlx_scaled_mm supports --scaling-pair BlockWise1x128,BlockWise128x128, "

--- a/tritonbench/operators/fp8_gemm/fp8_gemm.py
+++ b/tritonbench/operators/fp8_gemm/fp8_gemm.py
@@ -28,6 +28,25 @@ from tritonbench.utils.triton_utils import has_experimental_descriptor, has_tlx
 
 from .tutorial import matmul as tutorial_matmul
 
+# Warp-specialized FP8 scaled_mm TLX kernel (BlockWise + RowWise), imported straight
+# from the triton source tree (the source of truth) rather than a fork in this operator.
+# The HAS_TLX_SCALED_MM guard is still required: has_tlx() only says TLX exists, not that
+# this specific kernel imports cleanly (missing file / syntax error / dep) -- without it a
+# broken kernel would crash benchmark registration instead of just disabling the backend.
+if has_tlx():
+    try:
+        from triton.language.extra.tlx.tutorials.blackwell_scaled_mm_ws import (
+            blackwell_scaled_mm_ws as tlx_scaled_mm,
+        )
+
+        HAS_TLX_SCALED_MM = True
+    except Exception:
+        tlx_scaled_mm = None
+        HAS_TLX_SCALED_MM = False
+else:
+    tlx_scaled_mm = None
+    HAS_TLX_SCALED_MM = False
+
 with try_import("HAS_VLLM_CUTLASS"):
     from vllm import _custom_ops as vllm_ops
 
@@ -461,6 +480,35 @@ class Operator(BenchmarkOperator):
         sb = scale_b.squeeze()
         return lambda: scaled_mm_autows(
             a, b, sa, sb, a_mode, b_mode, out_dtype=self._get_dtype()
+        )
+
+    # Hand-written warp-specialized TLX scaled_mm (CUTLASS SM100 mirror). Supports the
+    # asymmetric BlockWise (BlockWise1x128 activations + BlockWise128x128 weights,
+    # DeepSeek) recipe and RowWise. Inputs pass straight through -- scale layouts are
+    # exactly what get_scale() produces (blockwise: scale_a M-major, scale_b
+    # [N/128,K/128] row-major; rowwise: scale_a [M,1], scale_b [1,N]).
+    @register_benchmark(enabled=is_cuda() and has_tlx() and HAS_TLX_SCALED_MM)
+    def tlx_scaled_mm_fp8_gemm(self, a, b, scale_a, scale_b):
+        ra, rb = self.scaling_recipe_a, self.scaling_recipe_b
+        if ra == ScalingType.BlockWise1x128 and rb == ScalingType.BlockWise128x128:
+            return lambda: tlx_scaled_mm(
+                a, b, scale_a, scale_b, out_dtype=self._get_dtype()
+            )
+        # RowWise: K-independent per-row/per-col scales -> rowwise mode (accumulate all K
+        # in one accumulator, single scaled epilogue). Kernel reshapes scales to [M]/[N].
+        if ra == ScalingType.RowWise and rb == ScalingType.RowWise:
+            return lambda: tlx_scaled_mm(
+                a, b, scale_a, scale_b, out_dtype=self._get_dtype(), scale_mode="rowwise"
+            )
+        # TensorWise: scalar scales -> tensorwise mode (same K-independent mainloop, single
+        # scalar-scaled epilogue). Kernel reshapes scale_a/scale_b to 1-element tensors.
+        if ra == ScalingType.TensorWise and rb == ScalingType.TensorWise:
+            return lambda: tlx_scaled_mm(
+                a, b, scale_a, scale_b, out_dtype=self._get_dtype(), scale_mode="tensorwise"
+            )
+        raise NotImplementedError(
+            "tlx_scaled_mm supports --scaling-pair BlockWise1x128,BlockWise128x128, "
+            f"RowWise,RowWise, or TensorWise,TensorWise; got {ra},{rb}"
         )
 
     @register_benchmark(enabled=HAS_VLLM_CUTLASS)


### PR DESCRIPTION
## Summary
Registers the tlx_scaled_mm_fp8_gemm backend in operator fp8_gemm, importing the kernel from the triton source tree [(blackwell_scaled_mm_ws)](https://github.com/facebookexperimental/triton/pull/1964). Routes the BlockWise1x128/BlockWise128x128 (DeepSeek), RowWise, and TensorWise scaling pairs to the kernel's blockwise/rowwise/tensorwise modes. A HAS_TLX_SCALED_MM import guard disables the backend if the kernel is unavailable.

## Test plan
TLX is ~104% of vllm CUTLASS for BlockWise (1x128, 128x128) deepseek style on Blackwell.
TLX is ~85% of vllm CUTLASS for TensorWise and RowWise on Blackwell, which needs more followup optimizations.

### TensorWise accuracy
```
CUDA_VISIBLE_DEVICES=1 TRITON_USE_META_WS=1 python run.py --op fp8_gemm --scaling-pair TensorWise,TensorWise --only vllm_cutlass_fp8_gemm,tlx_scaled_mm_fp8_gemm,triton_autows_fp8_gemm --metrics accuracy --baseline vllm_cutlass_fp8_gemm --atol 1e-4 --rtol 0.016 --simple-output --m 4096 --n 4096 --k 4096
```
```
             x_val    tlx_scaled_mm_fp8_gemm-accuracy    triton_autows_fp8_gemm-accuracy
------------------  ---------------------------------  ---------------------------------
(4096, 4096, 4096)                                  1                                  1
           1.0,1.0
```
### TensorWise performance
```
CUDA_VISIBLE_DEVICES=1 TRITON_USE_META_WS=1 python run.py --op fp8_gemm --scaling-pair TensorWise,TensorWise --only vllm_cutlass_fp8_gemm,tlx_scaled_mm_fp8_gemm,triton_autows_fp8_gemm --metrics tflops --rep 3000 --sleep 1.0 --simple-output --m 4096 --n 4096 --k 4096
```
```
                                                  x_val    vllm_cutlass_fp8_gemm-tflops    tlx_scaled_mm_fp8_gemm-tflops    triton_autows_fp8_gemm-tflops
-------------------------------------------------------  ------------------------------  -------------------------------  -------------------------------
                                     (4096, 4096, 4096)                         2006.99                          1739.56                          1945.18
```
### RowWise accuracy
```
CUDA_VISIBLE_DEVICES=1 TRITON_USE_META_WS=1 python run.py --op fp8_gemm --scaling-pair RowWise,RowWise --only vllm_cutlass_fp8_gemm,tlx_scaled_mm_fp8_gemm,triton_autows_fp8_gemm --metrics accuracy --baseline vllm_cutlass_fp8_gemm --atol 1e-4 --rtol 0.016 --simple-output --m 4096 --n 4096 --k 4096
```
```
             x_val    tlx_scaled_mm_fp8_gemm-accuracy    triton_autows_fp8_gemm-accuracy
------------------  ---------------------------------  ---------------------------------
(4096, 4096, 4096)                                  1                                  1
           1.0,1.0
```
### RowWise Performance
```
CUDA_VISIBLE_DEVICES=1 TRITON_USE_META_WS=1 python run.py --op fp8_gemm --scaling-pair RowWise,RowWise --only vllm_cutlass_fp8_gemm,tlx_scaled_mm_fp8_gemm,triton_autows_fp8_gemm --metrics tflops --rep 3000 --sleep 1.0 --simple-output --m 4096 --n 4096 --k 4096
```
```
                                                 x_val    vllm_cutlass_fp8_gemm-tflops    tlx_scaled_mm_fp8_gemm-tflops    triton_autows_fp8_gemm-tflops
------------------------------------------------------  ------------------------------  -------------------------------  -------------------------------
                                    (4096, 4096, 4096)                         2035.53                          1742.38                          1939.91
```
### BlockWise accuracy
```
CUDA_VISIBLE_DEVICES=1 TRITON_USE_META_WS=1 python run.py --op fp8_gemm --scaling-pair BlockWise1x128,BlockWise128x128 --only vllm_cutlass_fp8_gemm,tlx_scaled_mm_fp8_gemm,triton_autows_fp8_gemm --metrics accuracy --baseline vllm_cutlass_fp8_gemm --atol 1e-4 --rtol 0.016 --simple-output --m 4096 --n 4096 --k 4096
```
```
             x_val    tlx_scaled_mm_fp8_gemm-accuracy    triton_autows_fp8_gemm-accuracy
------------------  ---------------------------------  ---------------------------------
(4096, 4096, 4096)                                  1                                  1
           1.0,1.0
```
### BlockWise performance
```
CUDA_VISIBLE_DEVICES=1 TRITON_USE_META_WS=1 python run.py --op fp8_gemm --scaling-pair BlockWise1x128,BlockWise128x128 --only vllm_cutlass_fp8_gemm,tlx_scaled_mm_fp8_gemm,triton_autows_fp8_gemm --metrics tflops --rep 3000 --sleep 1.0 --simple-output --m 4096 --n 4096 --k 4096
```
```
                                                 x_val    vllm_cutlass_fp8_gemm-tflops    tlx_scaled_mm_fp8_gemm-tflops    triton_autows_fp8_gemm-tflops
------------------------------------------------------  ------------------------------  -------------------------------  -------------------------------
                                    (4096, 4096, 4096)                         1445.63                          1507.01                          547.478
```