### PR TITLE
[TPU] Run welford at the requested --precision instead of hardcoded bf16

### DIFF
--- a/tritonbench/operators/welford/operator.py
+++ b/tritonbench/operators/welford/operator.py
@@ -125,9 +125,13 @@ class Operator(BenchmarkOperator):
     def get_input_iter(self) -> Generator:
         for shape in self.shapes:
             s, d = shape
-            p1 = rand_strided((d,), (1,), device=self.device, dtype=torch.bfloat16)
-            p2 = rand_strided((d,), (1,), device=self.device, dtype=torch.bfloat16)
-            p3 = rand_strided((s, d), (d, 1), device=self.device, dtype=torch.bfloat16)
+            # Honor --precision so callers can request fp32; welford's bf16
+            # layer-norm output trips the 1e-2 accuracy tolerance on near-zero
+            # values. Default to bf16 (self.dtype is None when precision is unset).
+            dt = self.dtype or torch.bfloat16
+            p1 = rand_strided((d,), (1,), device=self.device, dtype=dt)
+            p2 = rand_strided((d,), (1,), device=self.device, dtype=dt)
+            p3 = rand_strided((s, d), (d, 1), device=self.device, dtype=dt)
             yield p1, p2, p3
 
     def accuracy(self, fn: Callable, baseline_fn: Callable) -> bool:

--- a/tritonbench/operators/welford/triton_welford.py
+++ b/tritonbench/operators/welford/triton_welford.py
@@ -235,7 +235,8 @@ def fused_native_layer_norm_no_welford(primals_1, primals_2, primals_3):
         buf2 = empty_strided_cuda((S, 1), (1, S), torch.float32)
         buf3 = reinterpret_tensor(buf2, (S, 1), (1, 1), 0)
         del buf2  # reuse
-        buf4 = empty_strided_cuda((S, D), (D, 1), torch.bfloat16)
+        # Output dtype tracks the input so accuracy()'s dtype check holds at any precision.
+        buf4 = empty_strided_cuda((S, D), (D, 1), primals_3.dtype)
         # Source Nodes: [fn], Original ATen: [aten.native_layer_norm]
         stream0 = get_raw_stream(0)
         grid = lambda META: (triton.cdiv(S, META["XBLOCK"]),)
@@ -260,7 +261,8 @@ def fused_native_layer_norm(primals_1, primals_2, primals_3):
         buf1 = empty_strided_cuda((S, 1), (1, S), torch.float32)
         buf3 = reinterpret_tensor(buf1, (S, 1), (1, 1), 0)
         del buf1  # reuse
-        buf4 = empty_strided_cuda((S, D), (D, 1), torch.bfloat16)
+        # Output dtype tracks the input so accuracy()'s dtype check holds at any precision.
+        buf4 = empty_strided_cuda((S, D), (D, 1), primals_3.dtype)
         # Source Nodes: [fn], Original ATen: [aten.native_layer_norm]
         stream0 = get_raw_stream(0)
         grid = lambda META: (triton.cdiv(S, META["XBLOCK"]),)


### PR DESCRIPTION
## What

`welford`'s `get_input_iter` hardcoded bf16 inputs and ignored `--precision`. Because `apply_precision` treats `fp32` as a no-op (it only casts for bf16/fp16), a caller could not actually run welford at fp32 — the inputs stayed bf16 regardless of the flag. This makes the operator honor `self.dtype`, defaulting to bf16 when precision is unset (`bypass` → `self.dtype` is `None`) so existing runs are unchanged.

## Why

At bf16 the layer-norm output drifts ~1 ULP on near-zero normalized values and exceeds the operator's own 1e-2 `assert_close` tolerance — for *every* correct implementation, including the pure-PyTorch reference welford compared against `F.layer_norm`. It's inherent bf16 rounding, not a kernel defect, so the accuracy metric reads 0 for all impls at bf16. Running the inputs at fp32 (which matches the canonical `examples/welford.py`) makes the comparison well-conditioned.

Manual verification on TPU (not covered by CI): the operator's accuracy flips 0→1 at `--precision fp32` and stays 0 at bf16.

The two CUDA Triton launchers also allocated their output buffer at hardcoded bf16; they now follow the input dtype, so `accuracy()` (which compares dtype) stays valid when a non-bf16 precision is requested.
