### PR TITLE
capture full Python source in tritonparse traces (#1228)

### DIFF
--- a/tritonbench/utils/tritonparse_utils.py
+++ b/tritonbench/utils/tritonparse_utils.py
@@ -38,6 +38,15 @@ def tritonparse_init(tritonparse_log_path):
                 f"{tritonparse_log_path}/raw_logs",
                 enable_trace_launch=True,
                 enable_more_tensor_information=True,
+                # Capture the whole Python file, not just the kernel's function
+                # definition. Tritonbench is a benchmarking harness whose traces
+                # are meant to be diffed and browsed afterwards, so trace
+                # completeness is worth more than the compile-time cost of one
+                # extra file read per kernel. Function-only capture is actively
+                # wrong for nested kernels: a thin @triton.jit wrapper that just
+                # calls the real kernel yields a source snippet containing none
+                # of the real kernel body.
+                enable_full_python_source=True,
             )
             print(
                 f"TritonParse structured logging initialized with log path: {tritonparse_log_path}"


### PR DESCRIPTION
Summary:

Turns on the `enable_full_python_source` switch added earlier in this stack for
tritonbench's tritonparse integration.

Function-only capture is actively wrong for nested kernels: when the traced
`triton.jit` entry point is a thin wrapper whose body just calls the real
kernel, the captured `python_source` contains none of the real kernel body, so
`tritonparse diff` can only attribute IR changes to the wrapper's callsite line
and the viewer shows no real source.

Tritonbench passes `enable_full_python_source=True` unconditionally rather than
threading a new CLI flag: it is a benchmarking harness whose traces exist to be
diffed and browsed afterwards, so trace completeness is worth more than the
compile-time cost of one extra file read per kernel -- and any new flag would
have to default to on anyway in order to fix this.

Kept as its own diff so the cost of turning the switch on is reverted, and
reviewed, independently of the `init()` API that provides it. That cost is
measured in the test plan: +0.43% trace size on a controlled `layer_norm` run,
with `python_source` staying under 1% of the trace either way.

Reviewed By: xuzhao9

Differential Revision: D115916483


