### PR TITLE
Hand-port the ast literal classes the codemod declined

### DIFF
--- a/tritonbench/components/tasks/base.py
+++ b/tritonbench/components/tasks/base.py
@@ -133,9 +133,9 @@ def parse_f(f: typing.Callable) -> typing.Tuple[inspect.Signature, str]:
         # line comment), we simply elect to skip over them and index on the
         # first node that will give valid indices.
         if node.col_offset == -1:
-            assert isinstance(node.value, ast.Str), (
-                f"Expected `ast.Str`, got {type(node)}. ({node}) {node.lineno}"
-            )
+            assert isinstance(node.value, ast.Constant) and isinstance(
+                node.value.value, str
+            ), f"Expected a string constant, got {type(node)}. ({node}) {node.lineno}"
             continue
 
         raw_body_lines = src_lines[node.lineno - 1 :]


### PR DESCRIPTION
Summary:
`ast.Num`, `ast.Str`, `ast.Bytes`, `ast.NameConstant` and `ast.Ellipsis` are gone
in 3.14, as are the `.s` / `.n` aliases on `ast.Constant`.

Produced by the codemod in D114483956. The `isinstance` rewrites follow CPython's
own `_const_types` / `_const_types_not` tables rather than the intuitive reading:
`ast.Num` excluded `bool` even though `bool` subclasses `int`, and
`ast.NameConstant` covered `None` *and* `bool`. Behaviour is identical on 3.12
and 3.14.

The residue the codemod declines because each needs a judgement it is not allowed
to make. Notable:

- `scribe/flake8_plugins/ast_linter.py` -- `visit_Str` is dispatched on 3.12 but
  **not** on 3.14: `NodeVisitor`'s routing from `visit_Constant` to the legacy hook
  names was removed. Left alone the S004 check would simply stop firing, silently.
  Merged into `visit_Constant` gated on `isinstance(node.value, str)`, which is
  what the removed routing did.
- `arvr/firmware/tools/xtensa/scripts/upload.py` contains a *store* through the
  alias (`...value.s = sha1_hash`). Reads raise on 3.14; stores just bind a dead
  attribute, so the sha1 update would quietly stop happening.
- `arvr/projects/sunstone/sunstone/pipeline_converter.py` -- the legacy arms sat
  below an `isinstance(node, ast.Constant)` arm that already matched them, so they
  have been unreachable since 3.8. Deleted rather than ported.
- `dba/api/log_parsing.py` -- the `ast.Num` and `ast.NameConstant` arms both assign
  `item.value`, so they collapse to one test over
  `(int, float, complex, type(None))`: `Num` excluded `bool`, `NameConstant`
  included it, and `bool` is already an `int`.

bypass-github-export-checks -- this is an internal-only 3.14 compatibility port
of files that are also mirrored to GitHub, so the export check wants a linked PR
that does not exist. Bypassing means DiffTrain will not carry the change outward
and the OSS copies need the same port applied upstream separately.

Reviewers have flagged `node.value.args[1].value[0]` and `re.match(..., arg.value)`
in `ast_linter.py` as able to raise on a non-`Constant` receiver. Both read `.s` on
the same unguarded receiver before this diff (with a `pyre-fixme` already
acknowledging it), so the exposure is pre-existing and only the alias is renamed.
Not hardened here for the same reason: a guard turns a crash into a silent skip,
which is a behaviour change the linter owners should make, not a 3.14 port.

Reviewed By: KasraGhodsi

Differential Revision: D114500250


