### PR TITLE
Yield input tensors from get_input_iter for rope

### DIFF
--- a/tritonbench/operators/rope/operator.py
+++ b/tritonbench/operators/rope/operator.py
@@ -33,7 +33,7 @@ class Operator(BenchmarkOperator):
         self.num_q_heads = 32
         self.num_kv_heads = 8
 
-    def get_input_iter(self) -> Generator:
+    def _shape_iter(self) -> Generator:
         hidden_size = 8192
         for seq_length in [2**i for i in range(10, 15)]:
             yield hidden_size, seq_length
@@ -42,7 +42,14 @@ class Operator(BenchmarkOperator):
         for hidden_size in [32 * (2**i) for i in range(4, 10, 2)]:
             yield hidden_size, seq_length
 
-    def prepare_input(self, hidden_size, seq_length):
+    def get_input_iter(self) -> Generator:
+        for hidden_size, seq_length in self._shape_iter():
+            yield self._make_inputs(hidden_size, seq_length)
+
+    def get_available_num_inputs(self) -> int:
+        return sum(1 for _ in self._shape_iter())
+
+    def _make_inputs(self, hidden_size, seq_length):
         head_dim = hidden_size // self.num_q_heads
         llama_config = LlamaConfig(
             head_dim=head_dim,
@@ -68,36 +75,32 @@ class Operator(BenchmarkOperator):
             .transpose(1, 2)
             .contiguous()
         )
-        dq, dk = (
-            torch.randn_like(q, device=self.device, dtype=self.dtype),
-            torch.randn_like(k, device=self.device),
-        )
         pos_ids = torch.arange(
             seq_length, device=self.device, dtype=torch.long
         ).unsqueeze(0)
         cos, sin = rotary_emb(k, pos_ids)
-        # save q,k to self for grad_to_none
-        self.q = q
-        self.k = k
-        # save dq,dk to self for backward
-        self.dq = dq
-        self.dk = dk
         return q, k, cos, sin, pos_ids
 
+    def _save_for_backward(self, q, k):
+        self.q = q
+        self.k = k
+        self.dq = torch.randn_like(q, device=self.device, dtype=self.dtype)
+        self.dk = torch.randn_like(k, device=self.device)
+
     @register_benchmark(baseline=True)
-    def apply_rotary_pos_emb(self, hidden_size, seq_length) -> Callable:
-        q, k, cos, sin, pos_ids = self.prepare_input(hidden_size, seq_length)
+    def apply_rotary_pos_emb(self, q, k, cos, sin, pos_ids) -> Callable:
+        self._save_for_backward(q, k)
         return lambda: apply_rotary_pos_emb(q, k, cos, sin)
 
     @register_benchmark()
-    def liger_rotary_pos_emb(self, hidden_size, seq_length) -> Callable:
-        q, k, cos, sin, pos_ids = self.prepare_input(hidden_size, seq_length)
+    def liger_rotary_pos_emb(self, q, k, cos, sin, pos_ids) -> Callable:
+        self._save_for_backward(q, k)
         return lambda: liger_rotary_pos_emb(q, k, cos, sin, pos_ids)
 
     @register_benchmark()
-    def torch_compile_rotary_pos_emb_full_op(self, hidden_size, seq_length) -> Callable:
-        q, k, cos, sin, pos_ids = self.prepare_input(hidden_size, seq_length)
-        head_dim = hidden_size // self.num_q_heads
+    def torch_compile_rotary_pos_emb_full_op(self, q, k, cos, sin, pos_ids) -> Callable:
+        self._save_for_backward(q, k)
+        head_dim = q.shape[-1]
         llama_config = LlamaConfig(
             head_dim=head_dim,
         )
@@ -113,7 +116,9 @@ class Operator(BenchmarkOperator):
 
     @register_x_val(label="(H, T)")
     def get_x_val(self, example_inputs) -> Tuple[int, int]:
-        return (example_inputs[0], example_inputs[1])
+        q = example_inputs[0]
+        _, num_q_heads, seq_length, head_dim = q.shape
+        return (head_dim * num_q_heads, seq_length)
 
     def get_bwd_fn(self, fwd_fn: Callable) -> Callable:
         q_out, k_out = fwd_fn()


### PR DESCRIPTION
rope was the only operator whose get_input_iter() yielded scalar (hidden_size, seq_length) tuples and constructed the actual q/k/cos/sin tensors inside each benchmark function. Every other operator yields its real input tensors from get_input_iter().