### PR TITLE
Migrate `-c fbcode.platform010_cuda_version` to the cuda constraint modifier

### DIFF
--- a/tritonbench/operators/decoding_attention/operator.py
+++ b/tritonbench/operators/decoding_attention/operator.py
@@ -119,7 +119,7 @@ from dataclasses import astuple, dataclass
 """
 - Runbook
 - Nvidia:
-buck2 run @mode/opt @mode/inplace -c fbcode.enable_gpu_sections=true -c fbcode.nvcc_arch=h100a -c fbcode.platform010_cuda_version=12.4 //pytorch/tritonbench:run -- --op decoding_attention --cudagraph --csv
+buck2 run @mode/opt @mode/inplace -c fbcode.enable_gpu_sections=true -c fbcode.nvcc_arch=h100a -m ovr_config//third-party/cuda/constraints:12.4 //pytorch/tritonbench:run -- --op decoding_attention --cudagraph --csv
 - AMD:
 buck2 run @mode/opt-amd-gpu @mode/inplace -c fbcode.enable_gpu_sections=true -c fbcode.rocm_arch=mi300 //pytorch/tritonbench:run -- --op decoding_attention --cudagraph --csv
 """

--- a/tritonbench/operators/fp8_gemm_rowwise_grouped/operator.py
+++ b/tritonbench/operators/fp8_gemm_rowwise_grouped/operator.py
@@ -27,7 +27,7 @@ To use this benchmark, simply run the buck cmd with the desired command-line arg
 * `--warp_specialization`: Whether to enable warp specialization.
 
 Example usage:
-buck2 run -c fbcode.platform010_cuda_version=12.4  @mode/opt //pytorch/tritonbench:run -- --op fp8_gemm_rowwise_grouped
+buck2 run -m ovr_config//third-party/cuda/constraints:12.4  @mode/opt //pytorch/tritonbench:run -- --op fp8_gemm_rowwise_grouped
 
 Functions/Classes
 -----------------


### PR DESCRIPTION
Summary:
This is the mechanical half of that migration (fbcode/pytorch): every
`-c fbcode.platform010_cuda_version=<V>` invocation becomes
`-m ovr_config//third-party/cuda/constraints:<V>`.

Differential Revision: D114299820


