### PR TITLE
Intel XPU support (3/4): Make operators and kernels device-agnostic for XPU

### DIFF
--- a/tritonbench/kernels/profile.py
+++ b/tritonbench/kernels/profile.py
@@ -14,6 +14,23 @@ IS_CUDA = tl.constexpr(is_cuda())
 IS_HIP = tl.constexpr(is_hip())
 
 
+def has_gpu_timer() -> bool:
+    """Whether ``time()``/``smid()`` below can be compiled on this platform.
+
+    Only CUDA and HIP expose the required intrinsics. Triton's Intel backend
+    declares ``tl.extra.intel.globaltimer``/``smid``, but both are verbatim
+    copies of the NVIDIA PTX inline asm, so they fail to build on SPIR-V
+    ("Constraints for inline assembly cannot be validated"). The portable
+    replacement, SPIR-V's ``OpReadClockKHR``, needs ``SPV_KHR_shader_clock``,
+    which Triton's SPIR-V translator does not currently allow either.
+
+    Callers should pass ``profile_mem=None`` when this returns False so that
+    the instrumented branches are never instantiated, rather than recording
+    bogus zero timestamps.
+    """
+    return is_cuda() or is_hip()
+
+
 @triton.jit
 def time(_semantic=None):
     if IS_HIP:

--- a/tritonbench/kernels/triton_fused_attention.py
+++ b/tritonbench/kernels/triton_fused_attention.py
@@ -18,6 +18,7 @@ import torch
 import triton
 import triton.language as tl
 from triton import knobs
+from tritonbench.utils.env_utils import get_num_sms
 
 from .attention_utils import (
     HAS_EXPLICIT_WS,  # guard new tuning configs such as num_consumer_groups
@@ -2547,7 +2548,7 @@ class _attention_opt(torch.autograd.Function):
                 1,
             )
 
-        NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+        NUM_SMS = get_num_sms(q.device)
 
         def grid_tma_persistent(META):
             return (
@@ -2565,7 +2566,7 @@ class _attention_opt(torch.autograd.Function):
 
         # TMA descriptors require a global memory allocation
         def alloc_fn(size: int, alignment: int, stream: Optional[int]):
-            return torch.empty(size, device="cuda", dtype=torch.int8)
+            return torch.empty(size, device=q.device, dtype=torch.int8)
 
         if HAS_NEW_TMA:
             triton.set_allocator(alloc_fn)

--- a/tritonbench/operators/bf16xint16_gemm/kernel.py
+++ b/tritonbench/operators/bf16xint16_gemm/kernel.py
@@ -5,7 +5,7 @@ Triton implementation by @jlebar: https://gist.github.com/jlebar/3435b2c00deea53
 import torch
 import triton
 import triton.language as tl
-from tritonbench.utils.env_utils import is_cuda
+from tritonbench.utils.env_utils import is_cuda, is_xpu
 
 
 def get_cuda_autotune_config():
@@ -236,6 +236,9 @@ def get_hip_autotune_config():
 
 def get_autotune_config():
     if is_cuda():
+        return get_cuda_autotune_config()
+    elif is_xpu():
+        # TODO: Add get_xpu_autotune_config() when we have a good config for xpu
         return get_cuda_autotune_config()
     else:
         return get_hip_autotune_config()

--- a/tritonbench/operators/flex_attention/operator.py
+++ b/tritonbench/operators/flex_attention/operator.py
@@ -81,13 +81,6 @@ MOD_TYPES = [
 TANH_SOFTCAP = 20
 
 
-def _accel_device() -> str:
-    """Current accelerator device string ("cuda", "xpu", ...), defaulting to
-    "cuda". Used in place of hardcoded "cuda" so this operator's input/mask
-    construction runs on non-CUDA accelerators (e.g. Intel XPU)."""
-    return get_current_device()
-
-
 class FullShape(NamedTuple):
     B: int
     Hq: int
@@ -513,7 +506,7 @@ class Operator(BenchmarkOperator):
 
         if mod_type == "alibi":
             """
-            h = torch.arange(Hq, dtype=torch.float32, device=_accel_device())
+            h = torch.arange(Hq, dtype=torch.float32, device=get_current_device())
             alibi_slopes = torch.exp2(-((h + 1) * 8.0 / Hq))
             FA_kwargs["alibi_slopes"] = alibi_slopes
 
@@ -766,7 +759,9 @@ class Operator(BenchmarkOperator):
         if attn_type == "document_mask":
             random.seed(0)
             lengths = generate_random_lengths(N * B, B)
-            mask_mod_kwargs = dict(offsets=length_to_offsets(lengths, _accel_device()))
+            mask_mod_kwargs = dict(
+                offsets=length_to_offsets(lengths, get_current_device())
+            )
 
         mask_mod_dict = {
             "noop": None,
@@ -786,7 +781,7 @@ class Operator(BenchmarkOperator):
             mask_mod = mask_mod(**mask_mod_kwargs)
 
         if is_decoding and mask_mod:
-            cached_seq_len = torch.tensor(N // 2).to(_accel_device())
+            cached_seq_len = torch.tensor(N // 2).to(get_current_device())
 
             def decoding_w_cached_seq_len(b, h, m, n):
                 return mask_mod(b, h, m + cached_seq_len, n)
@@ -800,7 +795,7 @@ class Operator(BenchmarkOperator):
         )
         compiled_block_mask = torch.compile(create_block_mask)
         block_mask = (
-            compiled_block_mask(new_mask_mod, *mask_shape, _accel_device())
+            compiled_block_mask(new_mask_mod, *mask_shape, get_current_device())
             if new_mask_mod
             else None
         )
@@ -837,7 +832,7 @@ class Operator(BenchmarkOperator):
         score_mod = function_dict[attn_type]
         is_decoding = M == 1
         if is_decoding and score_mod:
-            offset = torch.tensor(N // 2).to(_accel_device())
+            offset = torch.tensor(N // 2).to(get_current_device())
 
             def score_mod_w_offset(score, b, h, m, n):
                 return score_mod(score, b, h, m + offset, n)

--- a/tritonbench/operators/flex_attention/operator.py
+++ b/tritonbench/operators/flex_attention/operator.py
@@ -31,7 +31,13 @@ from tritonbench.operators.flex_attention.triton_autows import (
     autows_flex_attention,
     autows_flex_attention_persistent,
 )
-from tritonbench.utils.env_utils import is_amd_gfx950, is_hip, is_nvidia_blackwell
+from tritonbench.utils.env_utils import (
+    get_current_device,
+    get_num_sms,
+    is_amd_gfx950,
+    is_hip,
+    is_nvidia_blackwell,
+)
 from tritonbench.utils.input import input_filter
 from tritonbench.utils.triton_op import (
     BenchmarkOperator,
@@ -73,6 +79,13 @@ MOD_TYPES = [
 # Soft cap value for the tanh-softcap score_mod, shared by the providers and the
 # eager reference.
 TANH_SOFTCAP = 20
+
+
+def _accel_device() -> str:
+    """Current accelerator device string ("cuda", "xpu", ...), defaulting to
+    "cuda". Used in place of hardcoded "cuda" so this operator's input/mask
+    construction runs on non-CUDA accelerators (e.g. Intel XPU)."""
+    return get_current_device()
 
 
 class FullShape(NamedTuple):
@@ -500,7 +513,7 @@ class Operator(BenchmarkOperator):
 
         if mod_type == "alibi":
             """
-            h = torch.arange(Hq, dtype=torch.float32, device="cuda")
+            h = torch.arange(Hq, dtype=torch.float32, device=_accel_device())
             alibi_slopes = torch.exp2(-((h + 1) * 8.0 / Hq))
             FA_kwargs["alibi_slopes"] = alibi_slopes
 
@@ -693,7 +706,9 @@ class Operator(BenchmarkOperator):
                     "BLOCK_M2": 64,
                     "BLOCK_N2": 64,
                 }
-                if torch.cuda.get_device_capability() >= (8, 0) and D <= 128
+                if torch.cuda.is_available()
+                and torch.cuda.get_device_capability() >= (8, 0)
+                and D <= 128
                 else None
             ),
             "prefix_lm": None,
