### PR TITLE
run HSTU self-attention compiler DP on b200

### DIFF
--- a/test/test_gpu/skip_tests.yaml
+++ b/test/test_gpu/skip_tests.yaml
@@ -49,7 +49,8 @@ hstu_cross_attention_bwd:
 ragged_attention:
   # cuda covers all NVIDIA (keeps existing coverage); the literal b200 entry is
   # required for the b200-only CI filter. This exercises hstu_tlx plus the
-  # default, manual-DP, and DQ-reduce AutoWS self-attention backends on b200.
+  # default, manual-DP, compiler-DP, and DQ-reduce AutoWS self-attention
+  # backends on b200.
   devices:
     - cuda
     - b200

--- a/tritonbench/operators/ragged_attention/operator.py
+++ b/tritonbench/operators/ragged_attention/operator.py
@@ -326,7 +326,7 @@ class Operator(BenchmarkOperator):
             max_seq_len,
         )
 
-    @register_benchmark(enabled=False, fwd_only=True)
+    @register_benchmark(enabled=HAS_HSTU_SELF_ATTN and IS_BLACKWELL, fwd_only=True)
     def hstu_triton_autows_dp2(
         self, q, k, v, seq_offsets, num_targets, max_seq_len, sparsity
     ):


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookexperimental/triton/pull/2522

Enable the existing hstu_triton_autows_dp2 forward backend on Blackwell so the ragged_attention b200 CI coverage added by D113302925 exercises compiler-generated data partitioning alongside the default, manual-DP, and DQ-reduce variants.

Update both TritonBench CI skip-list descriptions to match the enabled backend set.

Authored with Claude.

Reviewed By: xuzhao9

Differential Revision: D113991746


