### PR TITLE
Drop dead for-buf loop in gdpa autotune configs

### DIFF
--- a/tritonbench/operators/gdpa/gdpa.py
+++ b/tritonbench/operators/gdpa/gdpa.py
@@ -1047,7 +1047,6 @@ bwd_configs_ws = [
             num_warps=w,
         )
     )
-    for buf in [2]
     for BM1 in [64]
     for BN1 in [128]
     for s in ([1, 2] if is_hip() else [0])


### PR DESCRIPTION
Summary:
Followup to D111169324 (ads_mkl warp-spec autotune-config cleanup).

The gdpa operator's WS autotune comprehension carried a `for buf in [2]` clause
whose loop var `buf` is unused (it previously fed num_buffers_warp_spec, already
gone). Pure dead-code removal — single-iteration loop, so the generated config
set is unchanged. No lowercase warp-spec Config kwargs remain in this file.

Drafted with Claude for review.

Differential Revision: D111173575


