### PR TITLE
[install] exclude fbgemm when --all specified

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -18,10 +18,10 @@ If you run `python install.py` without any argument, it will do the following:
 - `--liger`: Install [liger-kernel-nightly](https://github.com/linkedin/Liger-Kernel) package (Triton).
 - `--fa3`: Install Flash Attention 3 (CUTLASS).
 - `--fa2`: Install Flash Attention 2 (CUTLASS).
-- `--fbgemm`: Install FBGEMM GPU kernels.
+- `--fbgemm`: Install FBGEMM GPU kernels. This is not included by `--all`.
 - `--mslk`: Install MSLK kernels (CUTLASS and Triton).
 - `--jax`: Install JAX (Pallas and Mosaic).
 - `--tk`: Install [ThunderKittens](https://github.com/HazyResearch/ThunderKittens).
 - `--tile`: Install [Tile Lang](https://github.com/tile-ai/tilelang).
 - `--aiter`: Install [AITer](https://github.com/ROCm/aiter).
-- `--all`: Install all of the above.
+- `--all`: Install the default set of custom kernel repos, excluding FBGEMM.

--- a/install.py
+++ b/install.py
@@ -94,7 +94,11 @@ def setup_hip(args: argparse.Namespace):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(allow_abbrev=False)
     parser.add_argument("--numpy", action="store_true", help="Install suggested numpy")
-    parser.add_argument("--fbgemm", action="store_true", help="Install prebuilt FBGEMM")
+    parser.add_argument(
+        "--fbgemm",
+        action="store_true",
+        help="Install prebuilt FBGEMM (not included by --all)",
+    )
     parser.add_argument("--mslk", action="store_true", help="Install prebuilt MSLK")
     parser.add_argument(
         "--mslk-compile",
@@ -128,7 +132,9 @@ if __name__ == "__main__":
         help="Build the INT21 RMSNorm CUDA (sm_100a) kernel and export it as a PyTorch custom op",
     )
     parser.add_argument(
-        "--all", action="store_true", help="Install all custom kernel repos"
+        "--all",
+        action="store_true",
+        help="Install the default custom kernel repos (excluding FBGEMM)",
     )
     args = parser.parse_args()
 
@@ -159,7 +165,7 @@ if __name__ == "__main__":
         from tools.flash_attn.install import install_fa3
 
         install_fa3()
-    if args.fbgemm or args.all:
+    if args.fbgemm:
         logger.info("[tritonbench] installing prebuilt FBGEMM GPU...")
         from tools.fbgemm.install import install_fbgemm, test_fbgemm
 


### PR DESCRIPTION
Disable fbgemm install when `--all` is specified.

We found fbgemm nightly is often flaky and breaks the ci: https://github.com/facebookexperimental/triton/actions/runs/30637547731

We are not testing tbe kernels, and major Triton kernels have been migrated to mslk. So it should be safe to skip fbgemm install by default.