### PR TITLE
[ci] Make aggregate metrics all-or-nothing

### DIFF
--- a/benchmarks/common.py
+++ b/benchmarks/common.py
@@ -54,7 +54,17 @@ def post_run_callback(
     else:
         with open(output_file, "r") as f:
             obj = json.load(f)
-        obj[f"tritonbench_{benchmark}-pass"] = 1
+        reported_pass_keys = [
+            key
+            for key in obj
+            if key.startswith("tritonbench_")
+            and key.endswith("-pass")
+            and "[" not in key
+        ]
+        pass_value = (
+            min(obj.pop(key) for key in reported_pass_keys) if reported_pass_keys else 1
+        )
+        obj[f"tritonbench_{benchmark}-pass"] = pass_value
         with open(output_file, "w") as f:
             json.dump(obj, f, indent=4)
     output_files.append(output_file)

--- a/test/test_cpu/main.py
+++ b/test/test_cpu/main.py
@@ -88,10 +88,18 @@ class TestTritonbenchCpu(unittest.TestCase):
         self.assertAlmostEqual(complete_metrics[avg_key], 23 / 3)
         self.assertEqual(complete_metrics[pass_key], 1)
 
+        benchmark_result.metrics.append("kernel_source_hash")
+        hash_metrics = benchmark_result.userbenchmark_dict
+        self.assertAlmostEqual(hash_metrics[avg_key], 23 / 3)
+        self.assertEqual(len(benchmark_result.result), 3)
+        benchmark_result.metrics.remove("kernel_source_hash")
+
         last_result = benchmark_result.result.pop()
-        truncated_metrics = benchmark_result.userbenchmark_dict
+        with self.assertLogs("tritonbench.utils.triton_op", level="WARNING") as logs:
+            truncated_metrics = benchmark_result.userbenchmark_dict
         self.assertNotIn(avg_key, truncated_metrics)
         self.assertEqual(truncated_metrics[pass_key], 0)
+        self.assertIn("expected 3 input results, got 2", logs.output[0])
 
         benchmark_result.result.append(last_result)
         failed_metrics = next(iter(benchmark_result.result[1][1].values()))

--- a/test/test_cpu/main.py
+++ b/test/test_cpu/main.py
@@ -1,5 +1,10 @@
+import json
+import logging
+import tempfile
 import unittest
+from pathlib import Path
 
+from benchmarks.common import post_run_callback
 from tritonbench.operators import load_opbench_by_name
 from tritonbench.operators_collection import list_operators_by_collection
 from tritonbench.utils.parser import get_parser
@@ -62,6 +67,62 @@ class TestTritonbenchCpu(unittest.TestCase):
         self.assertFalse(
             any(["test_op-" in header for header in headers])
         )  # default benchmark label should not be present in headers
+
+    def test_ci_aggregate_metrics_are_all_or_nothing(self):
+        test_op = self._get_test_op(
+            extra_args=[
+                "--metrics",
+                "test_metric_per_benchmark",
+            ]
+        )
+        test_op.run()
+        benchmark_result = test_op.output
+        for _, backend_metrics in benchmark_result.result:
+            metrics = next(iter(backend_metrics.values()))
+            metric_value = metrics.extra_metrics["test_metric_per_benchmark"]
+            metrics.extra_metrics["test_metric_per_benchmark"] = metric_value[0]
+        avg_key = "tritonbench_test_op_fwd[new_op_label]-test_metric_per_benchmark-avg"
+        pass_key = "tritonbench_test_op_fwd-pass"
+
+        complete_metrics = benchmark_result.userbenchmark_dict
+        self.assertAlmostEqual(complete_metrics[avg_key], 23 / 3)
+        self.assertEqual(complete_metrics[pass_key], 1)
+
+        last_result = benchmark_result.result.pop()
+        truncated_metrics = benchmark_result.userbenchmark_dict
+        self.assertNotIn(avg_key, truncated_metrics)
+        self.assertEqual(truncated_metrics[pass_key], 0)
+
+        benchmark_result.result.append(last_result)
+        failed_metrics = next(iter(benchmark_result.result[1][1].values()))
+        failed_metrics.error_msg = "test failure"
+        partial_metrics = benchmark_result.userbenchmark_dict
+        self.assertNotIn(avg_key, partial_metrics)
+        self.assertEqual(partial_metrics[pass_key], 0)
+
+    def test_ci_callback_preserves_partial_failure(self):
+        reported_pass_key = "tritonbench_test_op_fwd-pass"
+        ci_pass_key = "tritonbench_configured_test_op-pass"
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_file = Path(temp_dir) / "test_op.json"
+            with open(output_file, "w") as file:
+                json.dump({reported_pass_key: 0}, file)
+            output_files = []
+
+            post_run_callback(
+                logging.getLogger(__name__),
+                "test_group",
+                "configured_test_op",
+                output_file,
+                output_files,
+                disabled=False,
+            )
+
+            with open(output_file, "r") as file:
+                metrics = json.load(file)
+            self.assertEqual(metrics[ci_pass_key], 0)
+            self.assertNotIn(reported_pass_key, metrics)
+            self.assertEqual(output_files, [output_file])
 
     def test_cpu_list_operators_by_collection(self):
         all_ops = list_operators_by_collection(op_collection="all")

--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -320,7 +320,7 @@ class BenchmarkOperatorResult:
     simple_mode: bool
     # Tuple: (x_val, Dict[impl_name, BenchmarkOperatorMetrics])
     result: List[Tuple[Any, Dict[str, BenchmarkOperatorMetrics]]]
-    expected_num_inputs: Optional[int] = None
+    expected_num_inputs: int
     _result_dict: Optional[Dict[Number, Dict[str, BenchmarkOperatorMetrics]]] = None
 
     def _table(self):
@@ -364,10 +364,11 @@ class BenchmarkOperatorResult:
                 headers.append(f"{label}-{metric}")
         # generate rows
         hashes = {}
+        results = self.result
         if "kernel_source_hash" in self.metrics:
-            self.result.append(tuple(["hashes", {}]))
+            results = [*results, ("hashes", {})]
         avg_row = []
-        for x_val, y_val in self.result:
+        for x_val, y_val in results:
             col_num = 0
             row = []
             row.append(x_val)
@@ -532,22 +533,25 @@ class BenchmarkOperatorResult:
         # Userbenchmark Metric key format:
         # tritonbench_{op_name}_{op_mode}[{x_val}-{provider}-{metric}]
         userbenchmark_metrics_dict = {}
-        result_count = sum(1 for x_val, _ in self.result if x_val != "hashes")
-        expected_agg_values = (
-            self.expected_num_inputs
-            if self.expected_num_inputs is not None
-            else result_count
+        result_count = len(self.result)
+        has_errors = any(
+            metrics.error_msg
+            for _, backend_metrics in self.result
+            for metrics in backend_metrics.values()
         )
         benchmark_complete = (
-            expected_agg_values > 0
-            and result_count == expected_agg_values
-            and all(
-                not metrics.error_msg
-                for x_val, backend_metrics in self.result
-                if x_val != "hashes"
-                for metrics in backend_metrics.values()
-            )
+            self.expected_num_inputs > 0
+            and result_count == self.expected_num_inputs
+            and not has_errors
         )
+        if not benchmark_complete:
+            error_note = " with backend errors" if has_errors else ""
+            logger.warning(
+                "Skipping aggregate metrics: expected %d input results, got %d%s",
+                self.expected_num_inputs,
+                result_count,
+                error_note,
+            )
         headers, table = self._table()
         table = self._post_process_table(table)
         agg_data = {}
@@ -572,6 +576,7 @@ class BenchmarkOperatorResult:
                         f"tritonbench_{benchmark_name}[x_{x_val}-{provider}]_{metrics}"
                     )
                     userbenchmark_metrics_dict[metric_name] = value
+                    # _table adds hash and average rows after the input rows.
                     if row_index >= result_count:
                         continue
                     agg_metric_name = (
@@ -589,11 +594,18 @@ class BenchmarkOperatorResult:
                         agg_data[agg_metric_name] = agg_data.get(
                             agg_metric_name, []
                         ) + [numeric_value]
-        final_agg_data = {
-            key: sum(values) / len(values)
-            for key, values in agg_data.items()
-            if benchmark_complete and len(values) == expected_agg_values
-        }
+        final_agg_data = {}
+        if benchmark_complete:
+            for key, values in agg_data.items():
+                if len(values) != self.expected_num_inputs:
+                    logger.warning(
+                        "Skipping aggregate metric %s: expected %d values, got %d",
+                        key,
+                        self.expected_num_inputs,
+                        len(values),
+                    )
+                    continue
+                final_agg_data[key] = sum(values) / len(values)
         userbenchmark_metrics_dict.update(final_agg_data)
         userbenchmark_metrics_dict[f"tritonbench_{benchmark_name}-pass"] = int(
             benchmark_complete

--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -320,6 +320,7 @@ class BenchmarkOperatorResult:
     simple_mode: bool
     # Tuple: (x_val, Dict[impl_name, BenchmarkOperatorMetrics])
     result: List[Tuple[Any, Dict[str, BenchmarkOperatorMetrics]]]
+    expected_num_inputs: Optional[int] = None
     _result_dict: Optional[Dict[Number, Dict[str, BenchmarkOperatorMetrics]]] = None
 
     def _table(self):
@@ -531,6 +532,22 @@ class BenchmarkOperatorResult:
         # Userbenchmark Metric key format:
         # tritonbench_{op_name}_{op_mode}[{x_val}-{provider}-{metric}]
         userbenchmark_metrics_dict = {}
+        result_count = sum(1 for x_val, _ in self.result if x_val != "hashes")
+        expected_agg_values = (
+            self.expected_num_inputs
+            if self.expected_num_inputs is not None
+            else result_count
+        )
+        benchmark_complete = (
+            expected_agg_values > 0
+            and result_count == expected_agg_values
+            and all(
+                not metrics.error_msg
+                for x_val, backend_metrics in self.result
+                if x_val != "hashes"
+                for metrics in backend_metrics.values()
+            )
+        )
         headers, table = self._table()
         table = self._post_process_table(table)
         agg_data = {}
@@ -539,7 +556,7 @@ class BenchmarkOperatorResult:
             if self.benchmark_name
             else f"{self.op_name}_{self.op_mode}"
         )
-        for row in table:
+        for row_index, row in enumerate(table):
             x_val = row[0]
 
             for ind, v in enumerate(row[1:]):
@@ -555,6 +572,8 @@ class BenchmarkOperatorResult:
                         f"tritonbench_{benchmark_name}[x_{x_val}-{provider}]_{metrics}"
                     )
                     userbenchmark_metrics_dict[metric_name] = value
+                    if row_index >= result_count:
+                        continue
                     agg_metric_name = (
                         f"tritonbench_{benchmark_name}[{provider}]-{metrics}-avg"
                     )
@@ -570,8 +589,15 @@ class BenchmarkOperatorResult:
                         agg_data[agg_metric_name] = agg_data.get(
                             agg_metric_name, []
                         ) + [numeric_value]
-        final_agg_data = {k: sum(v) / len(v) for k, v in agg_data.items()}
+        final_agg_data = {
+            key: sum(values) / len(values)
+            for key, values in agg_data.items()
+            if benchmark_complete and len(values) == expected_agg_values
+        }
         userbenchmark_metrics_dict.update(final_agg_data)
+        userbenchmark_metrics_dict[f"tritonbench_{benchmark_name}-pass"] = int(
+            benchmark_complete
+        )
 
         return userbenchmark_metrics_dict
 
@@ -1344,6 +1370,7 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
                 metrics=self.required_metrics,
                 simple_mode=self.tb_args.simple_output,
                 result=metrics,
+                expected_num_inputs=len(self._input_ids),
             )
             if self.tb_args.power_chart:
                 power_manager_task.stop()


### PR DESCRIPTION
## Summary
- suppress aggregate averages when a benchmark returns fewer inputs than requested or any backend reports an error
- emit the benchmark pass signal with the raw results and preserve it when CI maps metrics to the configured benchmark name
- add CPU regression coverage for complete, truncated, and failed benchmark results

Fixes #753

## Duplicate work
No open PR references #753 or implements all-or-nothing aggregate metrics as of August 10, 2026.

## Test plan
- [x] `.venv/bin/python -m unittest test.test_cpu.main.TestTritonbenchCpu.test_cpu_metric_x_only_true test.test_cpu.main.TestTritonbenchCpu.test_cpu_metric_custom_label test.test_cpu.main.TestTritonbenchCpu.test_cpu_list_operators_by_collection test.test_cpu.main.TestTritonbenchCpu.test_ci_aggregate_metrics_are_all_or_nothing test.test_cpu.main.TestTritonbenchCpu.test_ci_callback_preserves_partial_failure` (5 passed)
- [x] `.venv/bin/ufmt check tritonbench/utils/triton_op.py benchmarks/common.py test/test_cpu/main.py`
- [x] `git diff --check`
Full CPU module: the existing layer-norm test imports Triton, which is unavailable on macOS; the remaining five CPU tests pass locally