### PR TITLE
num_stages=0 -> 1 (meta-pytorch/tritonbench)

### DIFF
--- a/tritonbench/operators/gdpa/gdpa_blackwell_tlx.py
+++ b/tritonbench/operators/gdpa/gdpa_blackwell_tlx.py
@@ -2044,7 +2044,7 @@ def gdpa_backward_tlx(
                     qlen, start_n, BLOCK_M1, BLOCK_N1, WINDOW_SIZE
                 )
 
-                for i in tl.range(0, num_steps, 1, num_stages=0):
+                for i in tl.range(0, num_steps, 1, num_stages=1):
                     q_buf_id, q_phase = _get_bufidx_phase(i, NUM_BUFFERS_Q)
                     q_tile = tlx.local_view(q_tiles, q_buf_id)
                     q_full = tlx.local_view(q_fulls, q_buf_id)


### PR DESCRIPTION
Summary:
The GDPA Blackwell TLX operator plus the internal `tools/fb/fusionbench` rllayer_sparse TLX GEMM kernels.

Split out of D114751669 so each GitHub export destination lands as its
own diff. `num_stages=0` has been removed from TLX (AMD included), so the
remaining uses move to `num_stages=1` -- covering the
`triton.Config(..., num_stages=0)` autotune param, the
`tl.range(..., num_stages=0)` loop attribute, and autotune sweeps that
generate a 0 (the 0 is dropped rather than duplicated to 1).

See D114751669 for the full sweep and rationale.

Reviewed By: xuzhao9

Differential Revision: D114753272


