### PR TITLE
torchTLX provider convention + vendor_arch shape-file cleanup (#1184)

### DIFF
--- a/benchmarks/compare_benchmarks/run.py
+++ b/benchmarks/compare_benchmarks/run.py
@@ -27,7 +27,7 @@ Examples:
     # Custom shape file instead of Hive:
     buck2 run @mode/opt //pytorch/tritonbench/benchmarks:compare_benchmarks -- \
         --custom-bench diode --ops gemm \
-        --input-loader fb/cmf/h100/shapes_mm.json
+        --input-loader fb/nvidia_h100/mm_cmf.json
 
     # Directory of shape files, filtered by substring:
     buck2 run @mode/opt //pytorch/tritonbench/benchmarks:compare_benchmarks -- \

--- a/tritonbench/operators/addmm/operator.py
+++ b/tritonbench/operators/addmm/operator.py
@@ -6,8 +6,14 @@ from typing import Any, Callable, Generator, List, Optional, Tuple
 import torch
 import torch._inductor.config as inductor_config
 import triton
-from tritonbench.utils.env_utils import get_logger, IS_BLACKWELL, is_fbcode
+from tritonbench.utils.env_utils import (
+    get_logger,
+    IS_BLACKWELL,
+    is_fbcode,
+    is_hip_mi350,
+)
 from tritonbench.utils.python_utils import try_import
+from tritonbench.utils.triton_utils import has_tlx
 
 with try_import("HAS_HSTU"):
     try:
@@ -163,6 +169,30 @@ class Operator(BenchmarkOperator):
             max_autotune=True,
             max_autotune_gemm_backends="TRITON",
             autotune_fallback_to_aten=False,
+        ):
+            f = lambda a, mat1, mat2: torch.addmm(a, mat1, mat2)
+            compiled = torch.compile(f, dynamic=False)
+            compiled(a, mat1, mat2)
+        return lambda: compiled(a, mat1, mat2)
+
+    @register_benchmark(enabled=is_hip_mi350() and has_tlx())
+    def torch_tlx_addmm(self, a, mat1, mat2) -> Callable:
+        # torch_tlx_<op> convention: PT2 (torch.compile max-autotune, TRITON
+        # backend) with TLX "allow" mode, so TLX templates compete against the
+        # standard Triton templates during autotuning. Identical to the
+        # pt2_triton_matmul baseline except for triton.tlx_mode, giving a clean
+        # PT2-vs-PT2+TLX comparison. force_disable_caches forces a real recompile
+        # so the TLX candidates aren't served from the baseline's autotune cache.
+        # Gated to AMD MI350x (gfx950), where the TLX addmm template exists.
+        torch._dynamo.reset()
+        with inductor_config.patch(
+            {
+                "max_autotune": True,
+                "max_autotune_gemm_backends": "TRITON",
+                "autotune_fallback_to_aten": False,
+                "force_disable_caches": True,
+                "triton.tlx_mode": "allow",
+            }
         ):
             f = lambda a, mat1, mat2: torch.addmm(a, mat1, mat2)
             compiled = torch.compile(f, dynamic=False)

--- a/tritonbench/operators/gemm/operator.py
+++ b/tritonbench/operators/gemm/operator.py
@@ -416,6 +416,12 @@ class Operator(BenchmarkOperator):
 
     @register_benchmark(enabled=IS_BLACKWELL and has_tlx())
     def torch_tlx_mm(self, a, b, bias) -> Callable:
+        # torch_tlx_<op> convention: PT2 (torch.compile max-autotune, TRITON
+        # backend) with TLX "allow" mode, so TLX templates compete against the
+        # standard Triton templates during autotuning. Identical to the
+        # pt2_triton_matmul baseline except for triton.tlx_mode, giving a clean
+        # PT2-vs-PT2+TLX comparison. force_disable_caches forces a real recompile
+        # so the TLX candidates aren't served from the baseline's autotune cache.
         torch._dynamo.reset()
         inductor_config_patch = {
             "max_autotune": True,
@@ -423,17 +429,18 @@ class Operator(BenchmarkOperator):
             "autotune_fallback_to_aten": False,
             "autotune_num_choices_displayed": self.inductor_autotune_num_choices_displayed,
             "force_disable_caches": True,
+            "triton.tlx_mode": "allow",
         }
-        from torch._inductor.fb.tlx_templates import tlx_config
+        if self.template_filter_regex is not None:
+            inductor_config_patch["test_configs.autotune_choice_name_regex"] = (
+                self.template_filter_regex
+            )
 
-        with (
-            tlx_config.patch(tlx_mode="force"),
-            inductor_config.patch(inductor_config_patch),
-        ):
+        with inductor_config.patch(inductor_config_patch):
             if bias is not None:
-                f = lambda a, b: a.contiguous().matmul(b.contiguous()) + bias
+                f = lambda a, b: a.matmul(b) + bias
             else:
-                f = lambda a, b: a.contiguous().matmul(b.contiguous())
+                f = lambda a, b: a.matmul(b)
             compiled = torch.compile(f, dynamic=False)
             compiled(a, b)
 


### PR DESCRIPTION
Summary:

1. Provider convention torch_tlx_<op> (one per op). Now we have `torch_tlx_mm` and `torch_tlx_addmm`
2. Re-organize all TLX-relevant shape files to `fb/<vendor>_<arch>/<op>_<info>.json` (e.g. amd_mi350x/addmm_cmf.json, nvidia_b200/gemm_ads_omnifm_v5.json). Non-TLX configs (ads_omnifm_v2/v4, gemm_sota, etc.) left untouched.
3. Complete B200 run (pt2_triton_matmul vs torch_tlx_mm allow, all 171 shapes, 29 min, no hangs). Two TLX bugs are recorded and will be fixed in the next diff.

```
  ┌───────────────────────────────────────────────────────────┬──────────────────────────────────────────────┐
  │                          Outcome                          │                    Count                     │
  ├───────────────────────────────────────────────────────────┼──────────────────────────────────────────────┤
  │ OK (acc 1.0)                                              │ 47 — TLX faster on 40/47, geomean 1.35×, up  │
  │                                                           │ to 2.02×                                     │
  ├───────────────────────────────────────────────────────────┼──────────────────────────────────────────────┤
  │ STREAM_ERR (large-K, stream kwarg TypeError)              │ 63                                           │
  ├───────────────────────────────────────────────────────────┼──────────────────────────────────────────────┤
  │ SUBPROC_ERR (column-major A, make_tensor_descriptor A     │ 61                                           │
  │ undefined)                                                │                                              │
  └───────────────────────────────────────────────────────────┴──────────────────────────────────────────────┘
```

Reviewed By: xuzhao9

Differential Revision: D112059375
