### PR TITLE
Add gfx950 persistent GEMM with non-power-of-two N tiles (#1233)

### DIFF
--- a/tritonbench/operators/gemm/operator.py
+++ b/tritonbench/operators/gemm/operator.py
@@ -44,11 +44,11 @@ if has_tlx():
     except (ImportError, ModuleNotFoundError):
         _hopper_tlx_matmul_ws = None
 
-    # gfx950 (MI350X / CDNA4) inter-wave FP16 GEMM. Guarded separately from the
-    # NVIDIA tutorials above: it lives under a package path that only exists in
-    # Triton builds carrying the gfx9 tutorials.
+    # gfx950 (MI350X / CDNA4) GEMM. Guarded separately from the NVIDIA
+    # tutorials above: it lives under a package path that only exists in Triton
+    # builds carrying the gfx9 tutorials.
     try:
-        from triton.language.extra.tlx.tutorials.gfx9_gemm.inter_wave.a16w16.matmul_kernel import (
+        from triton.language.extra.tlx.tutorials.gfx9_gemm.a16w16_matmul import (
             matmul as _tlx_matmul_gfx950,
         )
     except (ImportError, ModuleNotFoundError):
@@ -641,11 +641,9 @@ class Operator(BenchmarkOperator):
     def tlx_matmul_gfx950(self, a, b, bias) -> Callable:
         """TLX FP16/BF16 GEMM for gfx950 (MI350X).
 
-        The kernel picks its own tile and split-K from the shape, so there is
-        nothing to tune here. B must be column-major, handled outside the timed
-        region: feeding a row-major B does not produce wrong numbers, it fails
-        to compile -- the direct-to-LDS load cannot be coalesced -- so the
-        transpose is mandatory, not an optimisation.
+        The public a16w16 entry selects a persistent specialization or the
+        general inter-wave fallback. B must be column-major, handled outside
+        the timed region.
         """
         if _tlx_matmul_gfx950 is None:
             return None


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookexperimental/triton/pull/2873

This change adds a dedicated persistent FP16 TN GEMM family for the gfx950 production shapes (1024, 20480, 6144) and (1024, 24576, 6144). For the primary shape it replaces the existing generic 8-wave inter-wave path with an MT256x160 persistent kernel.

Kernel design:
- Use MT256x160 for N=20480 and MT256x192 for N=24576, with four waves and native 16x16x32 FP16 MFMA instructions.
- Decompose each non-power-of-two N tile into reusable N128 groups plus independent N32 tails. This avoids padding the tile to a power of two while sharing the load, LDS, MFMA, persistent traversal, and epilogue implementation.
- Use a K64 double-buffered pipeline with explicit VGPR staging between global memory and LDS, preserving source-level scheduling freedom.
- Keep A/B load decomposition, LDS publication, operand reads, and MFMA work expressed as compile-time pipeline specifications rather than copying a shape-specific kernel body.
- Assign a compile-time-configurable group of adjacent N tiles to each persistent program. Before the current tile epilogue, prefetch the next tile's complete K0 slice so its global loads overlap MFMA completion, conversion, and output stores. The tuned production specializations currently use two tiles per program.
- Keep FP32 accumulators resident in AGPRs across the K loop and commit the native MFMA fragments only at each tile's epilogue boundary.

Implementation structure:
- Express the persistent tile traversal as a compile-time loop over TILES_PER_PROGRAM instead of a hand-written two-tile sequence.
- Require TILES_PER_PROGRAM to be positive and divide the N-tile count. NUM_PROGRAMS remains specialization data so device-level parallelism can be tuned independently of the reusable traversal mechanism.
- Keep pure LDS helpers under local-prefixed names and pure global-memory helpers under global-prefixed names. Mixed pipeline helpers retain operation-level names.
- Document the K(t), K(t+1), and K(t+2) state carried by the manual pipeline, including the K64-pair and final K94/K95 drain invariants.

Dispatch ownership:
- Add gfx9_gemm/a16w16_matmul.py as the family-level public a16w16 entry. It selects a persistent specialization when matmul_kernel_persistent.supports(a, b) succeeds and otherwise preserves the existing inter-wave fallback.
- Keep this dispatcher above both implementations rather than making the persistent implementation depend on the inter-wave fallback.
- Keep the specialization shape and dtype contract next to the persistent kernel instead of duplicating it in TritonBench.
- TritonBench only imports and invokes the public a16w16 entry; it does not know individual kernel names, tile shapes, or production-shape predicates.
- The a16w16-qualified filename leaves room for a future a4w4_matmul.py entry without overloading a generic gfx9_gemm/matmul.py.

Compiler support:
- Extend scheduled CDNA4 MFMA lowering to matching BF16 or FP16 inputs with FP32 accumulators.
- Allow amd_mfma_commit to terminate a persistent-AGPR chain without requiring a dummy live dot operand.
- Preserve the architecture-required MFMA result hazard and avoid redundant VGPR constraints for ordinary operands.

Scope:
- This diff intentionally contains no schedule-group pricing, cross-region memory interleaving, or MFMA cover-assignment changes. Those compiler scheduling algorithms live in the dependent D116251160.
- The public entry selects this kernel only for the two supported FP16 TN shapes and retains the existing gfx950 inter-wave kernel for all other inputs.

Performance:
Measured on (M, N, K) = (1024, 20480, 6144), layout TN, with D116133962 checked out alone and D116251160 absent. Before and After were invoked in the same TritonBench process on the same tensors. The table reports the median of three warm-cache paired sessions.

| Implementation | Latency (ms) | TFLOPS | Speedup vs aten | Accuracy | Change vs Before |
| --- | ---: | ---: | ---: | ---: | ---: |
| aten.matmul control | 0.243162 | 1059.78 | 1.000000 | 1 | n/a |
| Before D116133962: existing TLX 8-wave kernel | 0.270522 | 952.595 | 0.898862 | 1 | baseline |
| After D116133962 alone: persistent MT256x160 | 0.244282 | 1054.92 | 0.995415 | 1 | -9.70% latency, +10.74% TFLOPS |

The three paired latency measurements were:

| Session | aten (ms) | Before (ms) | After (ms) | After latency reduction |
| --- | ---: | ---: | ---: | ---: |
| 1 | 0.249602 | 0.272083 | 0.246362 | 9.45% |
| 2 | 0.243162 | 0.270522 | 0.244282 | 9.70% |
| 3 | 0.240762 | 0.268682 | 0.242281 | 9.83% |

D116133962 therefore removes about 9.7% of the legacy TLX latency by itself and brings the kernel from 0.899x to 0.995x of aten. The final scheduling improvement that moves the stacked result beyond aten belongs to D116251160 and is not attributed to this diff.

Configurable traversal validation:
- With the tuned TILES_PER_PROGRAM=2 configuration, three additional warm-cache runs measured 0.240602, 0.241043, and 0.240563 ms (median 0.240602 ms), all with accuracy 1.
- The generalized two-tile path preserves the exact 2,098-instruction global/LDS/MFMA/wait/barrier opcode sequence of the previous hand-written path: 960 MFMAs, 156 global loads, 312 ds_read_b128, 156 ds_write_b128, 360 waits, and 42 barriers.
- VGPR, AGPR, LDS, and scratch usage are unchanged: 348 VGPRs, 160 AGPRs, 132032 bytes shared, and zero scratch. SGPR allocation decreases from 67 to 59, and total scalar/vector opcode count decreases from 3272 to 3257.
- A temporary TILES_PER_PROGRAM=4 / NUM_PROGRAMS=128 specialization compiled and reported accuracy 1, but regressed to 0.377123 ms because it halved device-level program parallelism. The production specialization was restored to the measured two-tile default.

Reviewed By: htyu

Differential Revision: D116133962


