### PR TITLE
Intel XPU support (2/4): Make benchmark timing device-agnostic

### DIFF
--- a/tritonbench/components/do_bench/run.py
+++ b/tritonbench/components/do_bench/run.py
@@ -11,7 +11,7 @@ from tritonbench.utils.constants import DEFAULT_N_REP, DEFAULT_N_WARMUP
 from tritonbench.utils.cudagraph_utils import CudaGraphConfig
 
 from .common import summarize_statistics
-from .utils import estimate_cuda_runtime_ms, resolve_warmup_and_rep
+from .utils import estimate_gpu_runtime_ms, resolve_warmup_and_rep
 
 # Triton is optional: non-Triton devices (cpu, tpu) can run without it. The
 # Triton-backed timing paths (events, power, cudagraph, the driver benchmarker)
@@ -311,7 +311,7 @@ def _do_bench_profiler(
     )
 
     clear_cache_fn = cache.zero_ if not skip_cache_clearing else lambda *args: None
-    estimate_ms = estimate_cuda_runtime_ms(
+    estimate_ms = estimate_gpu_runtime_ms(
         fn,
         grad_to_none=grad_to_none,
         clear_cache_fn=clear_cache_fn,
@@ -733,7 +733,7 @@ def do_bench_wrapper(
         and device not in ("cpu", "tpu")
         and latency_measure_mode == "triton_do_bench"
     ):
-        estimate_runtime = estimate_cuda_runtime_ms(fn, grad_to_none=grad_to_none)
+        estimate_runtime = estimate_gpu_runtime_ms(fn, grad_to_none=grad_to_none)
         warmup, rep = resolve_warmup_and_rep(
             warmup,
             rep,

--- a/tritonbench/components/do_bench/utils.py
+++ b/tritonbench/components/do_bench/utils.py
@@ -2,6 +2,7 @@ from typing import Callable, Iterable, Optional, Tuple
 
 import torch
 from tritonbench.utils.constants import DEFAULT_WARMUP_REP_BY_ESTIMATED_KERNEL_MS
+from tritonbench.utils.env_utils import get_device_module
 
 
 def resolve_warmup_and_rep(
@@ -19,14 +20,16 @@ def resolve_warmup_and_rep(
     )
 
 
-def estimate_cuda_runtime_ms(
+def estimate_gpu_runtime_ms(
     fn: Callable,
     grad_to_none: Optional[Iterable[torch.Tensor]] = None,
     clear_cache_fn: Optional[Callable[[], None]] = None,
     iters: int = 5,
     prime: bool = True,
 ) -> float:
+    """Estimate the per-iteration runtime of ``fn`` using GPU events."""
     clear_cache_fn = clear_cache_fn or (lambda: None)
+    device_module = get_device_module()
 
     def run_once() -> None:
         if grad_to_none is not None:
@@ -37,13 +40,18 @@ def estimate_cuda_runtime_ms(
 
     if prime:
         run_once()
-        torch.cuda.synchronize()
+        device_module.synchronize()
 
-    start_event = torch.cuda.Event(enable_timing=True)
-    end_event = torch.cuda.Event(enable_timing=True)
+    start_event = device_module.Event(enable_timing=True)
+    end_event = device_module.Event(enable_timing=True)
     start_event.record()
     for _ in range(iters):
         run_once()
     end_event.record()
-    torch.cuda.synchronize()
+    device_module.synchronize()
     return start_event.elapsed_time(end_event) / iters
+
+
+# Deprecated alias: this helper is no longer CUDA-specific. Kept so out-of-tree
+# callers keep working; prefer `estimate_gpu_runtime_ms`.
+estimate_cuda_runtime_ms = estimate_gpu_runtime_ms

--- a/tritonbench/components/kineto/trace.py
+++ b/tritonbench/components/kineto/trace.py
@@ -9,7 +9,7 @@ from typing import Callable, Optional
 import torch
 import torch.profiler as profiler
 from tritonbench.components.do_bench.utils import (
-    estimate_cuda_runtime_ms,
+    estimate_gpu_runtime_ms,
     resolve_warmup_and_rep,
 )
 from tritonbench.utils.constants import DEFAULT_N_REP, DEFAULT_N_WARMUP
@@ -185,7 +185,7 @@ def do_bench_kineto(
     else:
         clear_cache = lambda *args: None
 
-    estimate_ms = estimate_cuda_runtime_ms(fn, clear_cache_fn=clear_cache)
+    estimate_ms = estimate_gpu_runtime_ms(fn, clear_cache_fn=clear_cache)
     warmup, rep = resolve_warmup_and_rep(warmup, rep, estimate_ms)
 
     # Calculate number of iterations based on target rep time

--- a/tritonbench/components/ncu/__init__.py
+++ b/tritonbench/components/ncu/__init__.py
@@ -2,7 +2,7 @@ from typing import Callable
 
 import torch
 from tritonbench.components.do_bench.utils import (
-    estimate_cuda_runtime_ms,
+    estimate_gpu_runtime_ms,
     resolve_warmup_and_rep,
 )
 
@@ -45,7 +45,7 @@ def do_bench_in_task(
     cache = torch.empty(int(256e6 // 4), dtype=torch.int, device="cuda")
 
     if warmup == True:
-        estimate_ms = estimate_cuda_runtime_ms(fn, clear_cache_fn=cache.zero_)
+        estimate_ms = estimate_gpu_runtime_ms(fn, clear_cache_fn=cache.zero_)
         warmup, _ = resolve_warmup_and_rep(warmup, None, estimate_ms)
 
         # compute number of warmup and repeat

--- a/tritonbench/utils/run_utils.py
+++ b/tritonbench/utils/run_utils.py
@@ -31,11 +31,12 @@ from tritonbench.utils.env_utils import (
     is_triton_beta,
     is_triton_main,
     is_triton_stable,
+    is_xpu,
     set_torchrun_env,
 )
 from tritonbench.utils.git_utils import get_branch, get_commit_time, get_current_hash
 from tritonbench.utils.gpu_telemetry_observer import TelemetryContext
-from tritonbench.utils.gpu_utils import get_amd_device_name, gpu_lockdown
+from tritonbench.utils.gpu_utils import get_gpu_device_name, gpu_lockdown
 from tritonbench.utils.helion_utils import apply_helion_backend_override
 from tritonbench.utils.list_operator_details import list_operator_details
 from tritonbench.utils.parser import get_parser
@@ -78,6 +79,7 @@ ENV_CHECK_MAP = {
         "b200": is_blackwell,
         "cuda": is_cuda,
         "hip": is_hip,
+        "xpu": is_xpu,
     },
     "channels": {
         "triton-main": is_triton_main,
@@ -105,14 +107,14 @@ def get_run_env(
     run_env["benchmark_date"] = run_timestamp
     if is_hip():
         run_env["cuda_version"] = torch.version.hip
+    elif is_xpu():
+        run_env["cuda_version"] = str(torch.version.xpu)
     else:
         run_env["cuda_version"] = (
             torch.version.cuda if torch.version.cuda else "unknown"
         )
     try:
-        run_env["device"] = (
-            get_amd_device_name() if is_hip() else torch.cuda.get_device_name()
-        )
+        run_env["device"] = get_gpu_device_name()
     except AssertionError:
         run_env["device"] = "unknown"
     run_env["conda_env"] = os.environ.get("CONDA_ENV", "unknown")

--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -41,7 +41,7 @@ except ImportError:
 
 from tritonbench.components.do_bench import do_bench_wrapper, Latency
 from tritonbench.components.do_bench.utils import (
-    estimate_cuda_runtime_ms,
+    estimate_gpu_runtime_ms,
     resolve_warmup_and_rep,
 )
 from tritonbench.components.export import export_data
@@ -62,9 +62,11 @@ from tritonbench.utils.diode_utils import (
 )
 from tritonbench.utils.env_utils import (
     apply_precision,
+    get_device_module,
     is_fbcode,
     is_hip,
     is_mtia,
+    is_xpu,
     override_default_precision_for_input_loader,
     reset_allow_tf32,
     set_allow_tf32,
@@ -175,13 +177,14 @@ class TimerContext:
 
 
 def do_bench_walltime(fn, warmup=None, rep=None):
+    device_module = get_device_module()
     fn()
-    torch.cuda.synchronize()
+    device_module.synchronize()
 
     with TimerContext() as timer:
         for _ in range(5):
             fn()
-        torch.cuda.synchronize()
+        device_module.synchronize()
     estimate_ms = timer.elapsed_ms / 5
     warmup, rep = resolve_warmup_and_rep(warmup, rep, estimate_ms)
 
@@ -196,19 +199,21 @@ def do_bench_walltime(fn, warmup=None, rep=None):
     # Warm-up
     for _ in range(n_warmup):
         fn()
-    torch.cuda.synchronize()
+    device_module.synchronize()
 
     # Benchmark
     start_time = time.perf_counter()
     for _ in range(n_repeat):
         fn()
-    torch.cuda.synchronize()
+    device_module.synchronize()
     end_time = time.perf_counter()
     wall_time_ms = (end_time - start_time) * 1e3 / n_repeat
     return wall_time_ms
 
 
 def _get_current_device_id() -> int:
+    if is_xpu():
+        return torch.xpu.current_device()
     return torch.cuda.current_device()
 
 
@@ -2755,10 +2760,11 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
             flop_counter = FlopCounterMode()
 
             def work_func():
-                if self.device == "cuda":
-                    torch.cuda.synchronize()
+                if self.device in ("cuda", "xpu"):
+                    device_module = get_device_module(self.device)
+                    device_module.synchronize()
                     func()
-                    torch.cuda.synchronize()
+                    device_module.synchronize()
                 else:
                     func()
 


### PR DESCRIPTION
## PR series
1. [device abstraction primitives](https://github.com/meta-pytorch/tritonbench/pull/1217)
2. -> [Device-agnostic benchmark timing](https://github.com/meta-pytorch/tritonbench/pull/1218)
3. [Device-agnostic operators & kernels](https://github.com/meta-pytorch/tritonbench/pull/1219)
4. [Enable GPU test suite on XPU](https://github.com/meta-pytorch/tritonbench/pull/1220)

## Summary
Part 2/4 of Intel XPU support. **Depends on #1217** (device abstraction primitives). Kept as draft until #1217 lands; will be rebased onto `main` afterward.

- Rename `estimate_cuda_runtime_ms` → `estimate_gpu_runtime_ms` (keeps a back-compat alias)
- Route timing/telemetry through `get_device_module()` instead of `torch.cuda.*`
- Covers `do_bench`, `kineto`, `ncu`, `triton_op`, `run_utils`

> Note: this PR currently targets `main`, so its diff temporarily includes #1217's changes. Review only this PR's own commit; it becomes minimal once #1217 merges and this is rebased.

## Test plan
- [ ] CUDA timing paths unchanged
- [ ] Back-compat alias keeps out-of-tree callers working