### PR TITLE
Fix internal_blackwell_attentions mslk_fa4_flex block_size ValueError and input-retention OOM

### DIFF
--- a/tritonbench/operators/blackwell_attentions/operator.py
+++ b/tritonbench/operators/blackwell_attentions/operator.py
@@ -317,6 +317,9 @@ def detach_inputs(*args):
 
 def multi_input_wrapper(fn):
     def wrapper(self, *args):
+        # Drop stale entries: they pin each prior input's q/k/v copies,
+        # which OOMs the GPU over a full SWEEP_SHAPES sweep.
+        self.optims.clear()
         preproc_fn, benchmark_fn = fn(self, *args)
         arg_len = len(args)
         assert arg_len % 3 == 0


### PR DESCRIPTION
Summary:
The internal_blackwell_attentions operator produced no results for any
backend. tritonbench swallows per-backend errors and exits 0, so the
benchmark_group had 0 rows for every backend for 30+ days, leaving the
executive summary dashboard with no internal SOTA data ("0 comparable
configs"). Two independent bugs:

**1. mslk_fa4_flex raised on every input, aborting the whole run:**

  ValueError: Block sparse tensors forward require explicit
  sparse_block_size[0] to disambiguate block size for
  seqlen_q=512 and num_m_blocks=2.

It builds block-sparse tensors at tile_m=256 (num_m_blocks >= 2) but
called FlashAttnFunc.apply, which constructs BlockSparseTensorsTorch
WITHOUT block_size. The kernel then cannot infer the M-block size
(ambiguous when num_m_blocks >= 2) and raises.

Fix: call _flash_attn_fwd directly with a BlockSparseTensorsTorch that
sets block_size=(256, 128) = (q_stage * tile_m, tile_n), matching the
tile_m=256, tile_n=128 used in compute_block_sparsity_from_vis. Setting
block_size explicitly bypasses the ambiguous inference. The import comes
from the fb interface (mslk.fb.mslk.attention.flash_attn.interface): the
public shim aliases a different _flash_attn_fwd (no block_sparse_tensors
arg) and does not re-export BlockSparseTensorsTorch.

**2. With (1) fixed, the SWEEP_SHAPES sweep OOMed at input 119/144**
(178 GiB retained). This explains the earlier caveat that mslk_fa4_flex
still emitted 0 rows after the ValueError fix: multi_input_wrapper in
blackwell_attentions stores torch.optim.SGD(all_inputs) into self.optims
keyed by each benchmark's closure and never removes entries, pinning
every input's preprocessed q/k/v copies (~64 GB for the largest shape
across 3 backends) for the whole run. In this operator the dict is
write-only (get_bwd_fn uses fn._grad_inputs).

Fix: clear stale entries at wrapper entry.

Also print a traceback when the mslk FA4 import fails instead of
silently disabling mslk_fa4_vis/mslk_fa4_flex (the source of "Skipping
benchmark ... since it is not enabled" in environments where the import
fails).

Differential Revision: D112070195


