### PR TITLE
Reduce register spills in softmax partition via lifetime shortening (#1213)

### DIFF
--- a/tritonbench/operators/blackwell_attentions/operator.py
+++ b/tritonbench/operators/blackwell_attentions/operator.py
@@ -829,6 +829,51 @@ class Operator(BenchmarkOperator):
 
         return preproc_noop, fn
 
+    @register_benchmark(enabled=HAS_TLX, label="tlx-1cta")
+    @multi_input_wrapper
+    def tlx_blackwell_1cta(self, *args) -> Tuple[Callable, Callable]:
+        cfg = {
+            "BLOCK_M": 256,
+            "BLOCK_N": 128,
+            "NUM_BUFFERS_Q": 1,
+            "NUM_BUFFERS_KV": 3,
+            "NUM_BUFFERS_QK": 1,
+            "NUM_MMA_GROUPS": 2,
+            "NUM_MMA_SLICES": 2,
+            "GROUP_SIZE_N": 1,
+            "RESCALE_OPT": True,
+            "USE_WHERE": False,
+            "USE_WARP_BARRIER": False,
+        }
+
+        def fn(q, k, v):
+            return tlx_blackwell(q, k, v, self.sm_scale, self.causal, config=cfg)
+
+        return preproc_noop, fn
+
+    @register_benchmark(enabled=HAS_TLX, label="tlx-2cta")
+    @multi_input_wrapper
+    def tlx_blackwell_2cta(self, *args) -> Tuple[Callable, Callable]:
+        cfg = {
+            "BLOCK_M": 256,
+            "BLOCK_N": 128,
+            "NUM_BUFFERS_Q": 1,
+            "NUM_BUFFERS_KV": 5,
+            "NUM_BUFFERS_QK": 1,
+            "NUM_MMA_GROUPS": 2,
+            "NUM_MMA_SLICES": 2,
+            "GROUP_SIZE_N": 1,
+            "RESCALE_OPT": True,
+            "USE_WHERE": False,
+            "USE_WARP_BARRIER": False,
+            "NUM_CTAS": 2,
+        }
+
+        def fn(q, k, v):
+            return tlx_blackwell(q, k, v, self.sm_scale, self.causal, config=cfg)
+
+        return preproc_noop, fn
+
     @register_benchmark(
         enabled=IS_BLACKWELL and HAS_TLX_HSTU and is_triton_beta(),
         label="tlx-hstu",


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookexperimental/triton/pull/2717

## Motivation

NCU profiling of the 2-CTA Flash Attention kernel revealed heavy register
spills in the softmax partition:
- 50.63M Local memory instructions (vs 98.3K Global memory instructions)
- 25.26M Local memory requests (read + write)
- L1/TEX cache hit rate 99.72% (spills stay in L1 but still add latency)

SASS showed two hot spill slots:
```
STL    [R1],      R2        ; spill alpha
LDL.LU R163,      [R1]      ; reload alpha

LDL.LU R80,       [R1+0x4]  ; reload l_i
STL    [R1+0x4],  R80       ; spill l_i
```

These correspond to `alpha` and `l_i` in `_softmax_inner_loop`, where:
1. `alpha` is computed then stored to TMEM, but not consumed until ~30 lines
   later. This long live range forces alpha to spill.
2. All `p_i` values are accumulated in a Python tuple `ps`, then joined and
   summed at the end. This keeps NUM_MMA_SLICES p_i tensors live
   simultaneously, adding register pressure.

## Changes

**Fix 1: Shorten alpha's lifetime**

Move `l_i *= alpha` right after `tlx.local_store(alpha_tiles, alpha)` so
alpha is consumed immediately and its register is freed. The final
`l_i += l_ij` replaces the original `l_i = l_i * alpha + l_ij`.
Mathematically equivalent.

**Fix 2: Incremental l_ij accumulation (eliminate ps tuple)**

Replace the `ps = ps + (p_i,)` tuple accumulation + `_join_n_2D(ps)` +
`tl.sum(p, 1)` with incremental `l_ij += tl.sum(p_i, 1)` inside the loop.
Each `p_i` dies at end of iteration instead of all staying live.

**Fix 3: Enable conditional rescale (IfOp) for 2-CTA mode**

The RESCALE_OPT conditional path uses `scf.if` to skip `acc *= alpha` when
alpha==1.0 (no rescale needed). This was previously disabled for 2-CTA mode
(`if RESCALE_OPT and not USE_2CTA`) due to a suspected compiler miscompile.

Investigation showed the original compiler bug has since been fixed in TLX
TMEM token chain handling. Removed the `not USE_2CTA` guard, enabling the
optimization for 2-CTA.

This skips a full TMEM round trip (tcgen05.ld.sync.aligned + multiply +
tcgen05.st.sync.aligned + waits) on the accumulator tile (128x128xf32 =
64KB) when alpha==1.0. Since the running row-max stabilizes after a few
KV tiles, ~90% of iterations have alpha==1.0 and the rescale is a no-op.

**Fix 4: Autotuner grid lambda None-safety**

Changed `META.get("Q_STAGE", 1)` to `(META.get("Q_STAGE") or 1)` to handle
configs where Q_STAGE key exists with value None.

**Benchmark: locked 1CTA / 2CTA-Q2 configs**
Added `tlx_blackwell_1cta` and `tlx_blackwell_2cta_q2` benchmarks with
locked configs for isolated performance comparison.

## Results (GB300, denoise.sh, tritonbench --input-id 3)

### Fix 1 + Fix 2 impact (A/B on parent commit, before Fix 3):

| SeqLen | cuDNN before | 1CTA before | 2CTA-Q2 before | cuDNN after | 1CTA after | 2CTA-Q2 after |
|--------|-------------|-------------|----------------|------------|------------|---------------|
| 1024   | 1213        | 880         | 1199           | 1066       | 1099       | 1192          |
| 2048   | 1502        | 1353        | 1461           | 1575       | 1390       | 1505          |
| 4096   | 1639        | 1457        | 1527           | 1630       | 1540       | 1624          |
| 8192   | 1635        | 1569        | 1562           | 1713       | 1673       | 1716          |
| 16384  | 1670        | 1671        | 1692           | 1697       | 1689       | 1711          |
| **avg**| **1532**    | **1386**    | **1488**       | **1536**   | **1478**   | **1550**      |

**1CTA +6.6% (1386->1478), 2CTA-Q2 +4.2% (1488->1550)**

### Full stack with all fixes: TLX 1CTA vs 2CTA-Q2 vs FAv4 vs CUTLASS (cudagraph mode, pure kernel time)

| SeqLen | TLX 1CTA | TLX 2CTA-Q2 | FAv4 (CuTeDSL) | CUTLASS |
|--------|----------|-------------|----------------|---------|
| 1024   | 1148     | 1285        | **1482**       | -       |
| 2048   | 1410     | 1579        | **1679**       | -       |
| 4096   | 1548     | 1690        | **1763**       | -       |
| 8192   | 1659     | 1749        | **1777**       | -       |
| 16384  | 1694     | 1770        | **1798**       | -       |
| **avg**| **1492** | **1614**    | **1700**       | -       |

2CTA-Q2 is +8.2% over 1CTA. Pure kernel perf (cudagraph) is -5.1% vs FAv4;
gap narrows at longer sequences (-1.6% at 16K).

Without cudagraph (includes launch overhead):

| SeqLen | TLX 1CTA | TLX 2CTA-Q2 | FAv4 (CuTeDSL) | CUTLASS |
|--------|----------|-------------|----------------|---------|
| 1024   | 1094     | **1220**    | 717            | 968     |
| 2048   | 1396     | 1576        | **1664**       | 1227    |
| 4096   | 1562     | **1617**    | 1650           | 1306    |
| 8192   | 1649     | 1747        | **1763**       | 1381    |
| 16384  | 1704     | 1773        | **1804**       | 1407    |
| **avg**| **1481** | **1587**    | **1520**       | **1258**|

With launch overhead, TLX 2CTA-Q2 avg +4.4% over FAv4 (CLC persistent
scheduling amortizes launch cost).

### Register tuning experiment (reverted -- not included):

Attempted increasing softmax partition registers from 168 to 184/200.
200 caused -18% regression (occupancy crash). 184 was mixed (+-1%).
168 regs is already the optimal spill-vs-occupancy tradeoff.

Reviewed By: htyu

Differential Revision: D114619646


