### PR TITLE
Add vLLM MoE fused mul-sum benchmark

### DIFF
--- a/tritonbench/operators/moe_fused_mul_sum/__init__.py
+++ b/tritonbench/operators/moe_fused_mul_sum/__init__.py
@@ -1,0 +1,1 @@
+from .operator import Operator

--- a/tritonbench/operators/moe_fused_mul_sum/kernels.py
+++ b/tritonbench/operators/moe_fused_mul_sum/kernels.py
@@ -1,0 +1,161 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def moe_fused_mul_sum_kernel(
+    inputs_ptr,
+    topk_weights_ptr,
+    outputs_ptr,
+    topk_ids_ptr,
+    expert_map_ptr,
+    num_tokens,
+    stride_m,
+    has_expert_map: tl.constexpr,
+    top_k: tl.constexpr,
+    size: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    """Fused weighted reduction of top-k expert outputs.
+
+    Adapted from vLLM's ``moe_fused_mul_sum_kernel``:
+    https://github.com/vllm-project/vllm/blob/1baf372bfc14d739860b4a7122877e22ef0dcbf1/vllm/model_executor/layers/fused_moe/moe_fused_mul_sum.py
+    """
+    pid_k = tl.program_id(0)
+    pid_m = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_k = pid_k * BLOCK_K + tl.arange(0, BLOCK_K)
+
+    m_mask = offs_m < num_tokens
+    k_mask = offs_k < size
+    mask = m_mask[:, None] & k_mask[None, :]
+
+    a_base = inputs_ptr + (offs_m * stride_m)[:, None] + offs_k[None, :]
+    b_base = topk_weights_ptr + offs_m * top_k
+    acc = tl.zeros((BLOCK_M, BLOCK_K), dtype=tl.float32)
+
+    for n in tl.static_range(top_k):
+        b_val = tl.load(b_base + n, mask=m_mask, other=0.0).to(tl.float32)
+        if has_expert_map:
+            id_val = tl.load(topk_ids_ptr + offs_m * top_k + n, mask=m_mask, other=0)
+            expert_mask = tl.load(expert_map_ptr + id_val) >= 0
+            a_vec = tl.load(
+                a_base + n * size,
+                mask=mask & expert_mask[:, None],
+                other=0.0,
+            ).to(tl.float32)
+        else:
+            a_vec = tl.load(
+                a_base + n * size,
+                mask=mask,
+                other=0.0,
+            ).to(tl.float32)
+        acc += a_vec * b_val[:, None]
+
+    out_ptrs = outputs_ptr + (offs_m * size)[:, None] + offs_k[None, :]
+    tl.store(out_ptrs, acc.to(outputs_ptr.dtype.element_ty), mask=mask)
+
+
+def _heuristic_config(
+    num_tokens: int,
+    size: int,
+    element_size: int,
+) -> tuple[int, int, int, int]:
+    is_fp32 = element_size > 2
+    if torch.version.cuda is not None:
+        major, minor = torch.cuda.get_device_capability()
+        capability = major * 10 + minor
+    else:
+        # vLLM's numeric device-capability branches are NVIDIA-specific.
+        capability = 80
+    is_sm90_plus = capability >= 90
+    is_before_sm80 = capability < 80
+
+    if is_sm90_plus:
+        if is_fp32:
+            block_m = 1 if num_tokens <= 4 else 2
+        elif num_tokens <= 4:
+            block_m = 1
+        elif num_tokens <= 128:
+            block_m = 2
+        else:
+            block_m = 4
+    elif is_fp32:
+        if num_tokens <= 4:
+            block_m = 1
+        elif num_tokens <= 32:
+            block_m = 2
+        else:
+            block_m = 4
+    elif num_tokens <= 4:
+        block_m = 1
+    elif num_tokens <= 32:
+        block_m = 2
+    elif num_tokens <= 128:
+        block_m = 4
+    elif num_tokens <= 1024:
+        block_m = 16
+    else:
+        block_m = 8
+
+    if is_fp32:
+        max_block_k = 256
+    elif is_before_sm80 or is_sm90_plus:
+        max_block_k = 512
+    else:
+        max_block_k = 1024
+    block_k = max(256, min(triton.next_power_of_2(size), max_block_k))
+
+    total = block_m * block_k
+    if is_fp32:
+        num_warps = max(8, min(16, total // 64))
+    else:
+        num_warps = max(4, min(16, total // 256))
+
+    if is_before_sm80:
+        num_warps = min(num_warps, 8)
+        num_stages = 2
+    elif is_sm90_plus:
+        num_warps = min(num_warps, 8)
+        num_stages = 4 if total <= 2048 else 2
+    else:
+        num_stages = 4 if total <= 2048 else 2
+
+    return block_m, block_k, num_warps, num_stages
+
+
+def moe_fused_mul_sum(
+    inputs: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor | None = None,
+    expert_map: torch.Tensor | None = None,
+) -> torch.Tensor:
+    num_tokens, top_k, size = inputs.shape
+    output = torch.empty((num_tokens, size), dtype=inputs.dtype, device=inputs.device)
+    block_m, block_k, num_warps, num_stages = _heuristic_config(
+        num_tokens, size, inputs.element_size()
+    )
+    grid = (triton.cdiv(size, block_k), triton.cdiv(num_tokens, block_m))
+    moe_fused_mul_sum_kernel[grid](
+        inputs,
+        topk_weights,
+        output,
+        topk_ids,
+        expert_map,
+        num_tokens,
+        top_k * size,
+        expert_map is not None,
+        top_k,
+        size,
+        block_m,
+        block_k,
+        num_warps=num_warps,
+        num_stages=num_stages,
+    )
+    return output

--- a/tritonbench/operators/moe_fused_mul_sum/operator.py
+++ b/tritonbench/operators/moe_fused_mul_sum/operator.py
@@ -36,7 +36,7 @@ class Operator(BenchmarkOperator):
     FWD_ONLY = True
 
     @register_benchmark(baseline=True)
-    def torch(
+    def eager(
         self,
         inputs: torch.Tensor,
         topk_weights: torch.Tensor,

--- a/tritonbench/operators/moe_fused_mul_sum/operator.py
+++ b/tritonbench/operators/moe_fused_mul_sum/operator.py
@@ -1,0 +1,106 @@
+from typing import Callable, Generator, Tuple
+
+import torch
+from tritonbench.utils.triton_op import (
+    BenchmarkOperator,
+    register_benchmark,
+    register_x_val,
+)
+
+from .kernels import moe_fused_mul_sum
+
+
+def torch_moe_fused_mul_sum(
+    inputs: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor | None,
+    expert_map: torch.Tensor | None,
+) -> torch.Tensor:
+    expert_outputs = inputs.float()
+    if expert_map is not None:
+        assert topk_ids is not None
+        valid_experts = expert_map[topk_ids] >= 0
+        expert_outputs = expert_outputs * valid_experts.unsqueeze(-1)
+    return (
+        (expert_outputs * topk_weights.float().unsqueeze(-1))
+        .sum(dim=1)
+        .to(inputs.dtype)
+    )
+
+
+class Operator(BenchmarkOperator):
+    """Benchmark vLLM's fused weighted reduction of MoE expert outputs."""
+
+    DEFAULT_METRICS = ["latency", "speedup", "accuracy"]
+    DEFAULT_PRECISION = "bf16"
+    FWD_ONLY = True
+
+    @register_benchmark(baseline=True)
+    def torch(
+        self,
+        inputs: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor | None,
+        expert_map: torch.Tensor | None,
+    ) -> Callable:
+        return lambda: torch_moe_fused_mul_sum(
+            inputs, topk_weights, topk_ids, expert_map
+        )
+
+    @register_benchmark(tags=["triton", "vllm"])
+    def triton(
+        self,
+        inputs: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor | None,
+        expert_map: torch.Tensor | None,
+    ) -> Callable:
+        return lambda: moe_fused_mul_sum(inputs, topk_weights, topk_ids, expert_map)
+
+    @register_x_val(label="(tokens, top_k, hidden, expert_map)")
+    def get_x_val(self, example_inputs) -> Tuple[int, int, int, bool]:
+        inputs, _, _, expert_map = example_inputs
+        return (*inputs.shape, expert_map is not None)
+
+    def get_input_iter(self) -> Generator:
+        shapes = [
+            (1, 2, 4096),
+            (4, 8, 4096),
+            (16, 8, 4096),
+            (64, 8, 4096),
+            (256, 8, 4096),
+            (1024, 8, 4096),
+        ]
+        num_experts = 64
+        for num_tokens, top_k, hidden_size in shapes:
+            inputs = torch.randn(
+                num_tokens,
+                top_k,
+                hidden_size,
+                device=self.device,
+                dtype=self.dtype,
+            )
+            topk_weights = torch.softmax(
+                torch.randn(
+                    num_tokens,
+                    top_k,
+                    device=self.device,
+                    dtype=torch.float32,
+                ),
+                dim=-1,
+            ).to(self.dtype)
+
+            yield inputs, topk_weights, None, None
+
+            topk_ids = torch.randint(
+                0,
+                num_experts,
+                (num_tokens, top_k),
+                device=self.device,
+                dtype=torch.int32,
+            )
+            expert_map = torch.arange(
+                num_experts, device=self.device, dtype=torch.int32
+            )
+            expert_map[::4] = -1
+            yield inputs, topk_weights, topk_ids, expert_map


### PR DESCRIPTION
# Add vLLM MoE fused mul-sum benchmark

## Summary

- add a standalone benchmark for vLLM's `moe_fused_mul_sum` Triton kernel
- compare the fused kernel with a float32-accumulating PyTorch reference
- cover representative decode/prefill token counts and top-k expert routing shapes
- include expert-parallel masking inputs through `topk_ids` and `expert_map`

This contributes one of the vLLM custom MoE Triton kernels requested in #479.

## Testing

- `ufmt check tritonbench/operators/moe_fused_mul_sum`
- Python bytecode compilation for all three new files
- `git diff --check`

GPU execution was not run locally because the development host is Apple Silicon and Triton does not publish macOS wheels. The repository's GPU CI should exercise the first benchmark input and accuracy comparison.

Fixes part of #479.
