### PR TITLE
Intel XPU support (1/4): Add XPU device abstraction primitives

### DIFF
--- a/tritonbench/utils/env_utils.py
+++ b/tritonbench/utils/env_utils.py
@@ -112,6 +112,42 @@ def is_hip() -> bool:
     return torch.version.hip is not None
 
 
+def is_xpu() -> bool:
+    return torch.version.xpu is not None
+
+
+def get_current_device() -> str:
+    """Return the device string of the accelerator available on this host.
+
+    Falls back to "cuda" when torch reports no accelerator, so that CUDA-only
+    hosts and CPU-only environments keep the historical default.
+    """
+    try:
+        accelerator = torch.accelerator.current_accelerator()
+    except Exception:
+        return "cuda"
+    return accelerator.type if accelerator is not None else "cuda"
+
+
+def get_device_module(device: Optional[str] = None):
+    """Return the ``torch.<device>`` module for ``device`` (default: current one)."""
+    return getattr(torch, device or get_current_device(), torch.cuda)
+
+
+def get_num_sms(device=None) -> int:
+    """Number of independently schedulable compute units on ``device``.
+
+    NVIDIA/AMD report this as ``multi_processor_count``; Intel XPU exposes the
+    equivalent quantity as ``gpu_subslice_count``. Persistent kernels use it to
+    size their grid, so it must be resolved per device type.
+    """
+    device = torch.device(device) if device is not None else None
+    device_type = device.type if device is not None else get_current_device()
+    if device_type == "xpu":
+        return torch.xpu.get_device_properties(device).gpu_subslice_count
+    return torch.cuda.get_device_properties(device).multi_processor_count
+
+
 def is_hip_mi200():
     try:
         target = triton.runtime.driver.active.get_current_target()

--- a/tritonbench/utils/gpu_utils.py
+++ b/tritonbench/utils/gpu_utils.py
@@ -5,10 +5,11 @@ from contextlib import contextmanager
 from typing import Dict, List, Optional
 
 try:
-    from tritonbench.utils.env_utils import is_hip, is_mtia
+    from tritonbench.utils.env_utils import is_hip, is_mtia, is_xpu
 except ModuleNotFoundError:
     is_hip = lambda: False
     is_mtia = lambda: False
+    is_xpu = lambda: False
 
 # Defer MTIA check to avoid triggering Triton driver initialization at import time
 try:
@@ -106,6 +107,8 @@ def get_gpu_device_name() -> str:
 
         if is_hip():
             return get_amd_device_name()
+        if is_xpu():
+            return torch.xpu.get_device_name()
         return torch.cuda.get_device_name()
     except Exception:
         return "None"

--- a/tritonbench/utils/parser.py
+++ b/tritonbench/utils/parser.py
@@ -53,7 +53,7 @@ def get_parser(args=None):
         "--device",
         "-d",
         default="cuda",
-        choices=["cuda", "cpu", "mtia", "tpu"],
+        choices=["cuda", "cpu", "mtia", "tpu", "xpu"],
         help="Device to benchmark.",
     )
     parser.add_argument(


### PR DESCRIPTION
## PR series
1. -> [device abstraction primitives](https://github.com/meta-pytorch/tritonbench/pull/1217)
2. [Device-agnostic benchmark timing](https://github.com/meta-pytorch/tritonbench/pull/1218)
3. [Device-agnostic operators & kernels](https://github.com/meta-pytorch/tritonbench/pull/1219)
4. [Enable GPU test suite on XPU](https://github.com/meta-pytorch/tritonbench/pull/1220)

## Summary
First of a 4-PR series adding Intel XPU support to tritonbench. This PR adds the device-abstraction primitives that later PRs build on. **Pure additions — CUDA behavior is unchanged.**

- `utils/env_utils.py`: `is_xpu()`, `get_current_device()`, `get_device_module()`, `get_num_sms()`
- `utils/gpu_utils.py`: XPU branch in `get_gpu_device_name()`
- `utils/parser.py`: add `"xpu"` to `--device` choices


## Test plan
- [ ] Existing CUDA runs unaffected (new helpers default to `cuda`)
