### PR TITLE
Log `operator_family` from tritonbench

### DIFF
--- a/tritonbench/utils/run_utils.py
+++ b/tritonbench/utils/run_utils.py
@@ -741,6 +741,7 @@ def _run(args: argparse.Namespace, extra_args: List[str]) -> BenchmarkOperatorRe
                 kwargs = {
                     "metrics": metrics,
                     "benchmark_name": args.benchmark_name or args.op,
+                    "operator_family": args.op,
                     "device": args.device,
                     "logging_group": args.logging_group or args.op,
                     "precision": args.precision,


### PR DESCRIPTION
Summary:
Populates the new `operator_family` field added to
`TritonOperatorBenchmarkLoggerConfig` in the parent diff.

`run_utils.py` passes `args.op` as `operator_family` in the `log_benchmark`
kwargs, so every benchmark row records the operator the run was launched with,
independent of `benchmark_name` / `logging_group` (both of which can be
overridden by `--benchmark-name` / `--logging-group` and therefore do not
reliably identify the operator).

`fb/utils.py` is updated in the same diff to accept the new keyword and forward
it to `TritonOperatorBenchmarkLogEntry`. Without this, `log_benchmark(**kwargs)`
would raise `TypeError: log_benchmark() got an unexpected keyword argument
'operator_family'` on every `--log-scuba` run in fbcode. The parameter defaults
to `None` and the logger field is nullable, so other callers are unaffected.

Depends on the parent diff: `TritonOperatorBenchmarkLogEntry` only accepts
`operator_family` once the LoggerConfig change has been codegen'd, landed, and
actualized.

Differential Revision: D115583008


