### PR TITLE
Add the FP16 and MXFP4 GEMMs to TritonBench (#1227)

### DIFF
--- a/tritonbench/operators/gemm/operator.py
+++ b/tritonbench/operators/gemm/operator.py
@@ -43,6 +43,16 @@ if has_tlx():
         )
     except (ImportError, ModuleNotFoundError):
         _hopper_tlx_matmul_ws = None
+
+    # gfx950 (MI350X / CDNA4) inter-wave FP16 GEMM. Guarded separately from the
+    # NVIDIA tutorials above: it lives under a package path that only exists in
+    # Triton builds carrying the gfx9 tutorials.
+    try:
+        from triton.language.extra.tlx.tutorials.gfx9_gemm.inter_wave.a16w16.matmul_kernel import (
+            matmul as _tlx_matmul_gfx950,
+        )
+    except (ImportError, ModuleNotFoundError):
+        _tlx_matmul_gfx950 = None
 else:
 
     def _tlx_matmul_2cta(*args, **kwargs):
@@ -56,6 +66,8 @@ else:
 
     def _tlx_matmul_ws(*args, **kwargs):
         raise RuntimeError("TLX not available in this Triton version")
+
+    _tlx_matmul_gfx950 = None
 
 
 from tritonbench.utils.path_utils import ensure_build_subdir_on_sys_path
@@ -78,6 +90,7 @@ from tritonbench.utils.env_utils import (
     is_cu130,
     is_cuda,
     is_fbcode,
+    is_hip_mi350,
     IS_HOPPER,
     supports_tma,
 )
@@ -619,6 +632,40 @@ class Operator(BenchmarkOperator):
             return lambda: compiled_decompose_k(a, b) + bias
         else:
             return lambda: compiled_decompose_k(a, b)
