### PR TITLE
[ci] remove the use of block ptrs for upstream block ptr deprecation

### DIFF
--- a/.ci/bisect/regression_detector.py
+++ b/.ci/bisect/regression_detector.py
@@ -64,9 +64,9 @@ if __name__ == "__main__":
             exit(e.returncode)
         exit(0)
 
-    assert BASELINE_LOG and os.path.exists(
-        BASELINE_LOG
-    ), f"BASELINE_LOG is not set or to a non-exist location: {BASELINE_LOG}."
+    assert BASELINE_LOG and os.path.exists(BASELINE_LOG), (
+        f"BASELINE_LOG is not set or to a non-exist location: {BASELINE_LOG}."
+    )
     try:
         baseline_signal = get_baseline(BASELINE_LOG)
     except Exception as e:

--- a/benchmarks/compare_benchmarks/run.py
+++ b/benchmarks/compare_benchmarks/run.py
@@ -342,10 +342,22 @@ def run_benchmarks(config: BenchmarkConfig) -> None:
                 )
 
                 lhs_log = run_benchmark_with_logs(
-                    op, lhs_benchmark, config, output_dir, label, input_loader, scaling_pair
+                    op,
+                    lhs_benchmark,
+                    config,
+                    output_dir,
+                    label,
+                    input_loader,
+                    scaling_pair,
                 )
                 rhs_log = run_benchmark_with_logs(
-                    op, rhs_benchmark, config, output_dir, label, input_loader, scaling_pair
+                    op,
+                    rhs_benchmark,
+                    config,
+                    output_dir,
+                    label,
+                    input_loader,
+                    scaling_pair,
                 )
 
                 if not lhs_log or not rhs_log:

--- a/benchmarks/compare_benchmarks/utils.py
+++ b/benchmarks/compare_benchmarks/utils.py
@@ -216,13 +216,19 @@ def log_benchmark(
                 scale_dtype = torch.float32
                 scale_a_recipe = (
                     _scale_recipe(
-                        (m_dim, k_dim), mat_dtype, (scale_a_row, scale_a_col), scale_dtype
+                        (m_dim, k_dim),
+                        mat_dtype,
+                        (scale_a_row, scale_a_col),
+                        scale_dtype,
                     )
                     or None
                 )
                 scale_b_recipe = (
                     _scale_recipe(
-                        (k_dim, n_dim), mat_dtype, (scale_b_row, scale_b_col), scale_dtype
+                        (k_dim, n_dim),
+                        mat_dtype,
+                        (scale_b_row, scale_b_col),
+                        scale_dtype,
                     )
                     or None
                 )

--- a/test/test_gpu/main.py
+++ b/test/test_gpu/main.py
@@ -152,9 +152,9 @@ def check_ci_output(op):
     )
     # Make sure that all the ci_enabled impls are in the output
     logger.info(f"output impls: {output_impls}, ci_enabled impls: {ci_enabled_impls}")
-    assert set(output_impls) == set(
-        ci_enabled_impls
-    ), f"output impls: {output_impls} != ci_enabled impls: {ci_enabled_impls}"
+    assert set(output_impls) == set(ci_enabled_impls), (
+        f"output impls: {output_impls} != ci_enabled impls: {ci_enabled_impls}"
+    )
 
 
 class MaybeTestOperatorTask:

