### PR TITLE
Fix tritonbench blackwell_attentions CI (seq>=256; skip broken upstream FA2) (#1180)

### DIFF
--- a/test/test_gpu/skip_tests.yaml
+++ b/test/test_gpu/skip_tests.yaml
@@ -28,6 +28,10 @@ flash_attention:
 blackwell_attentions:
   devices:
     - b200
+  # Default input-0 is N_CTX=128, which triggers an AutoWS compiler crash and a
+  # cross-tile race on the persistent Blackwell FA path (single-trip inner
+  # loop). Run seq>=256 in CI until that is fixed. See T279315890.
+  extra_args: --seq-len 256
 blackwell_attentions_mxfp8:
   devices:
     - b200

--- a/tritonbench/operators/blackwell_attentions/operator.py
+++ b/tritonbench/operators/blackwell_attentions/operator.py
@@ -59,6 +59,13 @@ try:
 except Exception:
     HAS_TRITON_TUTORIAL_FA2 = False
 
+# Upstream 06-fused-attention with warp_specialize currently crashes in
+# TritonGPUAutomaticWarpSpecialization on Blackwell ("ttng.tmem_alloc op
+# operation destroyed but still has uses"). Disable this benchmark until the
+# upstream-WS regression is fixed so blackwell_attentions CI is green. See
+# T279315890.
+HAS_TRITON_TUTORIAL_FA2 = False
+
 if SUPPORT_GLUON:
     from tritonbench.kernels.gluon_attention_forward import (
         attention_forward as gluon_blackwell_fwd,


### PR DESCRIPTION
Summary:

Two fixes so test_gpu_tritonbench_blackwell_attentions passes on Blackwell:
- Default input-0 is N_CTX=128, which triggers an AutoWS compiler crash and a
  cross-tile race on the persistent Blackwell FA path (single-trip inner loop).
  Run seq>=256 in CI via skip_tests.yaml extra_args until that is fixed.
- triton_tutorial_FA2 (upstream 06-fused-attention + warp_specialize) crashes in
  TritonGPUAutomaticWarpSpecialization on Blackwell ("ttng.tmem_alloc op
  operation destroyed but still has uses"). Disable it until the upstream-WS
  regression is fixed.

Depends on the companion triton beta fix (WSDataPartition scf.for slicing).

Reviewed By: njriasan, xuzhao9

Differential Revision: D111530890


