### PR TITLE
Add standalone gfx950 addmm kernel (#1230)

### DIFF
--- a/tritonbench/operators/addmm/operator.py
+++ b/tritonbench/operators/addmm/operator.py
@@ -15,6 +15,16 @@ from tritonbench.utils.env_utils import (
 from tritonbench.utils.python_utils import try_import
 from tritonbench.utils.triton_utils import has_tlx, has_torch_tlx
 
+if has_tlx():
+    try:
+        from triton.language.extra.tlx.tutorials.amd_addmm_gfx950 import (
+            addmm as _tlx_addmm_gfx950,
+        )
+    except (ImportError, ModuleNotFoundError):
+        _tlx_addmm_gfx950 = None
+else:
+    _tlx_addmm_gfx950 = None
+
 with try_import("HAS_HSTU"):
     try:
         from hammer.ops.triton.triton_hstu_linear import (
@@ -174,6 +184,24 @@ class Operator(BenchmarkOperator):
             compiled = torch.compile(f, dynamic=False)
             compiled(a, mat1, mat2)
         return lambda: compiled(a, mat1, mat2)
+
+    @register_benchmark(
+        enabled=is_hip_mi350() and has_tlx(),
+        fwd_only=True,
+        tags=["tlx", "amd", "gfx950"],
+    )
+    def tlx_addmm_gfx950(self, a, mat1, mat2) -> Callable:
+        """Standalone fused TLX addmm for gfx950 (MI350X)."""
+        if _tlx_addmm_gfx950 is None:
+            return None
+
+        mat1_in = mat1 if mat1.is_contiguous() else mat1.contiguous()
+        mat2_in = mat2 if mat2.stride(0) == 1 else mat2.T.contiguous().T
+        try:
+            _tlx_addmm_gfx950(a, mat1_in, mat2_in)
+        except (AssertionError, ValueError):
+            return None
+        return lambda: _tlx_addmm_gfx950(a, mat1_in, mat2_in)
 
     @register_benchmark(enabled=is_hip_mi350() and has_tlx() and has_torch_tlx())
     def torch_tlx_addmm(self, a, mat1, mat2) -> Callable:


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookexperimental/triton/pull/2864

Expose a standalone fused addmm tutorial by extending the tuned inter-wave `a16w16_8wave` kernel with bias handling in both the direct-store and split-K reduction paths. Register it in TritonBench as `tlx_addmm_gfx950`. Shared-memory allocations now follow the input dtype so the path also supports BF16.

Benchmark on MI350X for the seven shapes where D115683243 reports stock Triton as the autotune winner. Values are TFLOPS; PT2 and TorchTLX accuracy were 1 for every shape.

| M x N x K | ATen | PT2 Triton | TorchTLX | standalone TLX | accuracy |
|---|---:|---:|---:|---:|---:|
| 1024x896x1840 | 154.923 | 215.942 | 217.052 | unsupported | - |
| 1024x896x24 | 3.40589 | 2.8169 | 2.65707 | unsupported | - |
| 1024x896x104 | 14.0585 | 10.9451 | 11.7212 | unsupported | - |
| 1024x1536x2048 | 291.836 | 348.684 | 349.459 | 110.570 | 0 |
| 1024x6144x512 | 230.972 | 410.225 | 402.016 | 365.575 | 1 |
| 7000x256x256 | 60.800 | 58.331 | 61.2864 | 32.0983 | 1 |
| 32768x256x256 | 123.231 | 270.992 | 293.124 | 182.655 | 1 |
| average | 125.604 | 188.277 | 191.045 | 98.6998 | 0.428571 |

The unsupported shapes have K dimensions incompatible with the kernel 32-wide pipeline. The strict TritonBench accuracy miss at 1024x1536x2048 had a maximum absolute difference of 6.1035e-5.

Reviewed By: dshi7

Differential Revision: D116317727