@@ -701,7 +716,7 @@ class Operator(BenchmarkOperator):
         }
 
         def get_default_split_k(B: int, H: int, Mk: int) -> int:
-            num_SM = torch.cuda.get_device_properties("cuda").multi_processor_count
+            num_SM = get_num_sms()
             """Heuristic for the number of splits from xformer"""
             bh = max(B * H, 1)  # NOTE: Handle B*h=0 case
             split_k = num_SM // bh * 2  # Each SM should at least get one block.
@@ -751,7 +766,7 @@ class Operator(BenchmarkOperator):
         if attn_type == "document_mask":
             random.seed(0)
             lengths = generate_random_lengths(N * B, B)
-            mask_mod_kwargs = dict(offsets=length_to_offsets(lengths, "cuda"))
+            mask_mod_kwargs = dict(offsets=length_to_offsets(lengths, _accel_device()))
 
         mask_mod_dict = {
             "noop": None,
@@ -771,7 +786,7 @@ class Operator(BenchmarkOperator):
             mask_mod = mask_mod(**mask_mod_kwargs)
 
         if is_decoding and mask_mod:
-            cached_seq_len = torch.tensor(N // 2).to("cuda")
+            cached_seq_len = torch.tensor(N // 2).to(_accel_device())
 
             def decoding_w_cached_seq_len(b, h, m, n):
                 return mask_mod(b, h, m + cached_seq_len, n)
@@ -785,7 +800,7 @@ class Operator(BenchmarkOperator):
         )
         compiled_block_mask = torch.compile(create_block_mask)
         block_mask = (
-            compiled_block_mask(new_mask_mod, *mask_shape, "cuda")
+            compiled_block_mask(new_mask_mod, *mask_shape, _accel_device())
             if new_mask_mod
             else None
         )
@@ -822,7 +837,7 @@ class Operator(BenchmarkOperator):
         score_mod = function_dict[attn_type]
         is_decoding = M == 1
         if is_decoding and score_mod:
-            offset = torch.tensor(N // 2).to("cuda")
+            offset = torch.tensor(N // 2).to(_accel_device())
 
             def score_mod_w_offset(score, b, h, m, n):
                 return score_mod(score, b, h, m + offset, n)

--- a/tritonbench/operators/fp8_gemm/fp8_gemm.py
+++ b/tritonbench/operators/fp8_gemm/fp8_gemm.py
@@ -111,6 +111,8 @@ def get_fp8_dtype():
         if torch.cuda.get_device_capability() < (9, 5):
             return torch.float8_e4m3fnuz
         return torch.float8_e4m3fn
+    elif torch.xpu._is_compiled():
+        return torch.float8_e4m3fn
     return torch.float8_e4m3fnuz
 
 

--- a/tritonbench/operators/fp8_gemm/persistent.py
+++ b/tritonbench/operators/fp8_gemm/persistent.py
@@ -6,7 +6,7 @@ import triton
 import triton.language as tl
 from torch._inductor.kernel.mm import ScalingType
 from triton import knobs
-from tritonbench.utils.env_utils import is_cuda
+from tritonbench.utils.env_utils import get_num_sms, is_cuda
 from tritonbench.utils.triton_utils import has_experimental_descriptor
 
 if has_experimental_descriptor():
@@ -169,7 +169,7 @@ def matmul_persistent(a, b):
     # Check constraints.
     assert a.shape[1] == b.shape[0], "Incompatible dimensions"
     assert a.dtype == b.dtype, "Incompatible dtypes"
-    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+    NUM_SMS = get_num_sms(a.device)
     M, K = a.shape
     K, N = b.shape
     dtype = a.dtype
@@ -386,7 +386,7 @@ def matmul_tma_persistent(a, b, c, desc_a, desc_b, desc_c):
     N, K = b.shape
     dtype = a.dtype
 
-    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+    NUM_SMS = get_num_sms(a.device)
 
     grid = lambda META: (
         min(
@@ -434,9 +434,7 @@ def blackwell_persistent_tma(a, b, scale_a_ptr, scale_b_ptr, acc_dtype, scaling_
     N, K = b.shape
     shape_dtype = a.dtype  # low-precision dtype, e.g. fp8
 
-    NUM_SMS = torch.cuda.get_device_properties(
-        torch.cuda.current_device()
-    ).multi_processor_count
+    NUM_SMS = get_num_sms(a.device)
 
     c = torch.zeros((M, N), device=a.device, dtype=acc_dtype)
 

--- a/tritonbench/operators/fp8_gemm/tutorial.py
+++ b/tritonbench/operators/fp8_gemm/tutorial.py
@@ -152,7 +152,7 @@ You will specifically learn about:
 import torch
 import triton
 import triton.language as tl
-from tritonbench.utils.env_utils import is_cuda
+from tritonbench.utils.env_utils import is_cuda, is_xpu
 
 
 def get_cuda_autotune_config():
@@ -383,6 +383,8 @@ def get_hip_autotune_config():
 
 def get_autotune_config():
     if is_cuda():
+        return get_cuda_autotune_config()
+    elif is_xpu():
         return get_cuda_autotune_config()
     else:
         return get_hip_autotune_config()

--- a/tritonbench/operators/gather_gemv/operator.py
+++ b/tritonbench/operators/gather_gemv/operator.py
@@ -79,8 +79,8 @@ class Operator(BenchmarkOperator):
         for i in range(11, 15):
             S = 2**i
             arg0_1 = rand_strided(
-                (8, S, S), (S * S, S, 1), device="cuda:0", dtype=torch.int8
+                (8, S, S), (S * S, S, 1), device=self.device, dtype=torch.int8
             )
-            arg1_1 = rand_strided((2,), (1,), device="cuda:0", dtype=torch.int64)
-            arg2_1 = rand_strided((S,), (1,), device="cuda:0", dtype=torch.bfloat16)
+            arg1_1 = rand_strided((2,), (1,), device=self.device, dtype=torch.int64)
+            arg2_1 = rand_strided((S,), (1,), device=self.device, dtype=torch.bfloat16)
             yield arg0_1, arg1_1, arg2_1

--- a/tritonbench/operators/gather_gemv/triton_gather_gemv.py
+++ b/tritonbench/operators/gather_gemv/triton_gather_gemv.py
@@ -5,8 +5,8 @@ Based on https://github.com/pytorch/pytorch/issues/121661
 import torch
 import triton
 import triton.language as tl
+from tritonbench.utils.env_utils import get_device_module
 
-empty_strided_cuda = torch._C._dynamo.guards._empty_strided_cuda
 reinterpret_tensor = torch.ops.inductor._reinterpret_tensor
 assert_size_stride = torch._C._dynamo.guards.assert_size_stride
 
@@ -118,10 +118,10 @@ def triton_gemv_0(arg0_1, arg1_1, arg2_1):
     assert_size_stride(arg2_1, (S,), (1,))
     xnumel = 2 * S
     rnumel = S
-    with torch.cuda._DeviceGuard(0):
-        torch.cuda.set_device(0)
+    device = arg0_1.device
+    with get_device_module(device.type).device(device.index):
         # size will be double
-        buf1 = empty_strided_cuda((2 * S,), (1,), torch.bfloat16)
+        buf1 = torch.empty_strided((2 * S,), (1,), dtype=torch.bfloat16, device=device)
 
         grid = lambda META: (triton.cdiv(2 * S, META["XBLOCK"]),)
         triton_red_fused_mv_0[grid](arg1_1, arg0_1, arg2_1, buf1, xnumel, rnumel)

--- a/tritonbench/operators/gdn_fwd_h/operator.py
+++ b/tritonbench/operators/gdn_fwd_h/operator.py
@@ -252,7 +252,7 @@ class Operator(BenchmarkOperator):
             )
             nchunks = (seqlen + chunk_size - 1) // chunk_size
             k = torch.randn(
-                batch, seqlen, nheads, dhead, dtype=torch.bfloat16, device="cuda"
+                batch, seqlen, nheads, dhead, dtype=torch.bfloat16, device=self.device
             )
             w = torch.randn(
                 batch,
@@ -261,7 +261,7 @@ class Operator(BenchmarkOperator):
                 nheads,
                 dhead,
                 dtype=torch.float32,
-                device="cuda",
+                device=self.device,
             )
             wu, ws, wv = torch.linalg.svd(w.permute(0, 1, 3, 2, 4), full_matrices=False)
             w = torch.einsum("bnhik,bnhkj->bnhij", wu, wv)
@@ -276,12 +276,14 @@ class Operator(BenchmarkOperator):
                 nheads,
                 expand_v * dhead,
                 dtype=torch.bfloat16,
-                device="cuda",
+                device=self.device,
             )
             g = torch.cumsum(
                 0.5
                 * math.log(1 / dhead)
-                * torch.rand(batch, seqlen, nheads, dtype=torch.float32, device="cuda"),
+                * torch.rand(
+                    batch, seqlen, nheads, dtype=torch.float32, device=self.device
+                ),
                 dim=1,
             )
             yield k, w, u, g, chunk_size

--- a/tritonbench/operators/gdpa/gdpa.py
+++ b/tritonbench/operators/gdpa/gdpa.py
@@ -46,7 +46,9 @@ except ImportError:
     HAS_TLX = False
 
 try:
-    BF16_ATOMIC_ADD_SUPPORTED = torch.cuda.get_device_capability() >= (9, 0)
+    BF16_ATOMIC_ADD_SUPPORTED = torch.cuda.is_available() and (
+        torch.cuda.get_device_capability() >= (9, 0)
+    )
 except RuntimeError:  # Not running on GPU device
     BF16_ATOMIC_ADD_SUPPORTED = False
 
@@ -1972,7 +1974,7 @@ def generalized_dot_product_attention(
     if enable_tma:
         # TMA descriptors require a global memory allocation
         def alloc_fn(size: int, alignment: int, stream: int | None):
-            return torch.empty(size, device="cuda", dtype=torch.int8)
+            return torch.empty(size, device=q.device, dtype=torch.int8)
 
         triton.set_allocator(alloc_fn)
 

--- a/tritonbench/operators/gdpa/gdpa_utils.py
+++ b/tritonbench/operators/gdpa/gdpa_utils.py
@@ -7,6 +7,7 @@ from typing import Any, List, Optional
 
 import torch
 import triton  # @manual=//triton:triton
+from tritonbench.utils.env_utils import get_current_device, get_num_sms as _get_num_sms
 
 
 def generate_sparse_seq_len(
@@ -57,7 +58,7 @@ def generate_jagged_data(
     dff: int | None = None,
 ) -> dict[str, Any]:
     if device is None:
-        device = torch.device("cuda:0")
+        device = torch.device(get_current_device())
 
     if num_objects is None:
         num_objects = generate_sparse_seq_len(
@@ -135,7 +136,7 @@ def generate_jagged_data(
             B * dff,
             H,
             D,
-            device="cuda",
+            device=device,
             dtype=dtype,
             requires_grad=True,
         ).contiguous()
@@ -143,7 +144,7 @@ def generate_jagged_data(
             B * dff,
             H,
             D,
-            device="cuda",
+            device=device,
             dtype=dtype,
             requires_grad=True,
         ).contiguous()
@@ -151,7 +152,7 @@ def generate_jagged_data(
             torch.arange(
                 B + 1,
                 dtype=torch.int,
-                device="cuda",
+                device=device,
             )
             * dff
         )
@@ -261,5 +262,5 @@ def get_autotune_kernel(kernel, autotune_configs, **kwargs):
 
 @lru_cache
 def get_num_sms() -> Optional[int]:
-    if torch.cuda.is_available():
-        return torch.cuda.get_device_properties("cuda").multi_processor_count
+    if torch.accelerator.is_available():
+        return _get_num_sms()

--- a/tritonbench/operators/gdpa/operator.py
+++ b/tritonbench/operators/gdpa/operator.py
@@ -30,7 +30,7 @@ import gc
 from typing import Any, Callable, Generator, List, Optional
 
 import torch
-from tritonbench.utils.env_utils import is_blackwell, is_hip
+from tritonbench.utils.env_utils import get_device_module, is_blackwell, is_hip
 from tritonbench.utils.triton_op import (
     BenchmarkOperator,
     BenchmarkOperatorMetrics,
@@ -525,6 +525,7 @@ class Operator(BenchmarkOperator):
                 dense_q_len=dense_q_len,
                 broadcast_q=broadcast_q,
                 dff=dff,
+                device=self.device,
             )
             jagged_data["max_seq_len"] = max_M
             jagged_data["q_offsets"] = jagged_data["q_offsets"].to(torch.int32)
@@ -624,16 +625,17 @@ class Operator(BenchmarkOperator):
 
         # Calculate activation
         gc.collect()
-        torch.cuda.empty_cache()
+        device_module = get_device_module(self.device)
+        device_module.empty_cache()
         MB = 1024.0 * 1024.0
-        torch.cuda.reset_peak_memory_stats(device="cuda")
-        memory_start = torch.cuda.max_memory_allocated(device="cuda") / MB
+        device_module.reset_peak_memory_stats(device=self.device)
+        memory_start = device_module.max_memory_allocated(device=self.device) / MB
 
         output = fwd_fn()
         do = torch.rand_like(output) * 0.01
         output.backward(do, retain_graph=True)
 
-        memory_end = torch.cuda.max_memory_allocated(device="cuda") / MB
+        memory_end = device_module.max_memory_allocated(device=self.device) / MB
         memory_used_MB = memory_end - memory_start
 
         return memory_used_MB

--- a/tritonbench/operators/gdpa/triton_autows.py
+++ b/tritonbench/operators/gdpa/triton_autows.py
@@ -8,6 +8,7 @@ import triton
 # @manual=//triton:triton
 import triton.language as tl
 from triton.tools.tensor_descriptor import TensorDescriptor
+from tritonbench.utils.env_utils import get_num_sms
 
 
 @triton.jit
@@ -451,7 +452,7 @@ def triton_autows_gdpa_persistent(
 
     n_tile_num = triton.cdiv(max_seq_len_q, block_m)
     n_kv_blocks = triton.cdiv(max_seq_len_kv, block_n)
-    num_sms = torch.cuda.get_device_properties(query.device).multi_processor_count
+    num_sms = get_num_sms(query.device)
 
     def grid(_meta):
         total_tiles = batch * heads * n_tile_num

--- a/tritonbench/operators/gemm/operator.py
+++ b/tritonbench/operators/gemm/operator.py
@@ -365,7 +365,7 @@ class Operator(BenchmarkOperator):
         else:
             return lambda: torch.matmul(a, b)
 
-    @register_benchmark()
+    @register_benchmark(enabled=is_cuda())
     def aten_tunableop_matmul(self, a, b, bias) -> Callable:
         is_enabled = torch.cuda.tunable.is_enabled()
 

--- a/tritonbench/operators/gemm/persistent_matmul.py
+++ b/tritonbench/operators/gemm/persistent_matmul.py
@@ -3,7 +3,7 @@ import os
 import torch
 import triton
 import triton.language as tl
-from tritonbench.utils.env_utils import is_tile_enabled
+from tritonbench.utils.env_utils import get_num_sms, is_tile_enabled
 
 from .triton_matmul_configs import get_full_amd_config_space, get_tileir_configs
 
@@ -190,7 +190,7 @@ def matmul_persistent(a, b):
     # Check constraints.
     assert a.shape[1] == b.shape[0], "Incompatible dimensions"
     assert a.dtype == b.dtype, "Incompatible dtypes"
-    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+    NUM_SMS = get_num_sms(a.device)
     M, K = a.shape
     K, N = b.shape
     dtype = a.dtype

--- a/tritonbench/operators/grouped_gemm/kernels.py
+++ b/tritonbench/operators/grouped_gemm/kernels.py
@@ -33,6 +33,7 @@ import torch
 import triton
 import triton.language as tl
 from triton import knobs
+from tritonbench.utils.env_utils import get_current_device, get_num_sms
 
 try:
     # @manual=//triton:triton
@@ -48,7 +49,7 @@ def is_cuda():
 
 
 def num_sms():
-    return torch.cuda.get_device_properties("cuda").multi_processor_count
+    return get_num_sms()
 
 
 def is_hip_async_copy_enabled():
@@ -493,7 +494,7 @@ def tlx_group_gemm_fn(
 ):
     # TMA descriptors require a global memory allocation
     def alloc_fn(size: int, alignment: int, stream: Optional[int]):
-        return torch.empty(size, device="cuda", dtype=torch.int8)
+        return torch.empty(size, device=get_current_device(), dtype=torch.int8)
 
     triton.set_allocator(alloc_fn)
     grid = lambda META: (META["NUM_SMS"],)

--- a/tritonbench/operators/grouped_gemm/operator.py
+++ b/tritonbench/operators/grouped_gemm/operator.py
@@ -752,9 +752,13 @@ class Operator(BenchmarkOperator):
             g_lds += [A.stride(0), B.stride(0), C.stride(0)]
 
         # note these are device tensors
-        d_a_ptrs = torch.tensor(A_addrs, device=device)
-        d_b_ptrs = torch.tensor(B_addrs, device=device)
-        d_c_ptrs = torch.tensor(C_addrs, device=device)
+        # Raw data_ptr() values are unsigned 64-bit addresses. On some devices
+        # (e.g. Intel XPU) they exceed INT64_MAX, so torch's default int64
+        # inference raises "Overflow when unpacking long long". Pack them as
+        # uint64 explicitly; the kernel reinterprets each element as a pointer.
+        d_a_ptrs = torch.tensor(A_addrs, dtype=torch.uint64, device=device)
+        d_b_ptrs = torch.tensor(B_addrs, dtype=torch.uint64, device=device)
+        d_c_ptrs = torch.tensor(C_addrs, dtype=torch.uint64, device=device)
         d_g_sizes = torch.tensor(g_sizes, dtype=torch.int32, device=device)
         d_g_lds = torch.tensor(g_lds, dtype=torch.int32, device=device)
 

--- a/tritonbench/operators/jagged_sum/operator.py
+++ b/tritonbench/operators/jagged_sum/operator.py
@@ -5,6 +5,7 @@ from typing import Any, Callable, Generator, List, Optional, Tuple
 import torch
 import triton
 from tritonbench.data import get_input_loader
+from tritonbench.kernels.profile import has_gpu_timer
 from tritonbench.utils.jagged_utils import (
     ABSOLUTE_TOLERANCE,
     generate_input_vals,
@@ -70,8 +71,12 @@ def execute_kernel_variable_length_loop(x, sum_then_buffer):
     B, M = x.shape[0], x.shape[2]
     grid = lambda meta: ((len(x.offsets()) - 1) * triton.cdiv(M, meta["BLOCK_SIZE_M"]),)
     kernel_output = torch.zeros((B, M), device=x.device)
-    # The size of the profile memory will be determined by the autotuner
-    profile_mem = torch.empty(0, dtype=torch.int64, device=x.device)
+    # The size of the profile memory will be determined by the autotuner.
+    # Platforms without an in-kernel timer (see has_gpu_timer) pass None so the
+    # instrumented branches are compiled out instead of recording bogus values.
+    profile_mem = (
+        torch.empty(0, dtype=torch.int64, device=x.device) if has_gpu_timer() else None
+    )
 
     if sum_then_buffer:
         triton_jagged_sum_kernel_variable_length_loop_sum_then_buffer[grid](

--- a/tritonbench/operators/launch_latency/kernels.py
+++ b/tritonbench/operators/launch_latency/kernels.py
@@ -4,6 +4,7 @@ import torch
 import triton
 import triton.language as tl
 from triton.tools.tensor_descriptor import TensorDescriptor
+from tritonbench.utils.env_utils import get_current_device
 
 # Compatibility: c_cache kwarg was added in a newer Triton version.
 # When tritonbench pins an older Triton, fall back to plain @triton.jit.
@@ -231,8 +232,9 @@ def nop_tensordesc_kernel_nocache(
 def make_tensordesc_inputs(m_block: int = 8, n_block: int = 32):
     M = m_block * 3
     N = n_block * 4
-    t = torch.zeros((M, N), device="cuda", dtype=torch.float16)
-    out = torch.zeros((m_block, n_block), device="cuda", dtype=torch.float16)
+    device = get_current_device()
+    t = torch.zeros((M, N), device=device, dtype=torch.float16)
+    out = torch.zeros((m_block, n_block), device=device, dtype=torch.float16)
     desc = TensorDescriptor(
         t, shape=t.shape, strides=t.stride(), block_shape=[m_block, n_block]
     )
@@ -253,9 +255,10 @@ def auto_tma_add_kernel(x_ptr, y_ptr, out_ptr, N, BLOCK: tl.constexpr):
 
 
 def make_auto_tma_inputs(N: int = 8192, block: int = 256):
-    x = torch.randn(N, device="cuda", dtype=torch.float16)
-    y = torch.randn(N, device="cuda", dtype=torch.float16)
-    out = torch.empty(N, device="cuda", dtype=torch.float16)
+    device = get_current_device()
+    x = torch.randn(N, device=device, dtype=torch.float16)
+    y = torch.randn(N, device=device, dtype=torch.float16)
+    out = torch.empty(N, device=device, dtype=torch.float16)
     return x, y, out, N, block
 
 
@@ -428,7 +431,7 @@ def get_inductor_nop_kernel_0arg():
     Internally operates on a pre-allocated tensor to force exactly one kernel
     launch, but the caller invokes it with no arguments.
     """
-    x = torch.zeros(1, device="cuda")
+    x = torch.zeros(1, device=get_current_device())
 
     @torch.compile
     def _nop_impl(x):
@@ -490,7 +493,7 @@ def get_inductor_nop_kernel(tensor_args=None):
     CachingAutotuner.run = capturing_run
     try:
         if len(targs) < 2:
-            x = torch.zeros(1, device="cuda")
+            x = torch.zeros(1, device=get_current_device())
 
             @torch.compile
             def _nop(t):

--- a/tritonbench/operators/launch_latency/operator.py
+++ b/tritonbench/operators/launch_latency/operator.py
@@ -359,12 +359,12 @@ class Operator(BenchmarkOperator):
 
     def get_input_iter(self):
         yield tuple()
-        targs = [zeros(1, device="cuda") for _ in range(5)]
+        targs = [zeros(1, device=self.device) for _ in range(5)]
         iargs = [1 for _ in range(9)]
         cargs = [32 for _ in range(5)]
         yield tuple([*targs, *iargs, *cargs])
         # HSTU-like input: 14 pointers + 26 scalars + 18 constexprs = 58 args
-        hstu_ptrs = [zeros(1, device="cuda") for _ in range(14)]
+        hstu_ptrs = [zeros(1, device=self.device) for _ in range(14)]
         hstu_scalars = [1 for _ in range(26)]
         hstu_constexprs = [1 for _ in range(18)]
         yield tuple([*hstu_ptrs, *hstu_scalars, *hstu_constexprs])
@@ -475,13 +475,13 @@ class Operator(BenchmarkOperator):
         """
         if len(args) < 19:
             return lambda: nop_kernel[1,]()
-        q = zeros(1, device="cuda")
-        k = zeros(1, device="cuda")
-        v = zeros(1, device="cuda")
-        out = zeros(1, device="cuda")
-        bias = zeros(1, device="cuda")
-        mask = zeros(1, device="cuda")
-        scale = zeros(1, device="cuda")
+        q = zeros(1, device=self.device)
+        k = zeros(1, device=self.device)
+        v = zeros(1, device=self.device)
+        out = zeros(1, device=self.device)
+        bias = zeros(1, device=self.device)
+        mask = zeros(1, device=self.device)
+        scale = zeros(1, device=self.device)
         # First: warmup with REAL tensors to trigger autotune + compilation
         real_args = (q, k, v, out, bias, mask, scale, 128, 8)
         nop_autotuned_with_none_kernel[(1,)](*real_args)
@@ -591,8 +591,15 @@ class Operator(BenchmarkOperator):
             bin.packed_metadata if hasattr(bin, "packed_metadata") else bin.metadata
         )
         if hasattr(CompiledKernel, "launch_metadata"):
+            # The launcher dereferences the stream handle, so it has to be a
+            # real one. CUDA tolerates the 0 (default stream) sentinel, other
+            # backends (e.g. the SYCL queue used by XPU) do not.
+            from triton.runtime import driver
+
+            device = driver.active.get_current_device()
+            stream = driver.active.get_current_stream(device)
             return lambda: bin.run(
-                1, 1, 1, 0, function, metadata, None, None, None, *args
+                1, 1, 1, stream, function, metadata, None, None, None, *args
             )
         else:
             return lambda: bin.run(
@@ -630,7 +637,7 @@ class Operator(BenchmarkOperator):
         With D103454938 (shared launcher): ~23ms (Triton compile only)
         Without D103454938 (gcc launcher): ~40ms (Triton compile + gcc)
         """
-        x = torch.zeros(1, device="cuda")
+        x = torch.zeros(1, device=self.device)
 
         # Redirect Triton at a private, empty cache dir so every compile below
         # is cold. Wiping the shared cache dir in place races with anything else

--- a/tritonbench/operators/layer_norm/fused_triton.py
+++ b/tritonbench/operators/layer_norm/fused_triton.py
@@ -3,6 +3,7 @@ import math
 import torch
 import triton
 import triton.language as tl
+from tritonbench.utils.env_utils import get_num_sms
 
 
 @triton.jit
@@ -139,8 +140,8 @@ class LayerNorm(torch.autograd.Function):
         # reshape input data into 2D tensor
         x_arg = x.reshape(-1, x.shape[-1])
         M, N = x_arg.shape
-        mean = torch.empty((M,), dtype=torch.float32, device="cuda")
-        rstd = torch.empty((M,), dtype=torch.float32, device="cuda")
+        mean = torch.empty((M,), dtype=torch.float32, device=x.device)
+        rstd = torch.empty((M,), dtype=torch.float32, device=x.device)
         # Less than 64KB per feature: enqueue fused kernel
         MAX_FUSED_SIZE = 65536 // x.element_size()
         BLOCK_SIZE = min(MAX_FUSED_SIZE, triton.next_power_of_2(N))
@@ -178,7 +179,7 @@ class LayerNorm(torch.autograd.Function):
         dx = torch.empty_like(dy)
 
         M, N = x_arg.shape
-        NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+        NUM_SMS = get_num_sms(x.device)
         BLOCK_SIZE_M = min(2048, triton.next_power_of_2(M // (8 * NUM_SMS)))
         PARTIAL_SIZE = math.ceil(M / BLOCK_SIZE_M)
 

--- a/tritonbench/operators/layer_norm/tutorial.py
+++ b/tritonbench/operators/layer_norm/tutorial.py
@@ -239,8 +239,8 @@ class LayerNorm(torch.autograd.Function):
         # reshape input data into 2D tensor
         x_arg = x.reshape(-1, x.shape[-1])
         M, N = x_arg.shape
-        mean = torch.empty((M,), dtype=torch.float32, device="cuda")
-        rstd = torch.empty((M,), dtype=torch.float32, device="cuda")
+        mean = torch.empty((M,), dtype=torch.float32, device=x.device)
+        rstd = torch.empty((M,), dtype=torch.float32, device=x.device)
         # Less than 64KB per feature: enqueue fused kernel
         MAX_FUSED_SIZE = 65536 // x.element_size()
         BLOCK_SIZE = min(MAX_FUSED_SIZE, triton.next_power_of_2(N))
@@ -282,7 +282,7 @@ class LayerNorm(torch.autograd.Function):
         if N <= 1024:
             GROUP_SIZE_M = 256
         # allocate output
-        locks = torch.zeros(2 * GROUP_SIZE_M, dtype=torch.int32, device="cuda")
+        locks = torch.zeros(2 * GROUP_SIZE_M, dtype=torch.int32, device=w.device)
         _dw = torch.empty((GROUP_SIZE_M, w.shape[0]), dtype=x.dtype, device=w.device)
         _db = torch.empty((GROUP_SIZE_M, w.shape[0]), dtype=x.dtype, device=w.device)
         dw = torch.empty((w.shape[0],), dtype=w.dtype, device=w.device)

--- a/tritonbench/operators/ragged_attention/hstu.py
+++ b/tritonbench/operators/ragged_attention/hstu.py
@@ -1,5 +1,5 @@
 import torch
-from tritonbench.utils.env_utils import is_fbcode
+from tritonbench.utils.env_utils import get_current_device, is_fbcode
 from tritonbench.utils.path_utils import add_path, SUBMODULE_PATH
 
 if is_fbcode():
@@ -50,11 +50,12 @@ def get_test_inputs(
     dtype,
     requires_grad,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, int]:
+    device = get_current_device()
     lengths = generate_sparse_seq_len(
         size=batch_size,
         max_seq_len=seq_len,
         sparsity=seq_sparsity,
-        device=torch.device("cuda"),
+        device=device,
     )
     lengths = apply_sampling(lengths, alpha=2.0, max_seq_len=seq_len)
     if has_delta_q:
@@ -76,23 +77,21 @@ def get_test_inputs(
                 torch.int32
             )
     max_attn_len = max_attn_len if max_attn_len < seq_len else seq_len
-    seq_offsets = torch.zeros(
-        (batch_size + 1,), dtype=torch.int32, device=torch.device("cuda")
-    )
+    seq_offsets = torch.zeros((batch_size + 1,), dtype=torch.int32, device=device)
     seq_offsets[1:] = torch.cumsum(lengths, dim=0)
     L = int(seq_offsets[-1].item())
     x = torch.empty(
         (L, heads, attn_dim * 2 + hidden_dim),
         dtype=dtype,
-        device=torch.device("cuda"),
+        device=device,
     ).uniform_(-0.01, 0.01)
     q, k, v = torch.split(x, [attn_dim, attn_dim, hidden_dim], dim=-1)
     delta_q = torch.empty(
         (batch_size * delta_size, heads, attn_dim),
         dtype=dtype,
-        device=torch.device("cuda"),
+        device=device,
     ).uniform_(-0.1, 0.1)
-    delta_x_offsets = torch.arange(0, delta_size, device=torch.device("cuda"))
+    delta_x_offsets = torch.arange(0, delta_size, device=device)
     delta_x_offsets = (seq_offsets[1:] - delta_size).view(
         batch_size, 1
     ) + delta_x_offsets.view(1, delta_size)

--- a/tritonbench/operators/rms_norm/fused_triton.py
+++ b/tritonbench/operators/rms_norm/fused_triton.py
@@ -3,6 +3,7 @@ import math
 import torch
 import triton
 import triton.language as tl
+from tritonbench.utils.env_utils import get_num_sms
 
 
 @triton.autotune(
@@ -104,7 +105,7 @@ class RMSNorm(torch.autograd.Function):
         dx = torch.empty_like(dy)
 
         M, N = x_arg.shape
-        NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+        NUM_SMS = get_num_sms(x.device)
         BLOCK_SIZE_M = min(2048, triton.next_power_of_2(M // (8 * NUM_SMS)))
         PARTIAL_SIZE = math.ceil(M / BLOCK_SIZE_M)
 

--- a/tritonbench/operators/template_attention/operator.py
+++ b/tritonbench/operators/template_attention/operator.py
@@ -55,19 +55,19 @@ class Operator(BenchmarkOperator):
             arg0_1 = rand_strided(
                 (16, 16, 4096, 64),
                 (4194304, 262144, 64, 1),
-                device="cuda:0",
+                device=self.device,
                 dtype=torch.float16,
             )
             arg1_1 = rand_strided(
                 (16, 16, 4096, 64),
                 (4194304, 262144, 64, 1),
-                device="cuda:0",
+                device=self.device,
                 dtype=torch.float16,
             )
             arg2_1 = rand_strided(
                 (16, 16, 4096, 64),
                 (4194304, 262144, 64, 1),
-                device="cuda:0",
+                device=self.device,
                 dtype=torch.float16,
             )
             yield arg0_1, arg1_1, arg2_1

--- a/tritonbench/operators/template_attention/triton_attention.py
+++ b/tritonbench/operators/template_attention/triton_attention.py
@@ -6,11 +6,10 @@ Generated from Inductor for forward layernorm with and without welford
 import torch
 import triton
 import triton.language as tl
-from torch._C import _cuda_getCurrentRawStream as get_raw_stream
 from torch._inductor.runtime import triton_helpers, triton_heuristics
 from torch._inductor.runtime.triton_helpers import libdevice
+from tritonbench.utils.env_utils import get_device_module
 
-empty_strided_cuda = torch._C._dynamo.guards._empty_strided_cuda
 reinterpret_tensor = torch.ops.inductor._reinterpret_tensor
 assert_size_stride = torch._C._dynamo.guards.assert_size_stride
 
@@ -322,10 +321,12 @@ def triton_attention_no_exp2(arg0_1, arg1_1, arg2_1):
     assert_size_stride(arg0_1, (16, 16, 4096, 64), (4194304, 262144, 64, 1))
     assert_size_stride(arg1_1, (16, 16, 4096, 64), (4194304, 262144, 64, 1))
     assert_size_stride(arg2_1, (16, 16, 4096, 64), (4194304, 262144, 64, 1))
-    with torch.cuda._DeviceGuard(0):
-        torch.cuda.set_device(0)
-        buf0 = empty_strided_cuda(
-            (16, 16, 4096, 64), (4194304, 262144, 64, 1), torch.float16
+    with get_device_module(arg0_1.device.type).device(arg0_1.device.index):
+        buf0 = torch.empty_strided(
+            (16, 16, 4096, 64),
+            (4194304, 262144, 64, 1),
+            dtype=torch.float16,
+            device=arg0_1.device,
         )
 
         # batch_size, num_heads, num_queries: 16, 16, 4096
@@ -345,10 +346,12 @@ def triton_attention_with_exp2(arg0_1, arg1_1, arg2_1):
     assert_size_stride(arg0_1, (16, 16, 4096, 64), (4194304, 262144, 64, 1))
     assert_size_stride(arg1_1, (16, 16, 4096, 64), (4194304, 262144, 64, 1))
     assert_size_stride(arg2_1, (16, 16, 4096, 64), (4194304, 262144, 64, 1))
-    with torch.cuda._DeviceGuard(0):
-        torch.cuda.set_device(0)
-        buf0 = empty_strided_cuda(
-            (16, 16, 4096, 64), (4194304, 262144, 64, 1), torch.float16
+    with get_device_module(arg0_1.device.type).device(arg0_1.device.index):
+        buf0 = torch.empty_strided(
+            (16, 16, 4096, 64),
+            (4194304, 262144, 64, 1),
+            dtype=torch.float16,
+            device=arg0_1.device,
         )
 
         # batch_size, num_heads, num_queries: 16, 16, 4096

--- a/tritonbench/operators/vector_exp/operator.py
+++ b/tritonbench/operators/vector_exp/operator.py
@@ -2,6 +2,7 @@ from typing import Any, Callable, Generator, List
 
 import torch
 import triton
+from tritonbench.kernels.profile import has_gpu_timer
 from tritonbench.utils.triton_op import (
     BenchmarkOperator,
     BenchmarkOperatorMetrics,
@@ -47,9 +48,15 @@ class Operator(BenchmarkOperator):
     def triton_exp(self, x: torch.Tensor):
         n_elements = x.numel()
         # Prepare a memory buffer to store the profiled data, with the size equal to the number of programs.
+        # Platforms without an in-kernel timer (see has_gpu_timer) pass None so
+        # the instrumented branches are compiled out.
         BLOCK_SIZE = 1024
         n_programs = triton.cdiv(n_elements, BLOCK_SIZE)
-        profile_mem = torch.empty(n_programs, dtype=torch.int64, device=self.device)
+        profile_mem = (
+            torch.empty(n_programs, dtype=torch.int64, device=self.device)
+            if has_gpu_timer()
+            else None
+        )
 
         def _inner():
             output = TritonExpFunction.apply(x, BLOCK_SIZE, profile_mem)

--- a/tritonbench/utils/env_utils.py
+++ b/tritonbench/utils/env_utils.py
@@ -113,7 +113,7 @@ def is_hip() -> bool:
 
 
 def is_xpu() -> bool:
-    return torch.version.xpu is not None
+    return torch.xpu._is_compiled()
 
 
 def get_current_device() -> str:


### PR DESCRIPTION
## PR series
1. [device abstraction primitives](https://github.com/meta-pytorch/tritonbench/pull/1217)
2. [Device-agnostic benchmark timing](https://github.com/meta-pytorch/tritonbench/pull/1218)
3. -> [Device-agnostic operators & kernels](https://github.com/meta-pytorch/tritonbench/pull/1219)
4. [Enable GPU test suite on XPU](https://github.com/meta-pytorch/tritonbench/pull/1220)

## Summary
Part 3/4 of Intel XPU support. **Depends on #1217 and PR 2/4.** Draft until predecessors land; will be rebased onto `main` afterward.

- Replace hardcoded `"cuda"` / `torch.cuda.get_device_properties` with `self.device` / `get_num_sms()` / `get_current_device()` across operators and kernels
- Add XPU autotune fallbacks (bf16xint16_gemm, fp8_gemm)
- Add `has_gpu_timer()` guard in `kernels/profile.py` for missing SPIR-V timer intrinsics

28 files, all the same mechanical device-agnostic pattern — reviewable operator-by-operator.

> Note: targets `main`, so the diff temporarily includes earlier PRs' changes. Review only this PR's own commit; minimal once predecessors merge and this is rebased.

## Test plan
- [x] CUDA operators unchanged
- [x] Operators construct inputs / size grids on the active device