### PR TITLE
Add Intel XPU support

### DIFF
--- a/test/test_gpu/main.py
+++ b/test/test_gpu/main.py
@@ -14,6 +14,7 @@ from tritonbench.operators_collection import (
     list_operators_by_collection,  # @manual=//pytorch/tritonbench:tritonbench
 )
 from tritonbench.utils.env_utils import (
+    get_current_device,  # @manual=//pytorch/tritonbench:tritonbench
     is_blackwell,  # @manual=//pytorch/tritonbench:tritonbench
     is_fbcode,  # @manual=//pytorch/tritonbench:tritonbench
 )
@@ -40,6 +41,8 @@ def _load_skip_file(skip_file) -> dict:
     with open(skip_file, "r") as f:
         return yaml.safe_load(f) or {}
 
+# Run the suite on whatever accelerator this host exposes (cuda, xpu, ...).
+TEST_DEVICE = get_current_device()
 
 if custom_skip_file := os.environ.get(CUSTOM_SKIP_FILE_ENV):
     # Allow users to override the skip list with a custom yaml file.
@@ -220,7 +223,7 @@ def make_test(operator):
             "--op",
             operator,
             "--device",
-            "cuda",
+            TEST_DEVICE,
             "--num-inputs",
             "1",
             "--test-only",

--- a/test/test_gpu/skip_tests.yaml
+++ b/test/test_gpu/skip_tests.yaml
@@ -3,7 +3,7 @@
 #  op: to skip an entire operator
 #    extra_args: <extra args to pass to the test>
 #    extra_bwd_args: <extra args to pass to the backward test>
-#    devices: <list of devices> (options: "cuda", "hip", "h100", "mi350", "b200", default: ["h100", "mi350"])
+#    devices: <list of devices> (options: "cuda", "hip", "xpu", "h100", "mi350", "b200", default: ["h100", "mi350"])
 #    channels: <list of triton channels> (options: "triton-main", "meta-triton", default: ["triton-main", "meta-triton"])
 # to override the default, specify devices and channels to limit combinations
 # we rely on the code to determine specific backends to skip
@@ -68,3 +68,42 @@ embedding:
   report: true
   disabled_devices:
     - hip
+# TODO: times out on xpu (>10min). The torch_compile backend requests
+# mode="max-autotune-no-cudagraphs" over a 128256x4096 lm_head, which does not
+# converge in CI time on the Intel inductor backend.
+fused_linear_cross_entropy:
+  report: true
+  disabled_devices:
+    - xpu
+# TODO: crashes the Intel Graphics Compiler on xpu ("IGC: Internal Compiler
+# Error: Floating point exception"), which aborts the whole process. Reduced
+# repro: an online-softmax loop whose alpha/p are guarded by
+# `tl.where(m_i_new == float("-inf"), 0, tl.math.exp(...))`; dropping the
+# `== -inf` guard compiles fine, so this is a backend compiler bug rather than
+# something the kernel can work around.
+template_attention:
+  report: true
+  disabled_devices:
+    - xpu
+# TODO: times out on xpu (>30min). The liger/torch_compile backends lower a
+# fused JSD over a 128256-wide vocab, and the Intel inductor backend spends the
+# whole budget in kernel compilation and autotuning.
+fused_linear_jsd:
+  report: true
+  disabled_devices:
+    - xpu
+# TODO: times out on xpu (>30min), same root cause as fused_linear_jsd: the
+# torch_compile backend recompiles the fused geglu for every input shape and
+# does not converge in CI time on the Intel inductor backend.
+geglu:
+  report: true
+  disabled_devices:
+    - xpu
+# TODO: times out on xpu (>30min) in CI. The op does run correctly standalone
+# (~13min for a single input on an Arc B580), but every backend recompiles a
+# large jagged attention kernel from scratch, which is too slow to keep in the
+# per-operator CI budget.
+gdpa:
+  report: true
+  disabled_devices:
+    - xpu

--- a/tritonbench/components/do_bench/run.py
+++ b/tritonbench/components/do_bench/run.py
@@ -11,7 +11,7 @@ from tritonbench.utils.constants import DEFAULT_N_REP, DEFAULT_N_WARMUP
 from tritonbench.utils.cudagraph_utils import CudaGraphConfig
 
 from .common import summarize_statistics
-from .utils import estimate_cuda_runtime_ms, resolve_warmup_and_rep
+from .utils import estimate_gpu_runtime_ms, resolve_warmup_and_rep
 
 # Triton is optional: non-Triton devices (cpu, tpu) can run without it. The
 # Triton-backed timing paths (events, power, cudagraph, the driver benchmarker)
@@ -311,7 +311,7 @@ def _do_bench_profiler(
     )
 
     clear_cache_fn = cache.zero_ if not skip_cache_clearing else lambda *args: None
