### PR TITLE
Upload reactor_ci_benchmark results to manifold (#1232)

### DIFF
--- a/benchmarks/common.py
+++ b/benchmarks/common.py
@@ -80,7 +80,8 @@ def run_benchmark_config_ci(
     ci: bool = False,
     log_scuba: bool = False,
     logging_group: str | None = None,
-):
+) -> str | Path:
+    """Run a benchmark config, returning the output dir holding the result jsons."""
     from tritonbench.utils.run_utils import run_config, SPECIAL_CONFIG_FIELDS
     from tritonbench.utils.scuba_utils import decorate_benchmark_data, log_benchmark
 
@@ -161,6 +162,8 @@ def run_benchmark_config_ci(
             pass_rate=pass_rate,
             failed_benchmarks=failed_benchmarks,
         )
+
+    return output_dir
 
 
 def setup_output_dir(bm_name: str, ci: bool = False, output_dir: str | None = None):


### PR DESCRIPTION
Summary:

On MAST the benchmark output dir is a scratch tempdir under `/tmp` that
disappears with the container, so the per-benchmark JSONs and the aggregated
`result.json` are lost once the job finishes. Only the reduced metrics that
make it into Scuba survive.

Add `upload_results_to_manifold()` in `tritonbench/utils/fb/utils.py`, which
uploads a local directory to
`manifold://tc_bench_ci/tree/<benchmark_name>/results/<MAST_JOB_ID>` and
returns the resulting URL:

- `mast_job_id` defaults to `$MAST_HPC_JOB_NAME`; when that is unset (i.e. not
  running on MAST) the upload is skipped with an info log, so local and
  devserver runs are unaffected.
- `sync_putRecursive` does not create intermediate parents, so the remote path
  is `sync_mkdir`'d first when missing.
- `predicate=AllowOverwrite` so a MAST attempt retry does not 409 against a
  path written by an earlier attempt.
- Default TTL is 28 days, matching `model_extractor_benchmark`; pass
  `ttl_sec=0` for indefinite retention.
- Failures are logged and swallowed — a manifold outage should not fail an
  otherwise healthy benchmark job.

Only `reactor_ci_benchmark` opts in for now, rather than uploading for every
benchmark that goes through `run_benchmark_config_ci`. To let it do that,
`run_benchmark_config_ci` now returns the output dir it created; previously
the dir was built internally by `setup_output_dir` and never surfaced to the
caller.

For `reactor_ci_benchmark` the results land next to the configs the same
benchmark already reads from manifold (`tree/reactor_ci_benchmark/<hw>_ci.yaml`
vs `tree/reactor_ci_benchmark/results/<job>`).

The call site guards on `MAST_HPC_JOB_NAME` explicitly rather than relying on
the helper's own check, and imports the helper inside that guard. Off MAST the
output dir persists on the host, so there is nothing to preserve and nothing —
not even the `utils.fb.utils` import chain — is paid for.

`tritonbench_core` is `autodeps-skip`, so the
`//manifold/clients/python:manifold_client` dep is added to it by hand;
`tritonbench/utils/fb/utils.py` is picked up by its
`tritonbench/utils/**/*.py` glob. `reactor_ci_benchmark_lib` already declared
that dep for its config fetching, so no change was needed there.

Differential Revision: D116305776


