### PR TITLE
Support ctas_per_cga clusters in the PTX-direct launch spec

### DIFF
--- a/tritonbench/operators/flex_attention/operator.py
+++ b/tritonbench/operators/flex_attention/operator.py
@@ -295,9 +295,7 @@ class Operator(BenchmarkOperator):
         should_skip = False
         if mod_type == "document_mask" and B * S > 8192:
             should_skip = True
-            print(
-                f"Skipping eager for document_mask with batch*seq_len={B * S} > 8192"
-            )
+            print(f"Skipping eager for document_mask with batch*seq_len={B * S} > 8192")
         elif mod_type != "document_mask" and S > 8192:
             should_skip = True
             print(f"Skipping eager for {mod_type} with seq_len={S} > 8192")


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookexperimental/triton/pull/2230

X-link: https://github.com/facebookexperimental/ptx-anneal/pull/13

`build_spec` raised `NotImplementedError` for any kernel launched with a thread-block cluster, so 2-CTA TLX kernels (e.g. `blackwell_gemm_ws`) were skipped by the collector (`skip ... multi-CTA/cluster`) and could not be tuned by the factory. Support the TLX / CUDA-native clustering path: `num_ctas == 1` with the cluster shape (`ctas_per_cga`) carried by the cubin's `.reqnctapercluster` directive, which re-forms the clusters on a plain launch with the total-CTA grid -- matching the frontend launcher, which sets NO `CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION` for this path (see `ctypes_launcher.py`) and relies on the PTX directive. Record `spec["cluster"]` and assert each grid dim is a multiple of its cluster dim; the Triton `num_ctas > 1` multiplicative path (grid scaled by num_ctas + an explicit cluster launch attr) stays unsupported. Mirrored in both `build_spec` copies -- the collection-side `python/triton/compile_iq/ptx_launch.py` (triton core, after the relocation in the parent diff) and the factory-side `ptx_anneal/ptx_launch.py` -- which are kept in sync. Authored with Claude Code.

Reviewed By: xuzhao9

Differential Revision: D110969685


