### PR TITLE
[TPU] Compare accuracy by value, not storage dtype, on TPU

### DIFF
--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -1630,6 +1630,15 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
 
         return grads
 
+    @property
+    def _accuracy_check_dtype(self) -> bool:
+        # On TPU, --precision force-casts inputs to bf16, but an impl may
+        # legitimately compute/return a higher-precision result (e.g. a loss
+        # reduction kept in fp32) while the eager baseline returns bf16. Those
+        # agree in value but not in storage dtype; compare values (not dtype)
+        # on TPU. Keep strict dtype checks on every other device.
+        return self.device != "tpu"
+
     def _check_gradients(self, grads, baseline_grads, mode=""):
         """Helper to check gradients between two sets of tensors.
 
@@ -1674,6 +1683,7 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
                     baseline_grad,
                     rtol=self.tb_args.rtol,
                     atol=self.tb_args.atol,
+                    check_dtype=self._accuracy_check_dtype,
                     msg=f"{prefix}Gradient mismatch for tensor {i} with shape {grad.shape}",
                 )
 
@@ -1785,6 +1795,7 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
                         baseline_output,
                         rtol=self.tb_args.rtol,
                         atol=self.tb_args.atol,
+                        check_dtype=self._accuracy_check_dtype,
                     )
             elif self.mode == Mode.BWD:
                 # Get tensors with gradients from both implementations
@@ -1828,6 +1839,7 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
                             baseline_fwd_output,
                             rtol=self.tb_args.rtol,
                             atol=self.tb_args.atol,
+                            check_dtype=self._accuracy_check_dtype,
                         )
 
                     # Check backward gradients using helper
@@ -1854,6 +1866,7 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
                         baseline_output,
                         rtol=self.tb_args.rtol,
                         atol=self.tb_args.atol,
+                        check_dtype=self._accuracy_check_dtype,
                     )
             return True
         except Exception as e:


### PR DESCRIPTION
On TPU the benchmark bridge runs with `--precision bf16`, which force-casts operator inputs to bf16. Some impls legitimately return a higher-precision result — e.g. `kl_div` keeps its loss reduction in fp32 — while the eager baseline returns bf16. The values agree within tolerance, but `torch.testing.assert_close`'s default `check_dtype=True` fails on the dtype alone, so those kernels report spurious accuracy failures on the TPU bridge. On GPU the same ops run fp32 on both sides (`bypass` precision), so the mismatch never appears.

This adds a device-scoped `_accuracy_check_dtype` (strict everywhere except TPU) and threads `check_dtype` into the accuracy and gradient `assert_close` calls, so on TPU the check compares values (dtypes promoted to a common type) rather than storage dtype. The determinism check is left strict. No-op on non-TPU devices.

Verified on a TPU v7 pod: `kl_div` accuracy flips 0 → 1 with this change — the values were already within the 1e-2 tolerance; only the dtype gate was failing.