-    estimate_ms = estimate_cuda_runtime_ms(
+    estimate_ms = estimate_gpu_runtime_ms(
         fn,
         grad_to_none=grad_to_none,
         clear_cache_fn=clear_cache_fn,
@@ -733,7 +733,7 @@ def do_bench_wrapper(
         and device not in ("cpu", "tpu")
         and latency_measure_mode == "triton_do_bench"
     ):
-        estimate_runtime = estimate_cuda_runtime_ms(fn, grad_to_none=grad_to_none)
+        estimate_runtime = estimate_gpu_runtime_ms(fn, grad_to_none=grad_to_none)
         warmup, rep = resolve_warmup_and_rep(
             warmup,
             rep,

--- a/tritonbench/components/do_bench/utils.py
+++ b/tritonbench/components/do_bench/utils.py
@@ -2,6 +2,7 @@ from typing import Callable, Iterable, Optional, Tuple
 
 import torch
 from tritonbench.utils.constants import DEFAULT_WARMUP_REP_BY_ESTIMATED_KERNEL_MS
+from tritonbench.utils.env_utils import get_device_module
 
 
 def resolve_warmup_and_rep(
@@ -19,14 +20,16 @@ def resolve_warmup_and_rep(
     )
 
 
-def estimate_cuda_runtime_ms(
+def estimate_gpu_runtime_ms(
     fn: Callable,
     grad_to_none: Optional[Iterable[torch.Tensor]] = None,
     clear_cache_fn: Optional[Callable[[], None]] = None,
     iters: int = 5,
     prime: bool = True,
 ) -> float:
+    """Estimate the per-iteration runtime of ``fn`` using GPU events."""
     clear_cache_fn = clear_cache_fn or (lambda: None)
+    device_module = get_device_module()
 
     def run_once() -> None:
         if grad_to_none is not None:
@@ -37,13 +40,18 @@ def estimate_cuda_runtime_ms(
 
     if prime:
         run_once()
-        torch.cuda.synchronize()
+        device_module.synchronize()
 
-    start_event = torch.cuda.Event(enable_timing=True)
-    end_event = torch.cuda.Event(enable_timing=True)
+    start_event = device_module.Event(enable_timing=True)
+    end_event = device_module.Event(enable_timing=True)
     start_event.record()
     for _ in range(iters):
         run_once()
     end_event.record()
-    torch.cuda.synchronize()
+    device_module.synchronize()
     return start_event.elapsed_time(end_event) / iters
+
+
+# Deprecated alias: this helper is no longer CUDA-specific. Kept so out-of-tree
+# callers keep working; prefer `estimate_gpu_runtime_ms`.
+estimate_cuda_runtime_ms = estimate_gpu_runtime_ms

--- a/tritonbench/components/kineto/trace.py
+++ b/tritonbench/components/kineto/trace.py
@@ -9,7 +9,7 @@ from typing import Callable, Optional
 import torch
 import torch.profiler as profiler
 from tritonbench.components.do_bench.utils import (
-    estimate_cuda_runtime_ms,
+    estimate_gpu_runtime_ms,
     resolve_warmup_and_rep,
 )
 from tritonbench.utils.constants import DEFAULT_N_REP, DEFAULT_N_WARMUP
@@ -185,7 +185,7 @@ def do_bench_kineto(
     else:
         clear_cache = lambda *args: None
 
-    estimate_ms = estimate_cuda_runtime_ms(fn, clear_cache_fn=clear_cache)
+    estimate_ms = estimate_gpu_runtime_ms(fn, clear_cache_fn=clear_cache)
     warmup, rep = resolve_warmup_and_rep(warmup, rep, estimate_ms)
 
     # Calculate number of iterations based on target rep time

--- a/tritonbench/components/ncu/__init__.py
+++ b/tritonbench/components/ncu/__init__.py
@@ -2,7 +2,7 @@ from typing import Callable
 
 import torch
 from tritonbench.components.do_bench.utils import (
-    estimate_cuda_runtime_ms,
+    estimate_gpu_runtime_ms,
     resolve_warmup_and_rep,
 )
 
@@ -45,7 +45,7 @@ def do_bench_in_task(
     cache = torch.empty(int(256e6 // 4), dtype=torch.int, device="cuda")
 
     if warmup == True:
-        estimate_ms = estimate_cuda_runtime_ms(fn, clear_cache_fn=cache.zero_)
+        estimate_ms = estimate_gpu_runtime_ms(fn, clear_cache_fn=cache.zero_)
         warmup, _ = resolve_warmup_and_rep(warmup, None, estimate_ms)
 
         # compute number of warmup and repeat

--- a/tritonbench/kernels/profile.py
+++ b/tritonbench/kernels/profile.py
@@ -14,6 +14,23 @@ IS_CUDA = tl.constexpr(is_cuda())
 IS_HIP = tl.constexpr(is_hip())
 
 
+def has_gpu_timer() -> bool:
+    """Whether ``time()``/``smid()`` below can be compiled on this platform.
+
+    Only CUDA and HIP expose the required intrinsics. Triton's Intel backend
+    declares ``tl.extra.intel.globaltimer``/``smid``, but both are verbatim
+    copies of the NVIDIA PTX inline asm, so they fail to build on SPIR-V
+    ("Constraints for inline assembly cannot be validated"). The portable
+    replacement, SPIR-V's ``OpReadClockKHR``, needs ``SPV_KHR_shader_clock``,
+    which Triton's SPIR-V translator does not currently allow either.
+
+    Callers should pass ``profile_mem=None`` when this returns False so that
+    the instrumented branches are never instantiated, rather than recording
+    bogus zero timestamps.
+    """
+    return is_cuda() or is_hip()
+
+
 @triton.jit
 def time(_semantic=None):
     if IS_HIP:

--- a/tritonbench/kernels/triton_fused_attention.py
+++ b/tritonbench/kernels/triton_fused_attention.py
@@ -18,6 +18,7 @@ import torch
 import triton
 import triton.language as tl
 from triton import knobs
+from tritonbench.utils.env_utils import get_num_sms
 
 from .attention_utils import (
     HAS_EXPLICIT_WS,  # guard new tuning configs such as num_consumer_groups
@@ -2547,7 +2548,7 @@ class _attention_opt(torch.autograd.Function):
                 1,
             )
 
-        NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+        NUM_SMS = get_num_sms(q.device)
 
         def grid_tma_persistent(META):
             return (
@@ -2565,7 +2566,7 @@ class _attention_opt(torch.autograd.Function):
 
         # TMA descriptors require a global memory allocation
         def alloc_fn(size: int, alignment: int, stream: Optional[int]):
-            return torch.empty(size, device="cuda", dtype=torch.int8)
+            return torch.empty(size, device=q.device, dtype=torch.int8)
 
         if HAS_NEW_TMA:
             triton.set_allocator(alloc_fn)

--- a/tritonbench/operators/bf16xint16_gemm/kernel.py
+++ b/tritonbench/operators/bf16xint16_gemm/kernel.py
@@ -5,7 +5,7 @@ Triton implementation by @jlebar: https://gist.github.com/jlebar/3435b2c00deea53
 import torch
 import triton
 import triton.language as tl
-from tritonbench.utils.env_utils import is_cuda
+from tritonbench.utils.env_utils import is_cuda, is_xpu
 
 
 def get_cuda_autotune_config():
@@ -236,6 +236,9 @@ def get_hip_autotune_config():
 
 def get_autotune_config():
     if is_cuda():
+        return get_cuda_autotune_config()
+    elif is_xpu():
+        # TODO: Add get_xpu_autotune_config() when we have a good config for xpu
         return get_cuda_autotune_config()
     else:
         return get_hip_autotune_config()

--- a/tritonbench/operators/flex_attention/operator.py
+++ b/tritonbench/operators/flex_attention/operator.py
@@ -31,7 +31,13 @@ from tritonbench.operators.flex_attention.triton_autows import (
     autows_flex_attention,
     autows_flex_attention_persistent,
 )
-from tritonbench.utils.env_utils import is_amd_gfx950, is_hip, is_nvidia_blackwell
+from tritonbench.utils.env_utils import (
+    get_current_device,
+    get_num_sms,
+    is_amd_gfx950,
+    is_hip,
+    is_nvidia_blackwell,
+)
 from tritonbench.utils.input import input_filter
 from tritonbench.utils.triton_op import (
     BenchmarkOperator,
@@ -73,6 +79,13 @@ MOD_TYPES = [
 # Soft cap value for the tanh-softcap score_mod, shared by the providers and the
 # eager reference.
 TANH_SOFTCAP = 20
+
+
+def _accel_device() -> str:
+    """Current accelerator device string ("cuda", "xpu", ...), defaulting to
+    "cuda". Used in place of hardcoded "cuda" so this operator's input/mask
+    construction runs on non-CUDA accelerators (e.g. Intel XPU)."""
+    return get_current_device()
 
 
 class FullShape(NamedTuple):
@@ -500,7 +513,7 @@ class Operator(BenchmarkOperator):
 
         if mod_type == "alibi":
             """
-            h = torch.arange(Hq, dtype=torch.float32, device="cuda")
+            h = torch.arange(Hq, dtype=torch.float32, device=_accel_device())
             alibi_slopes = torch.exp2(-((h + 1) * 8.0 / Hq))
             FA_kwargs["alibi_slopes"] = alibi_slopes
 
@@ -693,7 +706,9 @@ class Operator(BenchmarkOperator):
                     "BLOCK_M2": 64,
                     "BLOCK_N2": 64,
                 }
-                if torch.cuda.get_device_capability() >= (8, 0) and D <= 128
+                if torch.cuda.is_available()
+                and torch.cuda.get_device_capability() >= (8, 0)
+                and D <= 128
                 else None
             ),
             "prefix_lm": None,
@@ -701,7 +716,7 @@ class Operator(BenchmarkOperator):
         }
 
         def get_default_split_k(B: int, H: int, Mk: int) -> int:
-            num_SM = torch.cuda.get_device_properties("cuda").multi_processor_count
+            num_SM = get_num_sms()
             """Heuristic for the number of splits from xformer"""
             bh = max(B * H, 1)  # NOTE: Handle B*h=0 case
             split_k = num_SM // bh * 2  # Each SM should at least get one block.
@@ -751,7 +766,7 @@ class Operator(BenchmarkOperator):
         if attn_type == "document_mask":
             random.seed(0)
             lengths = generate_random_lengths(N * B, B)
-            mask_mod_kwargs = dict(offsets=length_to_offsets(lengths, "cuda"))
+            mask_mod_kwargs = dict(offsets=length_to_offsets(lengths, _accel_device()))
 
         mask_mod_dict = {
             "noop": None,
@@ -771,7 +786,7 @@ class Operator(BenchmarkOperator):
             mask_mod = mask_mod(**mask_mod_kwargs)
 
         if is_decoding and mask_mod:
-            cached_seq_len = torch.tensor(N // 2).to("cuda")
+            cached_seq_len = torch.tensor(N // 2).to(_accel_device())
 
             def decoding_w_cached_seq_len(b, h, m, n):
                 return mask_mod(b, h, m + cached_seq_len, n)
@@ -785,7 +800,7 @@ class Operator(BenchmarkOperator):
         )
         compiled_block_mask = torch.compile(create_block_mask)
         block_mask = (
-            compiled_block_mask(new_mask_mod, *mask_shape, "cuda")
+            compiled_block_mask(new_mask_mod, *mask_shape, _accel_device())
             if new_mask_mod
             else None
         )
@@ -822,7 +837,7 @@ class Operator(BenchmarkOperator):
         score_mod = function_dict[attn_type]
         is_decoding = M == 1
         if is_decoding and score_mod:
-            offset = torch.tensor(N // 2).to("cuda")
+            offset = torch.tensor(N // 2).to(_accel_device())
 
             def score_mod_w_offset(score, b, h, m, n):
                 return score_mod(score, b, h, m + offset, n)

--- a/tritonbench/operators/fp8_gemm/fp8_gemm.py
+++ b/tritonbench/operators/fp8_gemm/fp8_gemm.py
@@ -111,6 +111,8 @@ def get_fp8_dtype():
         if torch.cuda.get_device_capability() < (9, 5):
             return torch.float8_e4m3fnuz
         return torch.float8_e4m3fn
+    elif torch.version.xpu:
+        return torch.float8_e4m3fn
     return torch.float8_e4m3fnuz
 
 

--- a/tritonbench/operators/fp8_gemm/persistent.py
+++ b/tritonbench/operators/fp8_gemm/persistent.py
@@ -6,7 +6,7 @@ import triton
 import triton.language as tl
 from torch._inductor.kernel.mm import ScalingType
 from triton import knobs
-from tritonbench.utils.env_utils import is_cuda
+from tritonbench.utils.env_utils import get_num_sms, is_cuda
 from tritonbench.utils.triton_utils import has_experimental_descriptor
 
 if has_experimental_descriptor():
@@ -169,7 +169,7 @@ def matmul_persistent(a, b):
     # Check constraints.
     assert a.shape[1] == b.shape[0], "Incompatible dimensions"
     assert a.dtype == b.dtype, "Incompatible dtypes"
-    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+    NUM_SMS = get_num_sms(a.device)
     M, K = a.shape
     K, N = b.shape
     dtype = a.dtype
@@ -386,7 +386,7 @@ def matmul_tma_persistent(a, b, c, desc_a, desc_b, desc_c):
     N, K = b.shape
     dtype = a.dtype
 
-    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+    NUM_SMS = get_num_sms(a.device)
 
     grid = lambda META: (
         min(
@@ -434,9 +434,7 @@ def blackwell_persistent_tma(a, b, scale_a_ptr, scale_b_ptr, acc_dtype, scaling_
     N, K = b.shape
     shape_dtype = a.dtype  # low-precision dtype, e.g. fp8
 
-    NUM_SMS = torch.cuda.get_device_properties(
-        torch.cuda.current_device()
-    ).multi_processor_count
+    NUM_SMS = get_num_sms(a.device)
 
     c = torch.zeros((M, N), device=a.device, dtype=acc_dtype)
 

--- a/tritonbench/operators/fp8_gemm/tutorial.py
+++ b/tritonbench/operators/fp8_gemm/tutorial.py
@@ -152,7 +152,7 @@ You will specifically learn about:
 import torch
 import triton
 import triton.language as tl
-from tritonbench.utils.env_utils import is_cuda
+from tritonbench.utils.env_utils import is_cuda, is_xpu
 
 
 def get_cuda_autotune_config():
@@ -383,6 +383,8 @@ def get_hip_autotune_config():
 
 def get_autotune_config():
     if is_cuda():
+        return get_cuda_autotune_config()
+    elif is_xpu():
         return get_cuda_autotune_config()
     else:
         return get_hip_autotune_config()

--- a/tritonbench/operators/gather_gemv/operator.py
+++ b/tritonbench/operators/gather_gemv/operator.py
@@ -79,8 +79,8 @@ class Operator(BenchmarkOperator):
         for i in range(11, 15):
             S = 2**i
             arg0_1 = rand_strided(
-                (8, S, S), (S * S, S, 1), device="cuda:0", dtype=torch.int8
+                (8, S, S), (S * S, S, 1), device=self.device, dtype=torch.int8
             )
-            arg1_1 = rand_strided((2,), (1,), device="cuda:0", dtype=torch.int64)
-            arg2_1 = rand_strided((S,), (1,), device="cuda:0", dtype=torch.bfloat16)
+            arg1_1 = rand_strided((2,), (1,), device=self.device, dtype=torch.int64)
+            arg2_1 = rand_strided((S,), (1,), device=self.device, dtype=torch.bfloat16)
             yield arg0_1, arg1_1, arg2_1

--- a/tritonbench/operators/gather_gemv/triton_gather_gemv.py
+++ b/tritonbench/operators/gather_gemv/triton_gather_gemv.py
@@ -5,8 +5,8 @@ Based on https://github.com/pytorch/pytorch/issues/121661
 import torch
 import triton
 import triton.language as tl
+from tritonbench.utils.env_utils import get_device_module
 
-empty_strided_cuda = torch._C._dynamo.guards._empty_strided_cuda
 reinterpret_tensor = torch.ops.inductor._reinterpret_tensor
 assert_size_stride = torch._C._dynamo.guards.assert_size_stride
 
@@ -118,10 +118,10 @@ def triton_gemv_0(arg0_1, arg1_1, arg2_1):
     assert_size_stride(arg2_1, (S,), (1,))
     xnumel = 2 * S
     rnumel = S
-    with torch.cuda._DeviceGuard(0):
-        torch.cuda.set_device(0)
+    device = arg0_1.device
+    with get_device_module(device.type).device(device.index):
         # size will be double
-        buf1 = empty_strided_cuda((2 * S,), (1,), torch.bfloat16)
+        buf1 = torch.empty_strided((2 * S,), (1,), dtype=torch.bfloat16, device=device)
 
         grid = lambda META: (triton.cdiv(2 * S, META["XBLOCK"]),)
         triton_red_fused_mv_0[grid](arg1_1, arg0_1, arg2_1, buf1, xnumel, rnumel)

--- a/tritonbench/operators/gdn_fwd_h/operator.py
+++ b/tritonbench/operators/gdn_fwd_h/operator.py
@@ -252,7 +252,7 @@ class Operator(BenchmarkOperator):
             )
             nchunks = (seqlen + chunk_size - 1) // chunk_size
             k = torch.randn(
-                batch, seqlen, nheads, dhead, dtype=torch.bfloat16, device="cuda"
+                batch, seqlen, nheads, dhead, dtype=torch.bfloat16, device=self.device
             )
             w = torch.randn(
                 batch,
@@ -261,7 +261,7 @@ class Operator(BenchmarkOperator):
                 nheads,
                 dhead,
                 dtype=torch.float32,
-                device="cuda",
+                device=self.device,
             )
             wu, ws, wv = torch.linalg.svd(w.permute(0, 1, 3, 2, 4), full_matrices=False)
             w = torch.einsum("bnhik,bnhkj->bnhij", wu, wv)
@@ -276,12 +276,14 @@ class Operator(BenchmarkOperator):
                 nheads,
                 expand_v * dhead,
                 dtype=torch.bfloat16,
-                device="cuda",
+                device=self.device,
             )
             g = torch.cumsum(
                 0.5
                 * math.log(1 / dhead)
-                * torch.rand(batch, seqlen, nheads, dtype=torch.float32, device="cuda"),
+                * torch.rand(
+                    batch, seqlen, nheads, dtype=torch.float32, device=self.device
+                ),
                 dim=1,
             )
             yield k, w, u, g, chunk_size

--- a/tritonbench/operators/gdpa/gdpa.py
+++ b/tritonbench/operators/gdpa/gdpa.py
@@ -46,7 +46,9 @@ except ImportError:
     HAS_TLX = False
 
 try:
-    BF16_ATOMIC_ADD_SUPPORTED = torch.cuda.get_device_capability() >= (9, 0)
+    BF16_ATOMIC_ADD_SUPPORTED = torch.cuda.is_available() and (
+        torch.cuda.get_device_capability() >= (9, 0)
+    )
 except RuntimeError:  # Not running on GPU device
     BF16_ATOMIC_ADD_SUPPORTED = False
 
@@ -1972,7 +1974,7 @@ def generalized_dot_product_attention(
     if enable_tma:
         # TMA descriptors require a global memory allocation
         def alloc_fn(size: int, alignment: int, stream: int | None):
-            return torch.empty(size, device="cuda", dtype=torch.int8)
+            return torch.empty(size, device=q.device, dtype=torch.int8)
 
         triton.set_allocator(alloc_fn)
 

--- a/tritonbench/operators/gdpa/gdpa_utils.py
+++ b/tritonbench/operators/gdpa/gdpa_utils.py
@@ -7,6 +7,7 @@ from typing import Any, List, Optional
 
 import torch
 import triton  # @manual=//triton:triton
+from tritonbench.utils.env_utils import get_current_device, get_num_sms as _get_num_sms
 
 
 def generate_sparse_seq_len(
@@ -57,7 +58,7 @@ def generate_jagged_data(
     dff: int | None = None,
 ) -> dict[str, Any]:
     if device is None:
-        device = torch.device("cuda:0")
+        device = torch.device(get_current_device())
 
     if num_objects is None:
         num_objects = generate_sparse_seq_len(
@@ -135,7 +136,7 @@ def generate_jagged_data(
             B * dff,
             H,
             D,
-            device="cuda",
+            device=device,
             dtype=dtype,
             requires_grad=True,
         ).contiguous()
@@ -143,7 +144,7 @@ def generate_jagged_data(
             B * dff,
             H,
             D,
-            device="cuda",
+            device=device,
             dtype=dtype,
             requires_grad=True,
         ).contiguous()
@@ -151,7 +152,7 @@ def generate_jagged_data(
             torch.arange(
                 B + 1,
                 dtype=torch.int,
-                device="cuda",
+                device=device,
             )
             * dff
         )
@@ -261,5 +262,5 @@ def get_autotune_kernel(kernel, autotune_configs, **kwargs):
 
 @lru_cache
 def get_num_sms() -> Optional[int]:
-    if torch.cuda.is_available():
-        return torch.cuda.get_device_properties("cuda").multi_processor_count
+    if torch.accelerator.is_available():
+        return _get_num_sms()

--- a/tritonbench/operators/gdpa/operator.py
+++ b/tritonbench/operators/gdpa/operator.py
@@ -30,7 +30,7 @@ import gc
 from typing import Any, Callable, Generator, List, Optional
 
 import torch
-from tritonbench.utils.env_utils import is_blackwell, is_hip
+from tritonbench.utils.env_utils import get_device_module, is_blackwell, is_hip
 from tritonbench.utils.triton_op import (
     BenchmarkOperator,
     BenchmarkOperatorMetrics,
@@ -525,6 +525,7 @@ class Operator(BenchmarkOperator):
                 dense_q_len=dense_q_len,
                 broadcast_q=broadcast_q,
                 dff=dff,
+                device=self.device,
             )
             jagged_data["max_seq_len"] = max_M
             jagged_data["q_offsets"] = jagged_data["q_offsets"].to(torch.int32)
@@ -624,16 +625,17 @@ class Operator(BenchmarkOperator):
 
         # Calculate activation
         gc.collect()
-        torch.cuda.empty_cache()
+        device_module = get_device_module(self.device)
+        device_module.empty_cache()
         MB = 1024.0 * 1024.0
-        torch.cuda.reset_peak_memory_stats(device="cuda")
-        memory_start = torch.cuda.max_memory_allocated(device="cuda") / MB
+        device_module.reset_peak_memory_stats(device=self.device)
+        memory_start = device_module.max_memory_allocated(device=self.device) / MB
 
         output = fwd_fn()
         do = torch.rand_like(output) * 0.01
         output.backward(do, retain_graph=True)
 
-        memory_end = torch.cuda.max_memory_allocated(device="cuda") / MB
+        memory_end = device_module.max_memory_allocated(device=self.device) / MB
         memory_used_MB = memory_end - memory_start
 
         return memory_used_MB

--- a/tritonbench/operators/gdpa/triton_autows.py
+++ b/tritonbench/operators/gdpa/triton_autows.py
@@ -8,6 +8,7 @@ import triton
 # @manual=//triton:triton
 import triton.language as tl
 from triton.tools.tensor_descriptor import TensorDescriptor
+from tritonbench.utils.env_utils import get_num_sms
 
 
 @triton.jit
@@ -451,7 +452,7 @@ def triton_autows_gdpa_persistent(
 
     n_tile_num = triton.cdiv(max_seq_len_q, block_m)
     n_kv_blocks = triton.cdiv(max_seq_len_kv, block_n)
-    num_sms = torch.cuda.get_device_properties(query.device).multi_processor_count
+    num_sms = get_num_sms(query.device)
 
     def grid(_meta):
         total_tiles = batch * heads * n_tile_num

--- a/tritonbench/operators/gemm/operator.py
+++ b/tritonbench/operators/gemm/operator.py
@@ -365,7 +365,7 @@ class Operator(BenchmarkOperator):
         else:
             return lambda: torch.matmul(a, b)
 
-    @register_benchmark()
+    @register_benchmark(enabled=is_cuda())
     def aten_tunableop_matmul(self, a, b, bias) -> Callable:
         is_enabled = torch.cuda.tunable.is_enabled()
 

--- a/tritonbench/operators/gemm/persistent_matmul.py
+++ b/tritonbench/operators/gemm/persistent_matmul.py
@@ -3,7 +3,7 @@ import os
 import torch
 import triton
 import triton.language as tl
-from tritonbench.utils.env_utils import is_tile_enabled
+from tritonbench.utils.env_utils import get_num_sms, is_tile_enabled
 
 from .triton_matmul_configs import get_full_amd_config_space, get_tileir_configs
 
@@ -190,7 +190,7 @@ def matmul_persistent(a, b):
     # Check constraints.
     assert a.shape[1] == b.shape[0], "Incompatible dimensions"
     assert a.dtype == b.dtype, "Incompatible dtypes"
-    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+    NUM_SMS = get_num_sms(a.device)
     M, K = a.shape
     K, N = b.shape
     dtype = a.dtype

--- a/tritonbench/operators/grouped_gemm/kernels.py
+++ b/tritonbench/operators/grouped_gemm/kernels.py
@@ -33,6 +33,7 @@ import torch
 import triton
 import triton.language as tl
 from triton import knobs
+from tritonbench.utils.env_utils import get_current_device, get_num_sms
 
 try:
     # @manual=//triton:triton
@@ -48,7 +49,7 @@ def is_cuda():
 
 
 def num_sms():
-    return torch.cuda.get_device_properties("cuda").multi_processor_count
+    return get_num_sms()
 
 
 def is_hip_async_copy_enabled():
@@ -493,7 +494,7 @@ def tlx_group_gemm_fn(
 ):
     # TMA descriptors require a global memory allocation
     def alloc_fn(size: int, alignment: int, stream: Optional[int]):
-        return torch.empty(size, device="cuda", dtype=torch.int8)
+        return torch.empty(size, device=get_current_device(), dtype=torch.int8)
 
     triton.set_allocator(alloc_fn)
     grid = lambda META: (META["NUM_SMS"],)

--- a/tritonbench/operators/grouped_gemm/operator.py
+++ b/tritonbench/operators/grouped_gemm/operator.py
@@ -740,9 +740,13 @@ class Operator(BenchmarkOperator):
             g_lds += [A.stride(0), B.stride(0), C.stride(0)]
 
         # note these are device tensors
-        d_a_ptrs = torch.tensor(A_addrs, device=device)
-        d_b_ptrs = torch.tensor(B_addrs, device=device)
-        d_c_ptrs = torch.tensor(C_addrs, device=device)
+        # Raw data_ptr() values are unsigned 64-bit addresses. On some devices
+        # (e.g. Intel XPU) they exceed INT64_MAX, so torch's default int64
+        # inference raises "Overflow when unpacking long long". Pack them as
+        # uint64 explicitly; the kernel reinterprets each element as a pointer.
+        d_a_ptrs = torch.tensor(A_addrs, dtype=torch.uint64, device=device)
+        d_b_ptrs = torch.tensor(B_addrs, dtype=torch.uint64, device=device)
+        d_c_ptrs = torch.tensor(C_addrs, dtype=torch.uint64, device=device)
         d_g_sizes = torch.tensor(g_sizes, dtype=torch.int32, device=device)
         d_g_lds = torch.tensor(g_lds, dtype=torch.int32, device=device)
 

--- a/tritonbench/operators/jagged_sum/operator.py
+++ b/tritonbench/operators/jagged_sum/operator.py
@@ -5,6 +5,7 @@ from typing import Any, Callable, Generator, List, Optional, Tuple
 import torch
 import triton
 from tritonbench.data import get_input_loader
+from tritonbench.kernels.profile import has_gpu_timer
 from tritonbench.utils.jagged_utils import (
     ABSOLUTE_TOLERANCE,
     generate_input_vals,
@@ -70,8 +71,12 @@ def execute_kernel_variable_length_loop(x, sum_then_buffer):
     B, M = x.shape[0], x.shape[2]
     grid = lambda meta: ((len(x.offsets()) - 1) * triton.cdiv(M, meta["BLOCK_SIZE_M"]),)
     kernel_output = torch.zeros((B, M), device=x.device)
-    # The size of the profile memory will be determined by the autotuner
-    profile_mem = torch.empty(0, dtype=torch.int64, device=x.device)
+    # The size of the profile memory will be determined by the autotuner.
+    # Platforms without an in-kernel timer (see has_gpu_timer) pass None so the
+    # instrumented branches are compiled out instead of recording bogus values.
+    profile_mem = (
+        torch.empty(0, dtype=torch.int64, device=x.device) if has_gpu_timer() else None
+    )
 
     if sum_then_buffer:
         triton_jagged_sum_kernel_variable_length_loop_sum_then_buffer[grid](

--- a/tritonbench/operators/launch_latency/kernels.py
+++ b/tritonbench/operators/launch_latency/kernels.py
@@ -4,6 +4,7 @@ import torch
 import triton
 import triton.language as tl
 from triton.tools.tensor_descriptor import TensorDescriptor
+from tritonbench.utils.env_utils import get_current_device
 
 # Compatibility: c_cache kwarg was added in a newer Triton version.
 # When tritonbench pins an older Triton, fall back to plain @triton.jit.
@@ -231,8 +232,9 @@ def nop_tensordesc_kernel_nocache(
 def make_tensordesc_inputs(m_block: int = 8, n_block: int = 32):
     M = m_block * 3
     N = n_block * 4
-    t = torch.zeros((M, N), device="cuda", dtype=torch.float16)
-    out = torch.zeros((m_block, n_block), device="cuda", dtype=torch.float16)
+    device = get_current_device()
+    t = torch.zeros((M, N), device=device, dtype=torch.float16)
+    out = torch.zeros((m_block, n_block), device=device, dtype=torch.float16)
     desc = TensorDescriptor(
         t, shape=t.shape, strides=t.stride(), block_shape=[m_block, n_block]
     )
@@ -253,9 +255,10 @@ def auto_tma_add_kernel(x_ptr, y_ptr, out_ptr, N, BLOCK: tl.constexpr):
 
 
 def make_auto_tma_inputs(N: int = 8192, block: int = 256):
-    x = torch.randn(N, device="cuda", dtype=torch.float16)
-    y = torch.randn(N, device="cuda", dtype=torch.float16)
-    out = torch.empty(N, device="cuda", dtype=torch.float16)
+    device = get_current_device()
+    x = torch.randn(N, device=device, dtype=torch.float16)
+    y = torch.randn(N, device=device, dtype=torch.float16)
+    out = torch.empty(N, device=device, dtype=torch.float16)
     return x, y, out, N, block
 
 
@@ -428,7 +431,7 @@ def get_inductor_nop_kernel_0arg():
     Internally operates on a pre-allocated tensor to force exactly one kernel
     launch, but the caller invokes it with no arguments.
     """
-    x = torch.zeros(1, device="cuda")
+    x = torch.zeros(1, device=get_current_device())
 
     @torch.compile
     def _nop_impl(x):
@@ -490,7 +493,7 @@ def get_inductor_nop_kernel(tensor_args=None):
     CachingAutotuner.run = capturing_run
     try:
         if len(targs) < 2:
-            x = torch.zeros(1, device="cuda")
+            x = torch.zeros(1, device=get_current_device())
 
             @torch.compile
             def _nop(t):

--- a/tritonbench/operators/launch_latency/operator.py
+++ b/tritonbench/operators/launch_latency/operator.py
@@ -359,12 +359,12 @@ class Operator(BenchmarkOperator):
 
     def get_input_iter(self):
         yield tuple()
-        targs = [zeros(1, device="cuda") for _ in range(5)]
+        targs = [zeros(1, device=self.device) for _ in range(5)]
         iargs = [1 for _ in range(9)]
         cargs = [32 for _ in range(5)]
         yield tuple([*targs, *iargs, *cargs])
         # HSTU-like input: 14 pointers + 26 scalars + 18 constexprs = 58 args
-        hstu_ptrs = [zeros(1, device="cuda") for _ in range(14)]
+        hstu_ptrs = [zeros(1, device=self.device) for _ in range(14)]
         hstu_scalars = [1 for _ in range(26)]
         hstu_constexprs = [1 for _ in range(18)]
         yield tuple([*hstu_ptrs, *hstu_scalars, *hstu_constexprs])
@@ -475,13 +475,13 @@ class Operator(BenchmarkOperator):
         """
         if len(args) < 19:
             return lambda: nop_kernel[1,]()
-        q = zeros(1, device="cuda")
-        k = zeros(1, device="cuda")
-        v = zeros(1, device="cuda")
-        out = zeros(1, device="cuda")
-        bias = zeros(1, device="cuda")
-        mask = zeros(1, device="cuda")
-        scale = zeros(1, device="cuda")
+        q = zeros(1, device=self.device)
+        k = zeros(1, device=self.device)
+        v = zeros(1, device=self.device)
+        out = zeros(1, device=self.device)
+        bias = zeros(1, device=self.device)
+        mask = zeros(1, device=self.device)
+        scale = zeros(1, device=self.device)
         # First: warmup with REAL tensors to trigger autotune + compilation
         real_args = (q, k, v, out, bias, mask, scale, 128, 8)
         nop_autotuned_with_none_kernel[(1,)](*real_args)
@@ -591,8 +591,15 @@ class Operator(BenchmarkOperator):
             bin.packed_metadata if hasattr(bin, "packed_metadata") else bin.metadata
         )
         if hasattr(CompiledKernel, "launch_metadata"):
+            # The launcher dereferences the stream handle, so it has to be a
+            # real one. CUDA tolerates the 0 (default stream) sentinel, other
+            # backends (e.g. the SYCL queue used by XPU) do not.
+            from triton.runtime import driver
+
+            device = driver.active.get_current_device()
+            stream = driver.active.get_current_stream(device)
             return lambda: bin.run(
-                1, 1, 1, 0, function, metadata, None, None, None, *args
+                1, 1, 1, stream, function, metadata, None, None, None, *args
             )
         else:
             return lambda: bin.run(
@@ -632,7 +639,7 @@ class Operator(BenchmarkOperator):
         """
         import shutil
 
-        x = torch.zeros(1, device="cuda")
+        x = torch.zeros(1, device=self.device)
 
         # Clear triton cache
         import triton.knobs

--- a/tritonbench/operators/layer_norm/fused_triton.py
+++ b/tritonbench/operators/layer_norm/fused_triton.py
@@ -3,6 +3,7 @@ import math
 import torch
 import triton
 import triton.language as tl
+from tritonbench.utils.env_utils import get_num_sms
 
 
 @triton.jit
@@ -139,8 +140,8 @@ class LayerNorm(torch.autograd.Function):
         # reshape input data into 2D tensor
         x_arg = x.reshape(-1, x.shape[-1])
         M, N = x_arg.shape
-        mean = torch.empty((M,), dtype=torch.float32, device="cuda")
-        rstd = torch.empty((M,), dtype=torch.float32, device="cuda")
+        mean = torch.empty((M,), dtype=torch.float32, device=x.device)
+        rstd = torch.empty((M,), dtype=torch.float32, device=x.device)
         # Less than 64KB per feature: enqueue fused kernel
         MAX_FUSED_SIZE = 65536 // x.element_size()
         BLOCK_SIZE = min(MAX_FUSED_SIZE, triton.next_power_of_2(N))
@@ -178,7 +179,7 @@ class LayerNorm(torch.autograd.Function):
         dx = torch.empty_like(dy)
 
         M, N = x_arg.shape
-        NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+        NUM_SMS = get_num_sms(x.device)
         BLOCK_SIZE_M = min(2048, triton.next_power_of_2(M // (8 * NUM_SMS)))
         PARTIAL_SIZE = math.ceil(M / BLOCK_SIZE_M)
 

--- a/tritonbench/operators/layer_norm/tutorial.py
+++ b/tritonbench/operators/layer_norm/tutorial.py
@@ -239,8 +239,8 @@ class LayerNorm(torch.autograd.Function):
         # reshape input data into 2D tensor
         x_arg = x.reshape(-1, x.shape[-1])
         M, N = x_arg.shape
-        mean = torch.empty((M,), dtype=torch.float32, device="cuda")
-        rstd = torch.empty((M,), dtype=torch.float32, device="cuda")
+        mean = torch.empty((M,), dtype=torch.float32, device=x.device)
+        rstd = torch.empty((M,), dtype=torch.float32, device=x.device)
         # Less than 64KB per feature: enqueue fused kernel
         MAX_FUSED_SIZE = 65536 // x.element_size()
         BLOCK_SIZE = min(MAX_FUSED_SIZE, triton.next_power_of_2(N))
@@ -282,7 +282,7 @@ class LayerNorm(torch.autograd.Function):
         if N <= 1024:
             GROUP_SIZE_M = 256
         # allocate output
-        locks = torch.zeros(2 * GROUP_SIZE_M, dtype=torch.int32, device="cuda")
+        locks = torch.zeros(2 * GROUP_SIZE_M, dtype=torch.int32, device=w.device)
         _dw = torch.empty((GROUP_SIZE_M, w.shape[0]), dtype=x.dtype, device=w.device)
         _db = torch.empty((GROUP_SIZE_M, w.shape[0]), dtype=x.dtype, device=w.device)
         dw = torch.empty((w.shape[0],), dtype=w.dtype, device=w.device)

--- a/tritonbench/operators/ragged_attention/hstu.py
+++ b/tritonbench/operators/ragged_attention/hstu.py
@@ -1,5 +1,5 @@
 import torch
-from tritonbench.utils.env_utils import is_fbcode
+from tritonbench.utils.env_utils import get_current_device, is_fbcode
 from tritonbench.utils.path_utils import add_path, SUBMODULE_PATH
 
 if is_fbcode():
@@ -50,11 +50,12 @@ def get_test_inputs(
     dtype,
     requires_grad,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, int]:
+    device = get_current_device()
     lengths = generate_sparse_seq_len(
         size=batch_size,
         max_seq_len=seq_len,
         sparsity=seq_sparsity,
-        device=torch.device("cuda"),
+        device=device,
     )
     lengths = apply_sampling(lengths, alpha=2.0, max_seq_len=seq_len)
     if has_delta_q:
@@ -76,23 +77,21 @@ def get_test_inputs(
                 torch.int32
             )
     max_attn_len = max_attn_len if max_attn_len < seq_len else seq_len
-    seq_offsets = torch.zeros(
-        (batch_size + 1,), dtype=torch.int32, device=torch.device("cuda")
-    )
+    seq_offsets = torch.zeros((batch_size + 1,), dtype=torch.int32, device=device)
     seq_offsets[1:] = torch.cumsum(lengths, dim=0)
     L = int(seq_offsets[-1].item())
     x = torch.empty(
         (L, heads, attn_dim * 2 + hidden_dim),
         dtype=dtype,
-        device=torch.device("cuda"),
+        device=device,
     ).uniform_(-0.01, 0.01)
     q, k, v = torch.split(x, [attn_dim, attn_dim, hidden_dim], dim=-1)
     delta_q = torch.empty(
         (batch_size * delta_size, heads, attn_dim),
         dtype=dtype,
-        device=torch.device("cuda"),
+        device=device,
     ).uniform_(-0.1, 0.1)
-    delta_x_offsets = torch.arange(0, delta_size, device=torch.device("cuda"))
+    delta_x_offsets = torch.arange(0, delta_size, device=device)
     delta_x_offsets = (seq_offsets[1:] - delta_size).view(
         batch_size, 1
     ) + delta_x_offsets.view(1, delta_size)

--- a/tritonbench/operators/rms_norm/fused_triton.py
+++ b/tritonbench/operators/rms_norm/fused_triton.py
@@ -3,6 +3,7 @@ import math
 import torch
 import triton
 import triton.language as tl
+from tritonbench.utils.env_utils import get_num_sms
 
 
 @triton.autotune(
@@ -104,7 +105,7 @@ class RMSNorm(torch.autograd.Function):
         dx = torch.empty_like(dy)
 
         M, N = x_arg.shape
-        NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+        NUM_SMS = get_num_sms(x.device)
         BLOCK_SIZE_M = min(2048, triton.next_power_of_2(M // (8 * NUM_SMS)))
         PARTIAL_SIZE = math.ceil(M / BLOCK_SIZE_M)
 

--- a/tritonbench/operators/template_attention/operator.py
+++ b/tritonbench/operators/template_attention/operator.py
@@ -55,19 +55,19 @@ class Operator(BenchmarkOperator):
             arg0_1 = rand_strided(
                 (16, 16, 4096, 64),
                 (4194304, 262144, 64, 1),
-                device="cuda:0",
+                device=self.device,
                 dtype=torch.float16,
             )
             arg1_1 = rand_strided(
                 (16, 16, 4096, 64),
                 (4194304, 262144, 64, 1),
-                device="cuda:0",
+                device=self.device,
                 dtype=torch.float16,
             )
             arg2_1 = rand_strided(
                 (16, 16, 4096, 64),
                 (4194304, 262144, 64, 1),
-                device="cuda:0",
+                device=self.device,
                 dtype=torch.float16,
             )
             yield arg0_1, arg1_1, arg2_1

--- a/tritonbench/operators/template_attention/triton_attention.py
+++ b/tritonbench/operators/template_attention/triton_attention.py
@@ -6,11 +6,10 @@ Generated from Inductor for forward layernorm with and without welford
 import torch
 import triton
 import triton.language as tl
-from torch._C import _cuda_getCurrentRawStream as get_raw_stream
 from torch._inductor.runtime import triton_helpers, triton_heuristics
 from torch._inductor.runtime.triton_helpers import libdevice
+from tritonbench.utils.env_utils import get_device_module
 
-empty_strided_cuda = torch._C._dynamo.guards._empty_strided_cuda
 reinterpret_tensor = torch.ops.inductor._reinterpret_tensor
 assert_size_stride = torch._C._dynamo.guards.assert_size_stride
 
@@ -322,10 +321,12 @@ def triton_attention_no_exp2(arg0_1, arg1_1, arg2_1):
     assert_size_stride(arg0_1, (16, 16, 4096, 64), (4194304, 262144, 64, 1))
     assert_size_stride(arg1_1, (16, 16, 4096, 64), (4194304, 262144, 64, 1))
     assert_size_stride(arg2_1, (16, 16, 4096, 64), (4194304, 262144, 64, 1))
-    with torch.cuda._DeviceGuard(0):
-        torch.cuda.set_device(0)
-        buf0 = empty_strided_cuda(
-            (16, 16, 4096, 64), (4194304, 262144, 64, 1), torch.float16
+    with get_device_module(arg0_1.device.type).device(arg0_1.device.index):
+        buf0 = torch.empty_strided(
+            (16, 16, 4096, 64),
+            (4194304, 262144, 64, 1),
+            dtype=torch.float16,
+            device=arg0_1.device,
         )
 
         # batch_size, num_heads, num_queries: 16, 16, 4096
@@ -345,10 +346,12 @@ def triton_attention_with_exp2(arg0_1, arg1_1, arg2_1):
     assert_size_stride(arg0_1, (16, 16, 4096, 64), (4194304, 262144, 64, 1))
     assert_size_stride(arg1_1, (16, 16, 4096, 64), (4194304, 262144, 64, 1))
     assert_size_stride(arg2_1, (16, 16, 4096, 64), (4194304, 262144, 64, 1))
-    with torch.cuda._DeviceGuard(0):
-        torch.cuda.set_device(0)
-        buf0 = empty_strided_cuda(
-            (16, 16, 4096, 64), (4194304, 262144, 64, 1), torch.float16
+    with get_device_module(arg0_1.device.type).device(arg0_1.device.index):
+        buf0 = torch.empty_strided(
+            (16, 16, 4096, 64),
+            (4194304, 262144, 64, 1),
+            dtype=torch.float16,
+            device=arg0_1.device,
         )
 
         # batch_size, num_heads, num_queries: 16, 16, 4096

--- a/tritonbench/operators/vector_exp/operator.py
+++ b/tritonbench/operators/vector_exp/operator.py
@@ -2,6 +2,7 @@ from typing import Any, Callable, Generator, List
 
 import torch
 import triton
+from tritonbench.kernels.profile import has_gpu_timer
 from tritonbench.utils.triton_op import (
     BenchmarkOperator,
     BenchmarkOperatorMetrics,
@@ -47,9 +48,15 @@ class Operator(BenchmarkOperator):
     def triton_exp(self, x: torch.Tensor):
         n_elements = x.numel()
         # Prepare a memory buffer to store the profiled data, with the size equal to the number of programs.
+        # Platforms without an in-kernel timer (see has_gpu_timer) pass None so
+        # the instrumented branches are compiled out.
         BLOCK_SIZE = 1024
         n_programs = triton.cdiv(n_elements, BLOCK_SIZE)
-        profile_mem = torch.empty(n_programs, dtype=torch.int64, device=self.device)
+        profile_mem = (
+            torch.empty(n_programs, dtype=torch.int64, device=self.device)
+            if has_gpu_timer()
+            else None
+        )
 
         def _inner():
             output = TritonExpFunction.apply(x, BLOCK_SIZE, profile_mem)

--- a/tritonbench/utils/env_utils.py
+++ b/tritonbench/utils/env_utils.py
@@ -112,6 +112,42 @@ def is_hip() -> bool:
     return torch.version.hip is not None
 
 
+def is_xpu() -> bool:
+    return torch.version.xpu is not None
+
+
+def get_current_device() -> str:
+    """Return the device string of the accelerator available on this host.
+
+    Falls back to "cuda" when torch reports no accelerator, so that CUDA-only
+    hosts and CPU-only environments keep the historical default.
+    """
+    try:
+        accelerator = torch.accelerator.current_accelerator()
+    except Exception:
+        return "cuda"
+    return accelerator.type if accelerator is not None else "cuda"
+
+
+def get_device_module(device: Optional[str] = None):
+    """Return the ``torch.<device>`` module for ``device`` (default: current one)."""
+    return getattr(torch, device or get_current_device(), torch.cuda)
+
+
+def get_num_sms(device=None) -> int:
+    """Number of independently schedulable compute units on ``device``.
+
+    NVIDIA/AMD report this as ``multi_processor_count``; Intel XPU exposes the
+    equivalent quantity as ``gpu_subslice_count``. Persistent kernels use it to
+    size their grid, so it must be resolved per device type.
+    """
+    device = torch.device(device) if device is not None else None
+    device_type = device.type if device is not None else get_current_device()
+    if device_type == "xpu":
+        return torch.xpu.get_device_properties(device).gpu_subslice_count
+    return torch.cuda.get_device_properties(device).multi_processor_count
+
+
 def is_hip_mi200():
     try:
         target = triton.runtime.driver.active.get_current_target()

--- a/tritonbench/utils/gpu_utils.py
+++ b/tritonbench/utils/gpu_utils.py
@@ -5,10 +5,11 @@ from contextlib import contextmanager
 from typing import Dict, List, Optional
 
 try:
-    from tritonbench.utils.env_utils import is_hip, is_mtia
+    from tritonbench.utils.env_utils import is_hip, is_mtia, is_xpu
 except ModuleNotFoundError:
     is_hip = lambda: False
     is_mtia = lambda: False
+    is_xpu = lambda: False
 
 # Defer MTIA check to avoid triggering Triton driver initialization at import time
 try:
@@ -106,6 +107,8 @@ def get_gpu_device_name() -> str:
 
         if is_hip():
             return get_amd_device_name()
+        if is_xpu():
+            return torch.xpu.get_device_name()
         return torch.cuda.get_device_name()
     except Exception:
         return "None"

--- a/tritonbench/utils/parser.py
+++ b/tritonbench/utils/parser.py
@@ -53,7 +53,7 @@ def get_parser(args=None):
         "--device",
         "-d",
         default="cuda",
-        choices=["cuda", "cpu", "mtia", "tpu"],
+        choices=["cuda", "cpu", "mtia", "tpu", "xpu"],
         help="Device to benchmark.",
     )
     parser.add_argument(

--- a/tritonbench/utils/run_utils.py
+++ b/tritonbench/utils/run_utils.py
@@ -31,11 +31,12 @@ from tritonbench.utils.env_utils import (
     is_triton_beta,
     is_triton_main,
     is_triton_stable,
+    is_xpu,
     set_torchrun_env,
 )
 from tritonbench.utils.git_utils import get_branch, get_commit_time, get_current_hash
 from tritonbench.utils.gpu_telemetry_observer import TelemetryContext
-from tritonbench.utils.gpu_utils import get_amd_device_name, gpu_lockdown
+from tritonbench.utils.gpu_utils import get_gpu_device_name, gpu_lockdown
 from tritonbench.utils.helion_utils import apply_helion_backend_override
 from tritonbench.utils.list_operator_details import list_operator_details
 from tritonbench.utils.parser import get_parser
@@ -78,6 +79,7 @@ ENV_CHECK_MAP = {
         "b200": is_blackwell,
         "cuda": is_cuda,
         "hip": is_hip,
+        "xpu": is_xpu,
     },
     "channels": {
         "triton-main": is_triton_main,
@@ -105,14 +107,14 @@ def get_run_env(
     run_env["benchmark_date"] = run_timestamp
     if is_hip():
         run_env["cuda_version"] = torch.version.hip
+    elif is_xpu():
+        run_env["cuda_version"] = str(torch.version.xpu)
     else:
         run_env["cuda_version"] = (
             torch.version.cuda if torch.version.cuda else "unknown"
         )
     try:
-        run_env["device"] = (
-            get_amd_device_name() if is_hip() else torch.cuda.get_device_name()
-        )
+        run_env["device"] = get_gpu_device_name()
     except AssertionError:
         run_env["device"] = "unknown"
     run_env["conda_env"] = os.environ.get("CONDA_ENV", "unknown")

--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -41,7 +41,7 @@ except ImportError:
 
 from tritonbench.components.do_bench import do_bench_wrapper, Latency
 from tritonbench.components.do_bench.utils import (
-    estimate_cuda_runtime_ms,
+    estimate_gpu_runtime_ms,
     resolve_warmup_and_rep,
 )
 from tritonbench.components.export import export_data
@@ -62,9 +62,11 @@ from tritonbench.utils.diode_utils import (
 )
 from tritonbench.utils.env_utils import (
     apply_precision,
+    get_device_module,
     is_fbcode,
     is_hip,
     is_mtia,
+    is_xpu,
     override_default_precision_for_input_loader,
     reset_allow_tf32,
     set_allow_tf32,
@@ -175,13 +177,14 @@ class TimerContext:
 
 
 def do_bench_walltime(fn, warmup=None, rep=None):
+    device_module = get_device_module()
     fn()
-    torch.cuda.synchronize()
+    device_module.synchronize()
 
     with TimerContext() as timer:
         for _ in range(5):
             fn()
-        torch.cuda.synchronize()
+        device_module.synchronize()
     estimate_ms = timer.elapsed_ms / 5
     warmup, rep = resolve_warmup_and_rep(warmup, rep, estimate_ms)
 
@@ -196,19 +199,21 @@ def do_bench_walltime(fn, warmup=None, rep=None):
     # Warm-up
     for _ in range(n_warmup):
         fn()
-    torch.cuda.synchronize()
+    device_module.synchronize()
 
     # Benchmark
     start_time = time.perf_counter()
     for _ in range(n_repeat):
         fn()
-    torch.cuda.synchronize()
+    device_module.synchronize()
     end_time = time.perf_counter()
     wall_time_ms = (end_time - start_time) * 1e3 / n_repeat
     return wall_time_ms
 
 
 def _get_current_device_id() -> int:
+    if is_xpu():
+        return torch.xpu.current_device()
     return torch.cuda.current_device()
 
 
@@ -2718,10 +2723,11 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
             flop_counter = FlopCounterMode()
 
             def work_func():
-                if self.device == "cuda":
-                    torch.cuda.synchronize()
+                if self.device in ("cuda", "xpu"):
+                    device_module = get_device_module(self.device)
+                    device_module.synchronize()
                     func()
-                    torch.cuda.synchronize()
+                    device_module.synchronize()
                 else:
                     func()
 


### PR DESCRIPTION
Make tritonbench runnable on Intel GPUs and get `test/test_gpu` green on XPU.

Device abstraction
- `env_utils`: add `get_current_device()` (built on
  `torch.accelerator.current_accelerator()`, falls back to "cuda"),
  `get_device_module()` and `get_num_sms()` (XPU reports
  `gpu_subslice_count` instead of `multi_processor_count`).
- Replace the per-file `device="cuda"` / `torch.cuda.*` / open-coded NUM_SMS
  branches across kernels and operators with those shared helpers, so device
  dispatch lives in one place instead of being duplicated per operator.
- `gpu_utils.get_gpu_device_name()` and `run_utils` env checks understand xpu;
  `parser` accepts `--device xpu`.
- Rename `estimate_cuda_runtime_ms` to `estimate_gpu_runtime_ms`, keeping the
  old name as an alias for backward compatibility.
- `test/test_gpu/main.py` derives `TEST_DEVICE` from the available accelerator
  and passes it through to each operator run.

In-kernel profiling
- `kernels/profile.py`: add `has_gpu_timer()`. `time()`/`smid()` need
  `%globaltimer`/`%smid` (CUDA) or `s_memrealtime`/`HW_REG_HW_ID` (HIP); no
  equivalent is currently usable on XPU, so `vector_exp` and `jagged_sum` now
  pass `profile_mem=None` there and compile the instrumentation out rather
  than recording zero timestamps. `jagged_sum`'s `occupancy` metric returns
  None accordingly.

Operator fixes uncovered by the XPU run
- `launch_latency`: `nop_triton_compiled_kernel_run` passed 0 as the stream
  handle. That is the CUDA default-stream sentinel; other backends dereference
  it and crash. Use `driver.active.get_current_stream()`.
- `gdpa`: `torch.cuda.get_device_capability()` raises AssertionError (not
  RuntimeError) on a CUDA-less build, so guard with `torch.cuda.is_available()`.
- `gather_gemv`, `template_attention`: drop the inductor-codegen leftovers
  (`_cuda_getCurrentRawStream`, `empty_strided_cuda`, `torch.cuda._DeviceGuard`)
  in favour of `torch.empty_strided(device=...)` and the device module's guard.

Skip list
- Mark `fused_linear_cross_entropy`, `fused_linear_jsd`, `geglu` and `gdpa` as
  disabled on xpu (CI timeouts) and `template_attention` (IGC crashes on an
  online-softmax `tl.where(m == -inf, ...)` pattern). Each entry documents the
  reason.

Test: `pytest test/test_gpu/main.py` on an Intel Arc B580 -> 42 passed.
