### PR TITLE
launcher recipe ABI (host-built CUtensorMap) (#1179)

### DIFF
--- a/tritonbench/operators/launch_latency/kernels.py
+++ b/tritonbench/operators/launch_latency/kernels.py
@@ -239,6 +239,26 @@ def make_tensordesc_inputs(m_block: int = 8, n_block: int = 32):
     return out, desc, M, N, m_block, n_block
 
 
+# --- Auto-TMA-eligible kernel (plain masked block load) for device-vs-host
+# launch-latency comparison under TRITON_AUTO_TMA=1. Plain @triton.jit (no
+# c_cache) so it goes through the variadic CudaLauncher where auto-TMA recipes
+# are wired.
+@triton.jit
+def auto_tma_add_kernel(x_ptr, y_ptr, out_ptr, N, BLOCK: tl.constexpr):
+    offs = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < N
+    x = tl.load(x_ptr + offs, mask=mask)
+    y = tl.load(y_ptr + offs, mask=mask)
+    tl.store(out_ptr + offs, x + y, mask=mask)
+
+
+def make_auto_tma_inputs(N: int = 8192, block: int = 256):
+    x = torch.randn(N, device="cuda", dtype=torch.float16)
+    y = torch.randn(N, device="cuda", dtype=torch.float16)
+    out = torch.empty(N, device="cuda", dtype=torch.float16)
+    return x, y, out, N, block
+
+
 # --- Autotuned kernel for benchmarking c_cache + autotune interaction ---
 # Uses num_ctas to exercise cluster dispatch path 1 (num_ctas > 1 → clusterDim.x = num_ctas).
 

--- a/tritonbench/operators/launch_latency/operator.py
+++ b/tritonbench/operators/launch_latency/operator.py
@@ -1,4 +1,5 @@
 import os
+from contextlib import contextmanager
 
 import torch
 from torch import zeros
@@ -759,6 +760,59 @@ class Operator(BenchmarkOperator):
         # remove constexpr args
         cute_args = cute_args[:-5]
         return lambda: kernel(*cute_args)
+
+    @register_benchmark(enabled=is_cuda())
+    def auto_tma_launch(self, *args):
+        """Launch latency of an auto-TMA-promoted kernel (TRITON_AUTO_TMA=1).
+
+        Compares device-build vs host-build of the TMA descriptor: device-build
+        allocates global scratch + builds the CUtensorMap on-GPU each launch;
+        host-build (recipe core) builds it on the host with no scratch. Run this
+        on both the host-build and device-build commits to get the delta.
+        """
+        # Only benchmark once (for the empty-args input variant).
+        if len(args) != 0:
+            return lambda: None
+        import triton as _triton
+
+        from .kernels import auto_tma_add_kernel, make_auto_tma_inputs
+
+        # TRITON_AUTO_TMA gates auto-TMA promotion at compile time and is part
+        # of the kernel's compile options, so it must be active whenever this
+        # kernel is (re)compiled -- including the returned callable's first
+        # launch. Scope it around every launch (restoring the prior value)
+        # rather than mutating os.environ globally, so it can't leak into other
+        # benchmarks compiled later in the same process. The two dict ops are
+        # negligible vs. the launch overhead being measured and are present on
+        # both the host-build and device-build commits, so the delta is unaffected.
+        @contextmanager
+        def _auto_tma_env():
+            prev = os.environ.get("TRITON_AUTO_TMA")
+            os.environ["TRITON_AUTO_TMA"] = "1"
+            try:
+                yield
+            finally:
+                if prev is None:
+                    os.environ.pop("TRITON_AUTO_TMA", None)
+                else:
+                    os.environ["TRITON_AUTO_TMA"] = prev
+
+        # Allocator is required by device-build; harmless (unused) for host-build.
+        _triton.set_allocator(
+            lambda size, alignment, stream: torch.empty(
+                size, dtype=torch.int8, device="cuda"
+            )
+        )
+        x, y, out, N, block = make_auto_tma_inputs()
+        grid = (_triton.cdiv(N, block),)
+        with _auto_tma_env():
+            auto_tma_add_kernel[grid](x, y, out, N, BLOCK=block)  # warmup + compile
+
+        def _run():
+            with _auto_tma_env():
+                return auto_tma_add_kernel[grid](x, y, out, N, BLOCK=block)
+
+        return _run
 
     @register_benchmark(baseline=True)
     def nop_python_function(self, *args):


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookexperimental/triton/pull/1975


## Background

Modern NVIDIA GPUs (Hopper sm_90+, Blackwell sm_100) have a hardware unit called
**TMA** (Tensor Memory Accelerator) that bulk-copies a rectangular *tile* of a
tensor between global memory and on-chip shared memory far more efficiently than
ordinary per-thread loads (`cp.async`). To use TMA you must first build a small
descriptor struct — a **`CUtensorMap`** — that tells the hardware the tensor's
global shape, per-dim byte strides, tile ("box") shape, element type and swizzle.

We are adding **auto-TMA**: let a kernel keep writing plain `tl.load(ptr + offs,
mask=...)` and have the compiler turn eligible loads into TMA copies automatically,
with **no hand-written descriptor**. Auto-TMA has two possible ways to produce the
`CUtensorMap`:

1. **host-recipe** — the CPU-side launcher builds the `CUtensorMap` from a compact
   "recipe" before the kernel launches, and passes it in as a hidden argument.
2. **device descriptor** — the kernel builds it in-kernel (added later, 5/n).

This diff (1/n) adds **only the host-recipe launcher machinery** — the *consumer*.
The *producer* (the `PromoteLoadToTMA` pass that emits recipes) lands in 2/n, so
this diff is inert for real kernels on its own.

## What a "recipe" is

A recipe is a compile-time record, one per promoted load/store, that tells the
launcher *how* to build one `CUtensorMap` from the kernel's runtime arguments:
which arg is the base pointer, which args hold the tensor shape, which hold the
strides, plus baked constants (tile/box shape, element type, swizzle). The
host reads the runtime arg values at launch and fills in the `CUtensorMap`.

## What this diff does

- **`launch.h`**: `triton_tma_recipe_t` struct + `triton_construct_tma_desc()`,
  which builds a `CUtensorMap` via `cuTensorMapEncodeTiled()` — the box dims come
  from the recipe's baked `block_shape`, the global dims/strides are read from the
  kernel args at launch.
- **`driver.c` / `driver.py`**: read the recipe list from the compiled kernel's
  metadata, build each `CUtensorMap`, and inject it as a trailing (hidden) kernel
  parameter (modeled on the existing global-scratch param).
- **`ir.cc`**: `get_auto_tma_recipes()` — reads the `ttg.auto_tma_recipes` module
  attribute and surfaces it to Python. Returns `[]` until the pass (2/n) produces
  recipes.
- **`nvidia/backend/compiler.py`**: recipe launcher-codegen + the
  `metadata["auto_tma_recipes"] = mod.get_auto_tma_recipes()` bridge. (Does NOT
  invoke the pass — that is 2/n.)
- **AOT-T / TritonCC** launcher paths (`triton_aot/*`) for the same ABI, and the
  `tritonbench` launch-latency bench.
- **`knobs.py`**: the `TRITON_AUTO_TMA` knob.

## Path a promoted load will take (once 2/n lands)

```
tl.load  --(pass, 2/n)-->  tt.descriptor_load %hidden_desc[idx] + recipe attr
recipe attr --(this diff)--> get_auto_tma_recipes() --> kernel metadata
kernel launch --(this diff, driver.c)--> triton_construct_tma_desc()
             --> cuTensorMapEncodeTiled() --> CUtensorMap injected as %hidden_desc
```

## Before / after

- **Before**: a TMA copy requires a hand-written `tl.make_tensor_descriptor`.
- **After (this diff only)**: the launcher *can* build a `CUtensorMap` from a
  recipe and inject it — but nothing emits recipes yet, so existing kernels are
  unchanged (recipe list is empty).

Differential Revision: D110948918