--- a/tritonbench/kernels/triton_fused_attention.py
+++ b/tritonbench/kernels/triton_fused_attention.py
@@ -149,8 +149,8 @@ def _attn_fwd_inner_autows(
     l_i,
     m_i,
     q,  #
-    K_block_ptr,
-    V_block_ptr,  #
+    K_ptrs,
+    V_ptrs,  #
     desc_k,
     desc_v,
     Q,
@@ -182,8 +182,8 @@ def _attn_fwd_inner_autows(
     else:
         lo, hi = 0, N_CTX
     if not ENABLE_TMA:
-        K_block_ptr = tl.advance(K_block_ptr, (0, lo))
-        V_block_ptr = tl.advance(V_block_ptr, (lo, 0))
+        K_ptrs += lo * stride_kn
+        V_ptrs += lo * stride_vk
     # loop over k, v and update accumulator
     for start_n in tl.range(
         lo, hi, BLOCK_N, warp_specialize=WARP_SPECIALIZE
@@ -195,7 +195,7 @@ def _attn_fwd_inner_autows(
                 [start_n.to(tl.int32) + (qvk_offset // stride_kn).to(tl.int32), 0]
             )
         else:
-            k = tl.load(K_block_ptr)
+            k = tl.load(K_ptrs)
         if ENABLE_TMA:
             k = tl.trans(k)
         if ENABLE_TMA:
@@ -207,13 +207,13 @@ def _attn_fwd_inner_autows(
             else:
                 v = desc_v.load([(qvk_offset // stride_vk + start_n).to(tl.int32), 0])
         else:
-            v = tl.load(V_block_ptr)
+            v = tl.load(V_ptrs)
         l_i, m_i, acc = _attn_fwd_iteration(
             q, k, offs_m, start_n, offs_n, qk_scale, l_i, m_i, acc, v, fp8_v, STAGE
         )
         if not ENABLE_TMA:
-            V_block_ptr = tl.advance(V_block_ptr, (BLOCK_N, 0))
-            K_block_ptr = tl.advance(K_block_ptr, (0, BLOCK_N))
+            V_ptrs += BLOCK_N * stride_vk
+            K_ptrs += BLOCK_N * stride_kn
     return acc, l_i, m_i
 
 
@@ -223,8 +223,8 @@ def _attn_fwd_inner(
     l_i,
     m_i,
     q,  #
-    K_block_ptr,
-    V_block_ptr,  #
+    K_ptrs,
+    V_ptrs,  #
     desc_k,
     desc_v,
     Q,
@@ -255,8 +255,8 @@ def _attn_fwd_inner(
     else:
         lo, hi = 0, N_CTX
     if not ENABLE_TMA:
-        K_block_ptr = tl.advance(K_block_ptr, (0, lo))
-        V_block_ptr = tl.advance(V_block_ptr, (lo, 0))
+        K_ptrs += lo * stride_kn
+        V_ptrs += lo * stride_vk
     # loop over k, v and update accumulator
     for start_n in tl.range(lo, hi, BLOCK_N):
         start_n = tl.multiple_of(start_n, BLOCK_N)
@@ -266,7 +266,7 @@ def _attn_fwd_inner(
                 [start_n.to(tl.int32) + (qvk_offset // stride_kn).to(tl.int32), 0]
             )
         else:
-            k = tl.load(K_block_ptr)
+            k = tl.load(K_ptrs)
         if ENABLE_TMA:
             k = tl.trans(k)
         if ENABLE_TMA:
@@ -278,13 +278,13 @@ def _attn_fwd_inner(
             else:
                 v = desc_v.load([(qvk_offset // stride_vk + start_n).to(tl.int32), 0])
         else:
-            v = tl.load(V_block_ptr)
+            v = tl.load(V_ptrs)
         l_i, m_i, acc = _attn_fwd_iteration(
             q, k, offs_m, start_n, offs_n, qk_scale, l_i, m_i, acc, v, fp8_v, STAGE
         )
         if not ENABLE_TMA:
-            V_block_ptr = tl.advance(V_block_ptr, (BLOCK_N, 0))
-            K_block_ptr = tl.advance(K_block_ptr, (0, BLOCK_N))
+            V_ptrs += BLOCK_N * stride_vk
+            K_ptrs += BLOCK_N * stride_kn
     return acc, l_i, m_i
 
 
@@ -294,8 +294,8 @@ def _attn_fwd_inner_ws(
     l_i,
     m_i,
     q,  #
-    K_block_ptr,
-    V_block_ptr,  #
+    K_ptrs,
+    V_ptrs,  #
     desc_k,
     desc_v,
     Q,
@@ -326,8 +326,8 @@ def _attn_fwd_inner_ws(
     else:
         lo, hi = 0, N_CTX
     if not ENABLE_TMA:
-        K_block_ptr = tl.advance(K_block_ptr, (0, lo))
-        V_block_ptr = tl.advance(V_block_ptr, (lo, 0))
+        K_ptrs += lo * stride_kn
+        V_ptrs += lo * stride_vk
     # loop over k, v and update accumulator
     for start_n in tl.range(lo, hi, BLOCK_N):  # , loop_schedule=LOOP_SCHEDULE):
         start_n = tl.multiple_of(start_n, BLOCK_N)
@@ -339,9 +339,13 @@ def _attn_fwd_inner_ws(
         else:
             # fp8 types don't support padding_option="zero" (Triton can't cast int32 to fp8)
             if fp8_v:
-                k = tl.load(K_block_ptr)
+                k = tl.load(K_ptrs)
             else:
-                k = tl.load(K_block_ptr, boundary_check=(1,), padding_option="zero")
+                k = tl.load(
+                    K_ptrs,
+                    mask=start_n + offs_n[None, :] < N_CTX,
+                    other=0.0,
+                )
         if ENABLE_TMA:
             k = tl.trans(k)
         qk = tl.dot(q, k)
@@ -370,9 +374,13 @@ def _attn_fwd_inner_ws(
                 v = desc_v.load([(qvk_offset // stride_vk + start_n).to(tl.int32), 0])
         else:
             if fp8_v:
-                v = tl.load(V_block_ptr)
+                v = tl.load(V_ptrs)
             else:
-                v = tl.load(V_block_ptr, boundary_check=(0,), padding_option="zero")
+                v = tl.load(
+                    V_ptrs,
+                    mask=start_n + offs_n[:, None] < N_CTX,
+                    other=0.0,
+                )
         if fp8_v:
             if ENABLE_TMA:
                 v = tl.trans(v)
@@ -383,8 +391,8 @@ def _attn_fwd_inner_ws(
         # update m_i and l_i
         m_i = m_ij
         if not ENABLE_TMA:
-            V_block_ptr = tl.advance(V_block_ptr, (BLOCK_N, 0))
-            K_block_ptr = tl.advance(K_block_ptr, (0, BLOCK_N))
+            V_ptrs += BLOCK_N * stride_vk
+            K_ptrs += BLOCK_N * stride_kn
     return acc, l_i, m_i
 
 
@@ -714,44 +722,34 @@ def _attn_fwd_compute(
     off_h = off_hz % H
     qvk_offset = off_z.to(tl.int64) * stride_qz + off_h.to(tl.int64) * stride_qh
 
-    K_block_ptr = None
-    V_block_ptr = None
-    Q_block_ptr = None
-    O_block_ptr = None
+    K_ptrs = None
+    V_ptrs = None
+    Q_ptrs = None
+    O_ptrs = None
     if not ENABLE_TMA:
-        # block pointers
-        Q_block_ptr = tl.make_block_ptr(
-            base=Q + qvk_offset,
-            shape=(N_CTX, HEAD_DIM),
-            strides=(stride_qm, stride_qk),
-            offsets=(start_m * BLOCK_M, 0),
-            block_shape=(BLOCK_M, HEAD_DIM),
-            order=(1, 0),
+        Q_ptrs = (
+            Q
+            + qvk_offset
+            + (start_m * BLOCK_M + tl.arange(0, BLOCK_M))[:, None] * stride_qm
+            + tl.arange(0, HEAD_DIM)[None, :] * stride_qk
         )
-        v_order: tl.constexpr = (0, 1) if V.dtype.element_ty == tl.float8e5 else (1, 0)
-        V_block_ptr = tl.make_block_ptr(
-            base=V + qvk_offset,
-            shape=(N_CTX, HEAD_DIM),
-            strides=(stride_vk, stride_vn),
-            offsets=(0, 0),
-            block_shape=(BLOCK_N, HEAD_DIM),
-            order=v_order,
+        V_ptrs = (
+            V
+            + qvk_offset
+            + tl.arange(0, BLOCK_N)[:, None] * stride_vk
+            + tl.arange(0, HEAD_DIM)[None, :] * stride_vn
         )
-        K_block_ptr = tl.make_block_ptr(
-            base=K + qvk_offset,
-            shape=(HEAD_DIM, N_CTX),
-            strides=(stride_kk, stride_kn),
-            offsets=(0, 0),
-            block_shape=(HEAD_DIM, BLOCK_N),
-            order=(0, 1),
+        K_ptrs = (
+            K
+            + qvk_offset
+            + tl.arange(0, HEAD_DIM)[:, None] * stride_kk
+            + tl.arange(0, BLOCK_N)[None, :] * stride_kn
         )
-        O_block_ptr = tl.make_block_ptr(
-            base=Out + qvk_offset,
-            shape=(N_CTX, HEAD_DIM),
-            strides=(stride_om, stride_on),
-            offsets=(start_m * BLOCK_M, 0),
-            block_shape=(BLOCK_M, HEAD_DIM),
-            order=(1, 0),
+        O_ptrs = (
+            Out
+            + qvk_offset
+            + (start_m * BLOCK_M + tl.arange(0, BLOCK_M))[:, None] * stride_om
+            + tl.arange(0, HEAD_DIM)[None, :] * stride_on
         )
     # initialize offsets
     offs_m = start_m * BLOCK_M + tl.arange(0, BLOCK_M)
@@ -769,9 +767,9 @@ def _attn_fwd_compute(
     else:
         # fp8 types don't support padding_option="zero" (Triton can't cast int32 to fp8)
         if V.dtype.element_ty == tl.float8e5:
-            q = tl.load(Q_block_ptr)
+            q = tl.load(Q_ptrs)
         else:
-            q = tl.load(Q_block_ptr, boundary_check=(0,), padding_option="zero")
+            q = tl.load(Q_ptrs, mask=offs_m[:, None] < N_CTX, other=0.0)
     # stage 1: off-band
     # For causal = True, STAGE = 3 and _attn_fwd_inner gets 1 as its STAGE
     # For causal = False, STAGE = 1, and _attn_fwd_inner gets 3 as its STAGE
@@ -782,8 +780,8 @@ def _attn_fwd_compute(
                 l_i,
                 m_i,
                 q,
-                K_block_ptr,
-                V_block_ptr,  #
+                K_ptrs,
+                V_ptrs,  #
                 desc_k,
                 desc_v,
                 Q,
@@ -811,8 +809,8 @@ def _attn_fwd_compute(
                 l_i,
                 m_i,
                 q,
-                K_block_ptr,
-                V_block_ptr,  #
+                K_ptrs,
+                V_ptrs,  #
                 desc_k,
                 desc_v,
                 Q,
@@ -844,8 +842,8 @@ def _attn_fwd_compute(
                 l_i,
                 m_i,
                 q,
-                K_block_ptr,
-                V_block_ptr,  #
+                K_ptrs,
+                V_ptrs,  #
                 desc_k,
                 desc_v,
                 Q,
@@ -873,8 +871,8 @@ def _attn_fwd_compute(
                 l_i,
                 m_i,
                 q,
-                K_block_ptr,
-                V_block_ptr,  #
+                K_ptrs,
+                V_ptrs,  #
                 desc_k,
                 desc_v,
                 Q,
@@ -907,7 +905,7 @@ def _attn_fwd_compute(
             acc.to(Out.type.element_ty),
         )
     else:
-        tl.store(O_block_ptr, acc.to(Out.type.element_ty), boundary_check=(0,))
+        tl.store(O_ptrs, acc.to(Out.type.element_ty), mask=offs_m[:, None] < N_CTX)
 
 
 @triton.jit
@@ -956,44 +954,34 @@ def _attn_fwd_compute_ws(
     off_h = off_hz % H
     qvk_offset = off_z.to(tl.int64) * stride_qz + off_h.to(tl.int64) * stride_qh
 
-    K_block_ptr = None
-    V_block_ptr = None
-    Q_block_ptr = None
-    O_block_ptr = None
+    K_ptrs = None
+    V_ptrs = None
+    Q_ptrs = None
+    O_ptrs = None
     if not ENABLE_TMA:
-        # block pointers
-        Q_block_ptr = tl.make_block_ptr(
-            base=Q + qvk_offset,
-            shape=(N_CTX, HEAD_DIM),
-            strides=(stride_qm, stride_qk),
-            offsets=(start_m * BLOCK_M, 0),
-            block_shape=(BLOCK_M, HEAD_DIM),
-            order=(1, 0),
+        Q_ptrs = (
+            Q
+            + qvk_offset
+            + (start_m * BLOCK_M + tl.arange(0, BLOCK_M))[:, None] * stride_qm
+            + tl.arange(0, HEAD_DIM)[None, :] * stride_qk
         )
-        v_order: tl.constexpr = (0, 1) if V.dtype.element_ty == tl.float8e5 else (1, 0)
-        V_block_ptr = tl.make_block_ptr(
-            base=V + qvk_offset,
-            shape=(N_CTX, HEAD_DIM),
-            strides=(stride_vk, stride_vn),
-            offsets=(0, 0),
-            block_shape=(BLOCK_N, HEAD_DIM),
-            order=v_order,
+        V_ptrs = (
+            V
+            + qvk_offset
+            + tl.arange(0, BLOCK_N)[:, None] * stride_vk
+            + tl.arange(0, HEAD_DIM)[None, :] * stride_vn
         )
-        K_block_ptr = tl.make_block_ptr(
-            base=K + qvk_offset,
-            shape=(HEAD_DIM, N_CTX),
-            strides=(stride_kk, stride_kn),
-            offsets=(0, 0),
-            block_shape=(HEAD_DIM, BLOCK_N),
-            order=(0, 1),
+        K_ptrs = (
+            K
+            + qvk_offset
+            + tl.arange(0, HEAD_DIM)[:, None] * stride_kk
+            + tl.arange(0, BLOCK_N)[None, :] * stride_kn
         )
-        O_block_ptr = tl.make_block_ptr(
-            base=Out + qvk_offset,
-            shape=(N_CTX, HEAD_DIM),
-            strides=(stride_om, stride_on),
-            offsets=(start_m * BLOCK_M, 0),
-            block_shape=(BLOCK_M, HEAD_DIM),
-            order=(1, 0),
+        O_ptrs = (
+            Out
+            + qvk_offset
+            + (start_m * BLOCK_M + tl.arange(0, BLOCK_M))[:, None] * stride_om
+            + tl.arange(0, HEAD_DIM)[None, :] * stride_on
         )
     # initialize offsets
     offs_m = start_m * BLOCK_M + tl.arange(0, BLOCK_M)
@@ -1009,7 +997,7 @@ def _attn_fwd_compute_ws(
     if ENABLE_TMA:
         q = desc_q.load([(qvk_offset // stride_qm + start_m * BLOCK_M).to(tl.int32), 0])
     else:
-        q = tl.load(Q_block_ptr)
+        q = tl.load(Q_ptrs)
     # stage 1: off-band
     # For causal = True, STAGE = 3 and _attn_fwd_inner gets 1 as its STAGE
     # For causal = False, STAGE = 1, and _attn_fwd_inner gets 3 as its STAGE
@@ -1019,8 +1007,8 @@ def _attn_fwd_compute_ws(
             l_i,
             m_i,
             q,
-            K_block_ptr,
-            V_block_ptr,  #
+            K_ptrs,
+            V_ptrs,  #
             desc_k,
             desc_v,
             Q,
@@ -1050,8 +1038,8 @@ def _attn_fwd_compute_ws(
             l_i,
             m_i,
             q,
-            K_block_ptr,
-            V_block_ptr,  #
+            K_ptrs,
+            V_ptrs,  #
             desc_k,
             desc_v,
             Q,
@@ -1083,7 +1071,7 @@ def _attn_fwd_compute_ws(
             acc.to(Out.type.element_ty),
         )
     else:
-        tl.store(O_block_ptr, acc.to(Out.type.element_ty))
+        tl.store(O_ptrs, acc.to(Out.type.element_ty))
 
 
 # only supports TMA, and explicit async_task

--- a/tritonbench/operators/gdpa/gdpa.py
+++ b/tritonbench/operators/gdpa/gdpa.py
@@ -78,18 +78,19 @@ def create_dummy_tensor(x):
 def _gdpa_fwd_inner_ws(
     acc,
     q,  #
-    K_block_ptr,
-    V_block_ptr,  #
+    K_ptrs,
+    V_ptrs,  #
     desc_k,
     desc_v,
     kv_offset,
     begin_k,
     stride_kn,
-    stride_kh,
+    stride_vn,
     start_m,
     BLOCK_M: tl.constexpr,
     BLOCK_D: tl.constexpr,
     BLOCK_N: tl.constexpr,  #
+    HEAD_DIM: tl.constexpr,
     STAGE: tl.constexpr,
     offs_m: tl.constexpr,
     offs_n: tl.constexpr,
@@ -118,8 +119,8 @@ def _gdpa_fwd_inner_ws(
         hi = min(hi, (start_m + 1) * BLOCK_M + WINDOW_SIZE)
 
     if not enable_tma:
-        K_block_ptr = tl.advance(K_block_ptr, (0, lo))
-        V_block_ptr = tl.advance(V_block_ptr, (lo, 0))
+        K_ptrs += lo * stride_kn
+        V_ptrs += lo * stride_vn
 
     # loop over k, v and update accumulator
     for start_n in range(lo, hi, BLOCK_N):
@@ -134,7 +135,8 @@ def _gdpa_fwd_inner_ws(
             )
             k = tl.trans(k)
         else:
-            k = tl.load(K_block_ptr, boundary_check=(0, 1), padding_option="zero")
+            k_mask = (offs_d[:, None] < HEAD_DIM) & (start_n + offs_n[None, :] < klen)
+            k = tl.load(K_ptrs, mask=k_mask, other=0.0)
 
         q = q.to(k.dtype)
         qk = tl.dot(q, k)
@@ -165,14 +167,15 @@ def _gdpa_fwd_inner_ws(
                 ],
             )
         else:
-            v = tl.load(V_block_ptr, boundary_check=(0, 1), padding_option="zero")
+            v_mask = (start_n + offs_n[:, None] < klen) & (offs_d[None, :] < HEAD_DIM)
+            v = tl.load(V_ptrs, mask=v_mask, other=0.0)
 
         p = p.to(v_dtype)
         acc = tl.dot(p, v, acc)
 
         if not enable_tma:
-            V_block_ptr = tl.advance(V_block_ptr, (BLOCK_N, 0))
-            K_block_ptr = tl.advance(K_block_ptr, (0, BLOCK_N))
+            V_ptrs += BLOCK_N * stride_vn
+            K_ptrs += BLOCK_N * stride_kn
     return acc
 
 
@@ -335,11 +338,10 @@ def _gdpa_fwd_compute(
     if start_m * BLOCK_M < qlen:
         begin_o = tl.load(Out_offsets + off_z)
 
-        # block pointers
-        Q_block_ptr = None
-        K_block_ptr = None
-        V_block_ptr = None
-        O_block_ptr = None
+        Q_ptrs = None
+        K_ptrs = None
+        V_ptrs = None
+        O_ptrs = None
         desc_q = None
         desc_out = None
         # can not reuse desc_k. jit error
@@ -350,34 +352,28 @@ def _gdpa_fwd_compute(
         offs_n = tl.arange(0, BLOCK_N)
         offs_d = tl.arange(0, BLOCK_D)
         if not enable_tma:
-            Q_block_ptr = tl.make_block_ptr(
-                base=Q + q_offset + begin_q * stride_qm,
-                shape=(qlen, HEAD_DIM),
-                strides=(stride_qm, stride_qk),
-                offsets=(start_m * BLOCK_M, 0),
-                block_shape=(BLOCK_M, BLOCK_D),
-                order=(1, 0),
+            Q_ptrs = (
+                Q
+                + q_offset
+                + begin_q * stride_qm
+                + offs_m[:, None] * stride_qm
+                + offs_d[None, :] * stride_qk
             )
-            v_order: tl.constexpr = (
-                (0, 1) if V.dtype.element_ty == tl.float8e5 else (1, 0)
+            V_ptrs = (
+                V
+                + kv_offset
+                + begin_k * stride_vn
+                + offs_n[:, None] * stride_vn
+                + offs_d[None, :] * stride_vk
             )
-            V_block_ptr = tl.make_block_ptr(
-                base=V + kv_offset + begin_k * stride_vn,
-                shape=(klen, HEAD_DIM),
-                strides=(stride_vn, stride_vk),
-                offsets=(0, 0),
-                block_shape=(BLOCK_N, BLOCK_D),
-                order=v_order,
+            K_ptrs = (
+                K
+                + kv_offset
+                + begin_k * stride_kn
+                + offs_d[:, None] * stride_kk
+                + offs_n[None, :] * stride_kn
             )
-            K_block_ptr = tl.make_block_ptr(
-                base=K + kv_offset + begin_k * stride_kn,
-                shape=(HEAD_DIM, klen),
-                strides=(stride_kk, stride_kn),
-                offsets=(0, 0),
-                block_shape=(BLOCK_D, BLOCK_N),
-                order=(0, 1),
-            )
-            O_block_ptr = (
+            O_ptrs = (
                 Out
                 + off_h.to(tl.int64) * stride_oh
                 + begin_o * stride_om
@@ -421,7 +417,8 @@ def _gdpa_fwd_compute(
                 ],
             )
         else:
-            q = tl.load(Q_block_ptr, boundary_check=(0, 1), padding_option="zero")
+            q_mask = (offs_m[:, None] < qlen) & (offs_d[None, :] < HEAD_DIM)
+            q = tl.load(Q_ptrs, mask=q_mask, other=0.0)
 
         # stage 1: off-band
         # For causal = True, STAGE = 3 and _gdpa_fwd_inner gets 1 as its STAGE
@@ -430,18 +427,19 @@ def _gdpa_fwd_compute(
         acc = _gdpa_fwd_inner_ws(
             acc,
             q,
-            K_block_ptr,
-            V_block_ptr,  #
+            K_ptrs,
+            V_ptrs,  #
             desc_k if IS_DENSE_KV else desc_k_tmp,
             desc_v if IS_DENSE_KV else desc_v_tmp,
             kv_offset,
             begin_k,
             stride_kn,
-            stride_kh,
+            stride_vn,
             start_m,  #
             BLOCK_M,
             BLOCK_D,
             BLOCK_N,  #
+            HEAD_DIM,
             4 - STAGE,
             offs_m,
             offs_n,
@@ -471,7 +469,7 @@ def _gdpa_fwd_compute(
             )
         else:
             o_mask = (offs_m[:, None] < qlen) & (offs_d[None, :] < HEAD_DIM)
-            tl.store(O_block_ptr, acc.to(Out.type.element_ty), mask=o_mask)
+            tl.store(O_ptrs, acc.to(Out.type.element_ty), mask=o_mask)
 
 
 @triton.jit
@@ -1843,9 +1841,9 @@ def generalized_dot_product_attention(
     fused_qkv = key is None and value is None
     fused_kv = key is not None and value is None
     if use_start_end_offsets:
-        assert not fused_qkv and not fused_kv and not broadcast_q, (
-            "fused_qkv/fused_kv/broadcast_q not supported with start/end offsets"
-        )
+        assert (
+            not fused_qkv and not fused_kv and not broadcast_q
+        ), "fused_qkv/fused_kv/broadcast_q not supported with start/end offsets"
         assert total_num_objects is not None, "total_num_objects must be provided"
 
     if qk_scale is None:

--- a/tritonbench/operators/gdpa/gdpa.py
+++ b/tritonbench/operators/gdpa/gdpa.py
@@ -1841,9 +1841,9 @@ def generalized_dot_product_attention(
     fused_qkv = key is None and value is None
     fused_kv = key is not None and value is None
     if use_start_end_offsets:
-        assert (
-            not fused_qkv and not fused_kv and not broadcast_q
-        ), "fused_qkv/fused_kv/broadcast_q not supported with start/end offsets"
+        assert not fused_qkv and not fused_kv and not broadcast_q, (
+            "fused_qkv/fused_kv/broadcast_q not supported with start/end offsets"
+        )
         assert total_num_objects is not None, "total_num_objects must be provided"
 
     if qk_scale is None:

--- a/tritonbench/operators/template_attention/triton_attention.py
+++ b/tritonbench/operators/template_attention/triton_attention.py
@@ -78,33 +78,13 @@ def triton_tem_fused_no_exp2(
     off_hz = tl.program_id(1)
 
     qkv_offset = off_hz * stride_qh
-    Q_block_ptr = tl.make_block_ptr(
-        base=Q + qkv_offset,
-        shape=(N_CTX, BLOCK_DMODEL),
-        strides=(stride_qm, stride_qk),
-        offsets=(start_m * BLOCK_M, 0),
-        block_shape=(BLOCK_M, BLOCK_DMODEL),
-        order=(1, 0),
-    )
-    K_block_ptr = tl.make_block_ptr(
-        base=K + qkv_offset,
-        shape=(BLOCK_DMODEL, N_CTX),
-        strides=(stride_kk, stride_kn),
-        offsets=(0, 0),
-        block_shape=(BLOCK_DMODEL, BLOCK_N),
-        order=(0, 1),
-    )
-    V_block_ptr = tl.make_block_ptr(
-        base=V + qkv_offset,
-        shape=(N_CTX, BLOCK_DMODEL),
-        strides=(stride_vk, stride_vn),
-        offsets=(0, 0),
-        block_shape=(BLOCK_N, BLOCK_DMODEL),
-        order=(1, 0),
-    )
     # initialize offsets
     offs_m = start_m * BLOCK_M + tl.arange(0, BLOCK_M)
     offs_n = tl.arange(0, BLOCK_N)
+    offs_d = tl.arange(0, BLOCK_DMODEL)
+    Q_ptrs = Q + qkv_offset + offs_m[:, None] * stride_qm + offs_d[None, :] * stride_qk
+    K_ptrs = K + qkv_offset + offs_d[:, None] * stride_kk + offs_n[None, :] * stride_kn
+    V_ptrs = V + qkv_offset + offs_n[:, None] * stride_vk + offs_d[None, :] * stride_vn
     # initialize pointer to m and l
     m_i = tl.zeros([BLOCK_M], dtype=tl.float32) - float("inf")
     l_i = tl.zeros([BLOCK_M], dtype=tl.float32)
@@ -114,7 +94,7 @@ def triton_tem_fused_no_exp2(
     # don't work as expected with `exp` in the loop
     # TODO fix me
     # qk_scale = sm_scale * 1.44269504
-    q = tl.load(Q_block_ptr)
+    q = tl.load(Q_ptrs)
     q = (q * qk_scale).to(MATMUL_PRECISION)
     # loop over k, v and update accumulator
     lo = 0
@@ -122,8 +102,8 @@ def triton_tem_fused_no_exp2(
     for start_n in range(lo, hi, BLOCK_N):
         start_n = tl.multiple_of(start_n, BLOCK_N)
         # -- load k, v --
-        k = tl.load(K_block_ptr)
-        v = tl.load(V_block_ptr)
+        k = tl.load(K_ptrs)
+        v = tl.load(V_ptrs)
         # -- compute qk ---
         qk = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float32)
         qk += tl.dot(q, k.to(MATMUL_PRECISION))
@@ -164,8 +144,8 @@ def triton_tem_fused_no_exp2(
         l_i = l_i * alpha + tl.sum(p, 1)
         m_i = m_i_new
         # update pointers
-        K_block_ptr = tl.advance(K_block_ptr, (0, BLOCK_N))
-        V_block_ptr = tl.advance(V_block_ptr, (BLOCK_N, 0))
+        K_ptrs += BLOCK_N * stride_kn
+        V_ptrs += BLOCK_N * stride_vk
 
     # write back l and m
     acc = acc / l_i[:, None]
@@ -254,39 +234,19 @@ def triton_tem_fused_with_exp2(
     off_hz = tl.program_id(1)
 
     qkv_offset = off_hz * stride_qh
-    Q_block_ptr = tl.make_block_ptr(
-        base=Q + qkv_offset,
-        shape=(N_CTX, BLOCK_DMODEL),
-        strides=(stride_qm, stride_qk),
-        offsets=(start_m * BLOCK_M, 0),
-        block_shape=(BLOCK_M, BLOCK_DMODEL),
-        order=(1, 0),
-    )
-    K_block_ptr = tl.make_block_ptr(
-        base=K + qkv_offset,
-        shape=(BLOCK_DMODEL, N_CTX),
-        strides=(stride_kk, stride_kn),
-        offsets=(0, 0),
-        block_shape=(BLOCK_DMODEL, BLOCK_N),
-        order=(0, 1),
-    )
-    V_block_ptr = tl.make_block_ptr(
-        base=V + qkv_offset,
-        shape=(N_CTX, BLOCK_DMODEL),
-        strides=(stride_vk, stride_vn),
-        offsets=(0, 0),
-        block_shape=(BLOCK_N, BLOCK_DMODEL),
-        order=(1, 0),
-    )
     # initialize offsets
     offs_m = start_m * BLOCK_M + tl.arange(0, BLOCK_M)
     offs_n = tl.arange(0, BLOCK_N)
+    offs_d = tl.arange(0, BLOCK_DMODEL)
+    Q_ptrs = Q + qkv_offset + offs_m[:, None] * stride_qm + offs_d[None, :] * stride_qk
+    K_ptrs = K + qkv_offset + offs_d[:, None] * stride_kk + offs_n[None, :] * stride_kn
+    V_ptrs = V + qkv_offset + offs_n[:, None] * stride_vk + offs_d[None, :] * stride_vn
     # initialize pointer to m and l
     m_i = tl.zeros([BLOCK_M], dtype=tl.float32) - float("inf")
     l_i = tl.zeros([BLOCK_M], dtype=tl.float32)
     acc = tl.zeros([BLOCK_M, BLOCK_DMODEL], dtype=tl.float32)
 
-    q = tl.load(Q_block_ptr)
+    q = tl.load(Q_ptrs)
     if SCORE_MOD_IS_LINEAR:
         qk_scale *= 1.44269504
     q = (q * qk_scale).to(MATMUL_PRECISION)
@@ -296,8 +256,8 @@ def triton_tem_fused_with_exp2(
     for start_n in range(lo, hi, BLOCK_N):
         start_n = tl.multiple_of(start_n, BLOCK_N)
         # -- load k, v --
-        k = tl.load(K_block_ptr)
-        v = tl.load(V_block_ptr)
+        k = tl.load(K_ptrs)
+        v = tl.load(V_ptrs)
         # -- compute qk ---
         qk = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float32)
         qk = tl.dot(q, k.to(MATMUL_PRECISION), acc=qk)
@@ -338,8 +298,8 @@ def triton_tem_fused_with_exp2(
         l_i = l_i * alpha + tl.sum(p, 1)
         m_i = m_i_new
         # update pointers
-        K_block_ptr = tl.advance(K_block_ptr, (0, BLOCK_N))
-        V_block_ptr = tl.advance(V_block_ptr, (BLOCK_N, 0))
+        K_ptrs += BLOCK_N * stride_kn
+        V_ptrs += BLOCK_N * stride_vk
 
     # write back l and m
     acc = acc / l_i[:, None]


### PR DESCRIPTION
Upstream removed block pointer support: https://github.com/triton-lang/triton/commit/9debefe44117a44c274b05033cfe9e4858883b86

We need to change the kernels to remove block pointer semantics.