+
+    @register_benchmark(
+        enabled=has_tlx() and is_hip_mi350(),
+        fwd_only=True,
+        tags=["tlx", "amd", "gfx950"],
+    )
+    def tlx_matmul_gfx950(self, a, b, bias) -> Callable:
+        """TLX FP16/BF16 GEMM for gfx950 (MI350X).
+
+        The kernel picks its own tile and split-K from the shape, so there is
+        nothing to tune here. B must be column-major, handled outside the timed
+        region: feeding a row-major B does not produce wrong numbers, it fails
+        to compile -- the direct-to-LDS load cannot be coalesced -- so the
+        transpose is mandatory, not an optimisation.
+        """
+        if _tlx_matmul_gfx950 is None:
+            return None
+
+        a_in = a if a.is_contiguous() else a.contiguous()
+        # b is (K, N); column-major means stride(0) == 1.
+        b_in = b if b.stride(0) == 1 else b.T.contiguous().T
+
+        # Probe rather than restate the kernel's shape constraints. It states
+        # them as plain asserts covering more than a minimum K -- K must also
+        # divide by BLOCK_K after the split -- and a partial copy here turns an
+        # unsupported shape into a failed benchmark run instead of a skip.
+        try:
+            _tlx_matmul_gfx950(a_in, b_in)
+        except AssertionError:
+            return None
+
+        if bias is not None:
+            return lambda: _tlx_matmul_gfx950(a_in, b_in) + bias
+        return lambda: _tlx_matmul_gfx950(a_in, b_in)
 
     @register_benchmark(
         enabled=has_tlx() and (IS_HOPPER or IS_BLACKWELL), fwd_only=True

--- a/tritonbench/operators/mxfp4_gemm/__init__.py
+++ b/tritonbench/operators/mxfp4_gemm/__init__.py
@@ -1,0 +1,1 @@
+from .operator import Operator

--- a/tritonbench/operators/mxfp4_gemm/operator.py
+++ b/tritonbench/operators/mxfp4_gemm/operator.py
@@ -1,0 +1,290 @@
+"""TritonBench operator for MXFP4 GEMM on AMD gfx950 (MI350X).
+
+All providers compute ``C[M, N] = A[M, K] @ B[N, K].T`` where A and B hold
+E2M1 (FP4) data packed two values per byte, and every group of 32 values along
+K carries one E8M0 scale byte. Quantization is not part of the timed region:
+the operator yields already-quantized tensors, as a real inference stack would.
+
+The baseline is ``torch._scaled_mm``, which is hipBLASLt's MXFP4 path on ROCm.
+The TLX provider is the gfx950 inter-wave kernel from the Triton tutorials. It
+dispatches internally between a 256x256 8-wave tile and a 128x128 + split-K
+path for occupancy-starved (skinny-N) shapes, so one provider covers the whole
+shape range.
+
+Usage from fbsource/fbcode:
+  HIP_VISIBLE_DEVICES=0 buck2 run @mode/opt-amd-gpu \
+      -m ovr_config//triton:beta \
+      -m ovr_config//third-party/rocm/constraints:7.0 \
+      -m fbcode//triton/cc:force_noop \
+      -c fbcode.enable_gpu_sections=true \
+      -c fbcode.rocm_arch=mi350 \
+      fbcode//pytorch/tritonbench:run -- \
+      --op mxfp4_gemm \
+      --metrics latency,tflops,speedup,accuracy
+"""
+
+import argparse
+from typing import Any, Callable, Generator, List, Optional, Tuple
+
+import torch
+from tritonbench.utils.env_utils import is_hip_mi350
+from tritonbench.utils.python_utils import try_import
+from tritonbench.utils.triton_op import (
+    BenchmarkOperator,
+    BenchmarkOperatorMetrics,
+    register_benchmark,
+    register_metric,
+    register_x_val,
+)
+from tritonbench.utils.triton_utils import has_tlx
+
+HAS_TLX_MXFP4 = False
+with try_import("HAS_TLX_MXFP4"):
+    from triton.language.extra.tlx.tutorials.gfx9_gemm.inter_wave.a4w4.matmul_kernel import (
+        matmul as tlx_mxfp4_matmul,
+    )
+
+SCALE_GROUP_SIZE = 32
+
+# (M, N, K). K sweeps at a fixed MN tile count isolate the main-loop, and the
+# small-M rows exercise the skinny dispatch inside the TLX kernel.
+# The gfx950 kernel takes M, N multiples of 256 and K a multiple of 512 that is
+# at least 1536 (the main loop prefetches six K-tiles). Shapes outside that are
+# not benchmarked here; the provider skips anything the kernel rejects.
+BENCHMARK_SHAPES = [
+    (4096, 4096, 2048),
+    (4096, 4096, 4096),
+    (4096, 4096, 8192),
+    (4096, 4096, 16384),
+    (2048, 8192, 4096),
+    (256, 8192, 4096),
+]
+
+SMALL_SHAPES = [
+    (1024, 1024, 2048),
+    (2048, 2048, 2048),
+]
+
+SHAPE_SETS = {
+    "benchmark": BENCHMARK_SHAPES,
+    "small": SMALL_SHAPES,
+}
+
+# E2M1 code point -> value. Index is the raw 4-bit code (sign in bit 3).
+_E2M1_VALUES = [
+    0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0,
+    -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0,
+]  # fmt: skip
+
+
+def parse_op_args(args: List[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="MXFP4 GEMM benchmark")
+    parser.add_argument("--m", type=int, default=None)
+    parser.add_argument("--n", type=int, default=None)
+    parser.add_argument("--k", type=int, default=None)
+    parser.add_argument(
+        "--shapes",
+        type=str,
+        default="benchmark",
+        choices=list(SHAPE_SETS),
+        help="Shape set to use",
+    )
+    return parser.parse_args(args)
+
+
+def _mxfp4_to_f32(x: torch.Tensor) -> torch.Tensor:
+    """Unpack (rows, K // 2) uint8 into (rows, K) float32."""
+    x = x.repeat_interleave(2, dim=1)
+    x[:, ::2] = x[:, ::2] & 0xF
+    x[:, 1::2] = x[:, 1::2] >> 4
+    values = torch.tensor(_E2M1_VALUES, dtype=torch.float32, device=x.device)
+    return values[x.long()]
+
+
+def _e8m0_to_f32(x: torch.Tensor) -> torch.Tensor:
+    return torch.pow(2.0, x.to(torch.int16).to(torch.float32) - 127.0)
+
+
+def _dequantize(data: torch.Tensor, scales: torch.Tensor) -> torch.Tensor:
+    return _mxfp4_to_f32(data) * _e8m0_to_f32(scales).repeat_interleave(
+        SCALE_GROUP_SIZE, dim=1
+    )
+
+
+class Operator(BenchmarkOperator):
+    DEFAULT_METRICS = ["latency", "tflops", "speedup", "accuracy"]
+    DEFAULT_PRECISION = "bf16"
+    FWD_ONLY = True
+
+    def __init__(
+        self, tb_args: argparse.Namespace, extra_args: Optional[List[str]] = None
+    ) -> None:
+        super().__init__(tb_args, extra_args)
+        args = parse_op_args(self.extra_args or [])
+        self.m, self.n, self.k = args.m, args.n, args.k
+        self.shape_set = args.shapes
+
+    def get_input_iter(self) -> Generator:
+        """Yield BF16 sources, not quantized tensors.
+
+        The providers do not agree on a scale layout -- hipBLASLt and the TLX
+        kernel take the plain [rows, K/32] block scales, others want a shuffled
+        variant -- so each provider quantizes for itself, outside the timed
+        region. Handing every provider one layout would silently benchmark
+        somebody's slow path.
+        """
+        if self.m is not None and self.n is not None and self.k is not None:
+            shapes = [(self.m, self.n, self.k)]
+        else:
+            shapes = SHAPE_SETS[self.shape_set]
+
+        for M, N, K in shapes:
+            torch.manual_seed(42)
+            # /8 keeps the values inside E2M1's tiny dynamic range so the
+            # per-32 scales do not all saturate.
+            a = torch.randn((M, K), device=self.device, dtype=torch.bfloat16) / 8
+            b = torch.randn((N, K), device=self.device, dtype=torch.bfloat16) / 8
+            yield a, b, M, N, K
+
+    @staticmethod
+    def _quantize(x: torch.Tensor):
+        """MXFP4-quantize [rows, K] BF16 -> packed E2M1 + plain E8M0 block scales.
+
+        Written out here rather than pulled from a vendor library so the
+        hipBLASLt and TLX providers do not inherit a dependency they do not
+        otherwise need. Standard MX rounding: one power-of-two scale per 32
+        values, chosen so the group maximum lands on E2M1's largest magnitude
+        (6.0), then round-half-to-even onto the eight E2M1 magnitudes.
+        """
+        rows, K = x.shape
+        g = x.float().reshape(rows, K // SCALE_GROUP_SIZE, SCALE_GROUP_SIZE)
+        amax = g.abs().amax(dim=-1, keepdim=True)
+        # 2 = floor(log2(6.0)); the exponent that maps amax into E2M1's range.
+        exp = torch.floor(torch.log2(amax.clamp(min=1e-30))) - 2
+        exp = exp.clamp(-127, 127)
+        scale = torch.pow(2.0, exp)
+        v = (g / scale).clamp(-6.0, 6.0)
+
+        mags = torch.tensor(
+            _E2M1_VALUES[:8], dtype=torch.float32, device=x.device
+        )  # 0 .. 6
+        av = v.abs()
+        idx = (av.unsqueeze(-1) - mags).abs().argmin(dim=-1)
+        # argmin breaks ties toward the lower index, i.e. toward zero; MX
+        # rounds half to even. The E2M1 code's low bit is its mantissa bit, so
+        # "even" is an even index: on an exact midpoint, step an odd index up.
+        upper = (idx + 1).clamp(max=len(_E2M1_VALUES[:8]) - 1)
+        midpoint = (idx < upper) & (av * 2 == mags[idx] + mags[upper])
+        idx = torch.where(midpoint & (idx % 2 == 1), upper, idx)
+        codes = (idx + torch.where(v < 0, 8, 0)).to(torch.uint8)
+        codes = codes.reshape(rows, K)
+        packed = (codes[:, 1::2] << 4) | codes[:, 0::2]
+
+        scales = (exp.squeeze(-1) + 127).to(torch.uint8)
+        # Pad the scale rows to the 256-row tile the kernels index against.
+        padded = ((rows + 255) // 256) * 256
+        if padded != rows:
+            scales = torch.nn.functional.pad(scales, (0, 0, 0, padded - rows))
+        return packed.contiguous(), scales.contiguous()
+
+    @register_benchmark()
+    def torch_bf16(
+        self, a: torch.Tensor, b: torch.Tensor, M: int, N: int, K: int
+    ) -> Callable:
+        """Un-quantized BF16 torch.mm.
+
+        The exact-arithmetic anchor, not a performance target: quoting a speedup
+        against a full-width BF16 GEMM would flatter any FP4 kernel. Its
+        accuracy column reads 0 by construction -- it is compared against an
+        FP4 baseline, and un-quantized BF16 is supposed to differ from it.
+        """
+        return lambda: torch.mm(a, b.T)
+
+    @register_benchmark(baseline=True)
+    def torch_scaled_mm(
+        self, a: torch.Tensor, b: torch.Tensor, M: int, N: int, K: int
+    ) -> Callable:
+        """torch._scaled_mm, i.e. hipBLASLt's MXFP4 path.
+
+        Plain block scales are the only layout this path accepts -- _scaled_mm_v2's SWIZZLE_32_4_4 is
+        rejected on ROCm ("scale_a must not be swizzled"), so there is no
+        faster hipBLASLt variant to reach for here.
+        """
+        a_q, a_s = self._quantize(a)
+        b_q, b_s = self._quantize(b)
+        try:
+            a_fp4 = a_q.view(torch.float4_e2m1fn_x2)
+            b_fp4 = b_q.view(torch.float4_e2m1fn_x2).T
+            sa = a_s[:M].contiguous().view(torch.float8_e8m0fnu)
+            sb = b_s[:N].contiguous().view(torch.float8_e8m0fnu)
+            torch._scaled_mm(
+                a_fp4, b_fp4, scale_a=sa, scale_b=sb, out_dtype=torch.bfloat16
+            )
+        # Only "this build or shape cannot do MXFP4" opts out: AttributeError
+        # for a torch without the FP4 dtypes, RuntimeError for a shape or
+        # layout hipBLASLt rejects. Anything else is a bug in this operator and
+        # must surface -- this is the baseline, and a silent None empties the
+        # speedup and accuracy columns for every other provider.
+        except (AttributeError, RuntimeError):
+            return None
+        return lambda: torch._scaled_mm(
+            a_fp4, b_fp4, scale_a=sa, scale_b=sb, out_dtype=torch.bfloat16
+        )
+
+    @register_benchmark(
+        enabled=HAS_TLX_MXFP4 and has_tlx() and is_hip_mi350(),
+        tags=["tlx", "amd", "gfx950"],
+    )
+    def tlx_mxfp4_gfx950(
+        self, a: torch.Tensor, b: torch.Tensor, M: int, N: int, K: int
+    ) -> Callable:
+        """TLX MXFP4 GEMM for gfx950 (MI350X).
+
+        Dispatches internally between a 256x256 8-wave tile and a 128x128 +
+        split-K path for occupancy-starved shapes.
+
+        The kernel asserts its own tile/K divisibility, and which assertions
+        apply depends on the tile it dispatches to, so probe once rather than
+        restating the dispatch here -- a copy would rot the first time the
+        kernel's constraints move. Scales must be contiguous along M/N.
+        """
+        a_q, a_s = self._quantize(a)
+        b_q, b_s = self._quantize(b)
+        sa = a_s[:M].T.contiguous().T
+        sb = b_s[:N].T.contiguous().T
+        try:
+            tlx_mxfp4_matmul(a_q, b_q, sa, sb)
+        # The kernel states its tile/K divisibility as plain asserts, so an
+        # unsupported shape arrives as AssertionError. Everything else is a
+        # real failure and should not be hidden.
+        except AssertionError:
+            return None
+        return lambda: tlx_mxfp4_matmul(a_q, b_q, sa, sb)
+
+    @register_x_val(label="(M, N, K)")
+    def get_x_val(self, args: Tuple[Any, ...]) -> Tuple[int, int, int]:
+        M, N, K = args[-3], args[-2], args[-1]
+        return (M, N, K)
+
+    @register_metric()
+    def tflops(
+        self,
+        fn: Callable,
+        example_inputs: Tuple[Any, ...],
+        metrics: BenchmarkOperatorMetrics,
+    ) -> float:
+        M, N, K = example_inputs[-3], example_inputs[-2], example_inputs[-1]
+        if metrics.latency == 0:
+            return float("nan")
+        return 2.0 * M * N * K / metrics.latency / 1e9
+
+    def _get_accuracy(self, fn: Callable, baseline_fn: Callable) -> bool:
+        # FP4 has 3 mantissa bits at most, so the products are exactly
+        # representable and the only divergence is FP32-vs-MFMA accumulation
+        # order over K.
+        output = fn().to(torch.float32)
+        baseline = baseline_fn().to(torch.float32)
+        return torch.allclose(output, baseline, atol=1e-2, rtol=1e-2)
+
+    def get_bwd_fn(self, fwd_fn: Callable) -> Callable:
+        return None


### PR DESCRIPTION
Summary:

Add the two gfx950 TLX GEMMs to TritonBench.

FP16 goes into the existing gemm operator as tlx_matmul_gfx950. B is transposed to column-major outside the
timed region (a row-major B does not give wrong numbers, it fails to compile --
the direct-to-LDS load cannot be coalesced) and shapes below MIN_K are skipped.
The FP16 baseline is already strong: torch.matmul here dispatches to hipBLASLt
(profiled -- a Tensile Cijk_..._MT256x256x64_MI16x16_..._ISA950_SK3 stream-K
kernel), and TunableOp measured slower.

MXFP4 gets a new operator, mxfp4_gemm. Inputs are yielded as BF16 and each
provider quantizes for itself outside the timed region, because the providers do
not agree on a scale layout -- handing all of them one layout benchmarks
somebody's slow path, which is how the first version of this diff ended up
quoting a 5x win against a strawman. The quantizer is written out in the
operator rather than taken from a vendor library so neither provider carries a
dependency it does not otherwise need.

Provider names follow nvfp4_gemm, the closest sibling operator; the TLX ones
carry the arch so it is visible which providers are AMD-only, and both also
carry tags=["tlx", "amd", "gfx950"].

  * torch_scaled_mm -- torch._scaled_mm, the baseline, same name nvfp4_gemm
    gives the same call. Plain block scales are
    the only layout ROCm accepts here: _scaled_mm_v2 with SWIZZLE_32_4_4 is
    rejected ("scale_a must not be swizzled"), so there is no faster hipBLASLt
    variant to reach for.
  * tlx_mxfp4_gfx950 -- our kernel, probed once so unsupported shapes skip
    instead of asserting.
  * torch_bf16 -- exact-arithmetic anchor, deliberately not the baseline
    (it is a full-width BF16 GEMM; a speedup against it flatters any FP4
    kernel). Its accuracy column reads 0 by construction.

hipBLASLt is not the fastest MXFP4 path on this hardware -- AMD's AITER is well
ahead of it -- so read the speedups below as "versus the vendor library reachable
from PyTorch", not as a claim about the best available kernel. Wiring AITER into
TritonBench is left out of this diff: it cannot run there today, because
TritonBench's link tree ships only aiter/*.py while AITER JIT-builds its a4w4
modules from sources that are not present.

The operator is OSS (tritonbench/operators/, not operators/fb/) deliberately:
the MI350 CI job checks out meta-pytorch/tritonbench, so only OSS operators are
covered there, and external users can run it too.

Reviewed By: htyu

Differential Revision: D115522478


