### PR TITLE
Intel XPU support (4/4): Enable GPU test suite on XPU

### DIFF
--- a/test/test_gpu/main.py
+++ b/test/test_gpu/main.py
@@ -14,6 +14,7 @@ from tritonbench.operators_collection import (
     list_operators_by_collection,  # @manual=//pytorch/tritonbench:tritonbench
 )
 from tritonbench.utils.env_utils import (
+    get_current_device,  # @manual=//pytorch/tritonbench:tritonbench
     is_blackwell,  # @manual=//pytorch/tritonbench:tritonbench
     is_fbcode,  # @manual=//pytorch/tritonbench:tritonbench
 )
@@ -40,6 +41,8 @@ def _load_skip_file(skip_file) -> dict:
     with open(skip_file, "r") as f:
         return yaml.safe_load(f) or {}
 
+# Run the suite on whatever accelerator this host exposes (cuda, xpu, ...).
+TEST_DEVICE = get_current_device()
 
 if custom_skip_file := os.environ.get(CUSTOM_SKIP_FILE_ENV):
     # Allow users to override the skip list with a custom yaml file.
@@ -220,7 +223,7 @@ def make_test(operator):
             "--op",
             operator,
             "--device",
-            "cuda",
+            TEST_DEVICE,
             "--num-inputs",
             "1",
             "--test-only",

--- a/test/test_gpu/skip_tests.yaml
+++ b/test/test_gpu/skip_tests.yaml
@@ -3,7 +3,7 @@
 #  op: to skip an entire operator
 #    extra_args: <extra args to pass to the test>
 #    extra_bwd_args: <extra args to pass to the backward test>
-#    devices: <list of devices> (options: "cuda", "hip", "h100", "mi350", "b200", default: ["h100", "mi350"])
+#    devices: <list of devices> (options: "cuda", "hip", "xpu", "h100", "mi350", "b200", default: ["h100", "mi350"])
 #    channels: <list of triton channels> (options: "triton-main", "meta-triton", default: ["triton-main", "meta-triton"])
 # to override the default, specify devices and channels to limit combinations
 # we rely on the code to determine specific backends to skip
@@ -74,3 +74,42 @@ embedding:
   report: true
   disabled_devices:
     - hip
+# TODO: times out on xpu (>10min). The torch_compile backend requests
+# mode="max-autotune-no-cudagraphs" over a 128256x4096 lm_head, which does not
+# converge in CI time on the Intel inductor backend.
+fused_linear_cross_entropy:
+  report: true
+  disabled_devices:
+    - xpu
+# TODO: crashes the Intel Graphics Compiler on xpu ("IGC: Internal Compiler
+# Error: Floating point exception"), which aborts the whole process. Reduced
+# repro: an online-softmax loop whose alpha/p are guarded by
+# `tl.where(m_i_new == float("-inf"), 0, tl.math.exp(...))`; dropping the
+# `== -inf` guard compiles fine, so this is a backend compiler bug rather than
+# something the kernel can work around.
+template_attention:
+  report: true
+  disabled_devices:
+    - xpu
+# TODO: times out on xpu (>30min). The liger/torch_compile backends lower a
+# fused JSD over a 128256-wide vocab, and the Intel inductor backend spends the
+# whole budget in kernel compilation and autotuning.
+fused_linear_jsd:
+  report: true
+  disabled_devices:
+    - xpu
+# TODO: times out on xpu (>30min), same root cause as fused_linear_jsd: the
+# torch_compile backend recompiles the fused geglu for every input shape and
+# does not converge in CI time on the Intel inductor backend.
+geglu:
+  report: true
+  disabled_devices:
+    - xpu
+# TODO: times out on xpu (>30min) in CI. The op does run correctly standalone
+# (~13min for a single input on an Arc B580), but every backend recompiles a
+# large jagged attention kernel from scratch, which is too slow to keep in the
+# per-operator CI budget.
+gdpa:
+  report: true
+  disabled_devices:
+    - xpu


### PR DESCRIPTION
## PR series
1. [device abstraction primitives](https://github.com/meta-pytorch/tritonbench/pull/1217)
2. [Device-agnostic benchmark timing](https://github.com/meta-pytorch/tritonbench/pull/1218)
3. [Device-agnostic operators & kernels](https://github.com/meta-pytorch/tritonbench/pull/1219)
4. -> [Enable GPU test suite on XPU](https://github.com/meta-pytorch/tritonbench/pull/1220)
## Summary
Part 4/4 of Intel XPU support. **Depends on PRs 1–3.** Draft until predecessors land; will be rebased onto `main` afterward.

- Run `test/test_gpu` on whatever accelerator the host exposes via `get_current_device()`
- Add `xpu` device option and document known-failing ops (`fused_linear_cross_entropy`, `template_attention`, `fused_linear_jsd`, `geglu`, `gdpa`) in `skip_tests.yaml`

> Note: targets `main`, so the diff temporarily includes earlier PRs' changes. Review only this PR's own commit; minimal once predecessors merge and this is rebased.

## Test plan
- [x] `test_gpu` suite runs on `--device xpu`
- [x] CUDA test runs unaffected (device resolved dynamically)
- [x] Documented skips have TODO rationale