### PR TITLE
Add --ncu-kernel-name flag to filter NCU profiling by kernel

### DIFF
--- a/tritonbench/utils/parser.py
+++ b/tritonbench/utils/parser.py
@@ -445,6 +445,16 @@ def get_parser(args=None):
         help="Skip the L2 cache clearing during benchmarking",
     )
     parser.add_argument(
+        "--ncu-kernel-name",
+        type=str,
+        default=None,
+        help="Restrict NCU profiling to kernels matching this name. Passed "
+        "verbatim to `ncu -k <name>`. Supports NCU's `regex:` prefix for regex "
+        "matching against the mangled kernel name, e.g. "
+        "'regex:.*gdpa_backward_tlx.*'. Only affects the ncu_rep/ncu_rep_ir "
+        "metrics.",
+    )
+    parser.add_argument(
         "--plugin",
         type=str,
         help="Load plugin from a Python function. This is for loading backends at runtime.",

--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -2532,6 +2532,9 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
             "--import-source",
             "yes",
         ]
+        ncu_kernel_name = getattr(self.tb_args, "ncu_kernel_name", None)
+        if ncu_kernel_name:
+            ncu_args.extend(["-k", ncu_kernel_name])
         ncu_args.extend(extend_ncu_args)
         if replay:
             ncu_args.extend(


### PR DESCRIPTION
Summary:
Add a `--ncu-kernel-name` CLI flag that restricts NCU profiling to kernels
matching a given name. Previously the NCU path (ncu_rep / ncu_rep_ir metrics)
scoped capture only to the `tritonbench_range` NVTX range, profiling every
kernel launched inside it.

The flag value is passed verbatim to `ncu -k <name>`, so NCU's `regex:`
prefix is supported for regex matching against the mangled kernel name, e.g.
`--ncu-kernel-name 'regex:.*gdpa_backward_tlx.*'`. When the flag is omitted,
behavior is unchanged.

Differential Revision: D112616897


