### PR TITLE
[tlx] Guard torch_tlx_* providers on torch's tlx_mode inductor knob

### DIFF
--- a/tritonbench/operators/addmm/operator.py
+++ b/tritonbench/operators/addmm/operator.py
@@ -13,7 +13,7 @@ from tritonbench.utils.env_utils import (
     is_hip_mi350,
 )
 from tritonbench.utils.python_utils import try_import
-from tritonbench.utils.triton_utils import has_tlx
+from tritonbench.utils.triton_utils import has_tlx, has_torch_tlx
 
 with try_import("HAS_HSTU"):
     try:
@@ -175,7 +175,7 @@ class Operator(BenchmarkOperator):
             compiled(a, mat1, mat2)
         return lambda: compiled(a, mat1, mat2)
 
-    @register_benchmark(enabled=is_hip_mi350() and has_tlx())
+    @register_benchmark(enabled=is_hip_mi350() and has_tlx() and has_torch_tlx())
     def torch_tlx_addmm(self, a, mat1, mat2) -> Callable:
         # torch_tlx_<op> convention: PT2 (torch.compile max-autotune, TRITON
         # backend) with TLX "allow" mode, so TLX templates compete against the

--- a/tritonbench/operators/flex_attention/operator.py
+++ b/tritonbench/operators/flex_attention/operator.py
@@ -41,7 +41,7 @@ from tritonbench.utils.triton_op import (
     register_metric,
     register_x_val,
 )
-from tritonbench.utils.triton_utils import has_tlx
+from tritonbench.utils.triton_utils import has_tlx, has_torch_tlx
 
 from .mods import (
     causal_mask,
@@ -374,7 +374,9 @@ class Operator(BenchmarkOperator):
         return self.compiled(q, k, v, score_mod, block_mask, mod_type, kernel_options)
 
     @register_benchmark(
-        enabled=(is_nvidia_blackwell() or is_amd_gfx950()) and has_tlx(),
+        enabled=(is_nvidia_blackwell() or is_amd_gfx950())
+        and has_tlx()
+        and has_torch_tlx(),
         fwd_only=True,
     )
     def torch_tlx_flex_attention(

--- a/tritonbench/operators/gemm/operator.py
+++ b/tritonbench/operators/gemm/operator.py
@@ -21,7 +21,7 @@ if False:
         blackwell_matmul_tma_persistent,
         blackwell_matmul_tma_persistent_splitk,
     )
-from tritonbench.utils.triton_utils import has_tlx
+from tritonbench.utils.triton_utils import has_tlx, has_torch_tlx
 
 if has_tlx():
     from triton.language.extra.tlx.tutorials.blackwell_gemm_2cta import (
@@ -414,7 +414,7 @@ class Operator(BenchmarkOperator):
 
         return lambda: compiled(a, b)
 
-    @register_benchmark(enabled=IS_BLACKWELL and has_tlx())
+    @register_benchmark(enabled=IS_BLACKWELL and has_tlx() and has_torch_tlx())
     def torch_tlx_mm(self, a, b, bias) -> Callable:
         # torch_tlx_<op> convention: PT2 (torch.compile max-autotune, TRITON
         # backend) with TLX "allow" mode, so TLX templates compete against the

--- a/tritonbench/utils/triton_utils.py
+++ b/tritonbench/utils/triton_utils.py
@@ -35,6 +35,24 @@ def has_tlx():
     return spec is not None
 
 
+@functools.lru_cache
+def has_torch_tlx():
+    """
+    Returns whether the installed torch exposes the inductor `triton.tlx_mode`
+    knob -- the torch-side half of torchTLX. Providers that run TLX templates
+    through torch.compile (torch_tlx_* benchmarks) need this in addition to
+    has_tlx(): has_tlx() only says the Triton TLX module exists, not that torch's
+    inductor config can select it. Older torch builds omit the knob and would
+    otherwise raise AttributeError inside inductor_config.patch(...).
+    """
+    try:
+        import torch._inductor.config as inductor_config
+
+        return hasattr(inductor_config.triton, "tlx_mode")
+    except (ImportError, AttributeError):
+        return False
+
+
 def has_experimental_descriptor():
     import triton.language as tl
 


### PR DESCRIPTION
## Summary

The `torch_tlx_flex_attention`, `torch_tlx_addmm`, and `torch_tlx_mm` providers patch `triton.tlx_mode` via `inductor_config.patch(...)`, but were only gated on `has_tlx()` — which checks that the **Triton** TLX module exists, not that **torch's** inductor config exposes the `tlx_mode` knob.

On a torch build without `torch._inductor.config.triton.tlx_mode` (e.g. the MI350 CI's `torch 2.10.0+rocm7.0`), `inductor_config.patch()` raises `AttributeError` on `__enter__` while saving the prior value of the key — before `torch.compile` even runs — which fails the benchmark:

```
File ".../torch/utils/_config_module.py", line 870, in __enter__
    prior[key] = config.__getattr__(key)
AttributeError: torch._inductor.config.triton.tlx_mode does not exist
```

This was observed on MI350 CI for `flex_attention`; `addmm`/`gemm` carry the same latent bug (their `torch_tlx_*` providers use the identical pattern).

## Change

- Add `has_torch_tlx()` to `triton_utils.py` — the torch-side capability probe (`hasattr(torch._inductor.config.triton, "tlx_mode")`), the mirror of `has_tlx()` for the torch half of torchTLX.
- Require `has_torch_tlx()` on all three `torch_tlx_*` provider gates, so they self-disable when the knob is absent and run unchanged when it's present.

## Test

- `has_torch_tlx()` returns `False` on a torch without the knob (reproduces the CI condition) and `True` when present.
- Syntax + import verified on all four touched files.

🤖 Authored with Claude Code.