### PR TITLE
Disable ADS autotuning in TritonBench GPU tests

### DIFF
--- a/test/test_gpu/main.py
+++ b/test/test_gpu/main.py
@@ -215,7 +215,8 @@ def _run_one_operator(op: str, args: List[str], in_task: bool = False):
 
 def make_test(operator):
     def test_case(self):
-        # Add `--test-only` to disable Triton autotune in tests
+        # Limit benchmark work; the BUCK target separately disables ADS MKL
+        # autotuning so correctness tests use each kernel's fixed config.
         args = [
             "--op",
             operator,


### PR DESCRIPTION
Summary: The GPU test harness claimed that --test-only disabled Triton autotuning, but ADS MKL kernels key their fixed correctness configurations off ADS_MKL_DISABLE_AUTOTUNE. Set that environment variable on the target so cold workers do not compile hundreds of performance configurations.

Differential Revision: D116723735


