### PR TITLE
[ci] re-enable embedding and flash_attention on amd

### DIFF
--- a/test/test_gpu/skip_tests.yaml
+++ b/test/test_gpu/skip_tests.yaml
@@ -63,3 +63,8 @@ mx4_to_fp32:
   devices:
     - cuda
 # ============ TODO: errors in CI ============
+# TODO: embedding will segfault on hip
+embedding:
+  report: true
+  disabled_devices:
+    - hip

--- a/test/test_gpu/skip_tests.yaml
+++ b/test/test_gpu/skip_tests.yaml
@@ -63,12 +63,3 @@ mx4_to_fp32:
   devices:
     - cuda
 # ============ TODO: errors in CI ============
-# TODO: flash_attention will segfault on hip
-flash_attention:
-  report: true
-  disabled_devices:
-    - hip
-embedding:
-  report: true
-  disabled_devices:
-    - hip


### PR DESCRIPTION
Upstream has fixed the segfault error, and we want to re-enable segfault tests on amd.

`embedding` still has segfault error on amd, but the rest of the ops are fine.