### PR TITLE
Benchmark AMD TLX Flash Attention (#1240)

### DIFF
--- a/tritonbench/operators/flash_attention/operator.py
+++ b/tritonbench/operators/flash_attention/operator.py
@@ -51,7 +51,7 @@ from tritonbench.kernels.proton_fused_attention import (
 from tritonbench.kernels.triton_fused_attention import (
     attention_opt as triton_tutorial_FA2_opt,
 )
-from tritonbench.utils.env_utils import IS_BLACKWELL, is_hip
+from tritonbench.utils.env_utils import IS_BLACKWELL, is_hip, is_hip_mi350
 from tritonbench.utils.path_utils import add_ld_library_path
 from tritonbench.utils.python_utils import try_import
 from tritonbench.utils.triton_op import is_fbcode
@@ -122,7 +122,80 @@ from tritonbench.utils.triton_op import (
     register_metric,
     register_x_val,
 )
-from tritonbench.utils.triton_utils import has_new_tma, has_warp_spec
+from tritonbench.utils.triton_utils import has_new_tma, has_tlx, has_warp_spec
+
+if has_tlx():
+    try:
+        from triton.language.extra.tlx.tutorials.amd_fa_pipelined import (
+            attention as _tlx_amd_fa_pipelined,
+        )
+    except (ImportError, ModuleNotFoundError):
+        _tlx_amd_fa_pipelined = None
+else:
+    _tlx_amd_fa_pipelined = None
+
+if has_tlx() and is_hip_mi350():
+    try:
+        from triton.language.extra.tlx.tutorials.amd_fa_bwd import (
+            fa_backward as _tlx_amd_fa_backward,
+        )
+    except (ImportError, ModuleNotFoundError) as error:
+        if is_hip_mi350():
+            logger.warning("AMD TLX Flash Attention backward is unavailable: %s", error)
+        _tlx_amd_fa_backward = None
+else:
+    _tlx_amd_fa_backward = None
+
+
+class _TlxAmdFlashAttention(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, q, k, v, sm_scale, causal):
+        tlx_attention = _tlx_amd_fa_pipelined
+        assert tlx_attention is not None
+        config = {
+            "BLOCK_M": 256,
+            "BLOCK_N": 64,
+            "num_warps": 8,
+            "PREFETCH": True,
+        }
+        output = tlx_attention(
+            q,
+            k,
+            v,
+            sm_scale,
+            causal,
+            config=config,
+        )
+        _, lse, *_ = torch.ops.aten._scaled_dot_product_flash_attention.default(
+            q,
+            k,
+            v,
+            0.0,
+            causal,
+            False,
+            scale=sm_scale,
+        )
+        ctx.save_for_backward(q, k, v, output, lse)
+        ctx.sm_scale = sm_scale
+        ctx.causal = causal
+        return output
+
+    @staticmethod
+    def backward(ctx, do):
+        tlx_backward = _tlx_amd_fa_backward
+        assert tlx_backward is not None
+        q, k, v, output, lse = ctx.saved_tensors
+        dq, dk, dv = tlx_backward(
+            q,
+            k,
+            v,
+            output,
+            do.contiguous(),
+            lse,
+            ctx.sm_scale,
+            ctx.causal,
+        )
+        return dq, dk, dv, None, None
 
 
 def parse_op_args(args: List[str]):
@@ -195,7 +268,8 @@ def multi_input_wrapper(fn):
                 outputs.append(benchmark_fn(*i))
             return outputs
 
-        self.optims[multi_input_fn] = torch.optim.SGD(all_inputs)
+        # Citrine C2: use the multi-tensor optimizer implementation.
+        self.optims[multi_input_fn] = torch.optim.SGD(all_inputs, foreach=True)
 
         return multi_input_fn
 
@@ -307,6 +381,45 @@ class Operator(BenchmarkOperator):
             # includes base (default scheduling) + opt (optimized loop scheduling based on heuristics)
             return triton_tutorial_FA2_opt(
                 q, k, v, self.causal, self.sm_scale, "base_opt"
+            )
+
+        return preproc_noop, fn
+
+    @register_benchmark(
+        enabled=(
+            is_hip_mi350()
+            and _tlx_amd_fa_pipelined is not None
+            and _tlx_amd_fa_backward is not None
+        ),
+        tags=["tlx", "amd", "gfx950"],
+    )
+    @multi_input_wrapper
+    def tlx_amd_fa_pipelined(self, *args) -> Tuple[Callable, Callable]:
+        tlx_attention = _tlx_amd_fa_pipelined
+        assert tlx_attention is not None
+        config = {
+            "BLOCK_M": 256,
+            "BLOCK_N": 64,
+            "num_warps": 8,
+            "PREFETCH": True,
+        }
+
+        def fn(q, k, v):
+            if self.mode in (BenchmarkMode.BWD, BenchmarkMode.FWD_BWD):
+                return _TlxAmdFlashAttention.apply(
+                    q,
+                    k,
+                    v,
+                    self.sm_scale,
+                    self.causal,
+                )
+            return tlx_attention(
+                q,
+                k,
+                v,
+                self.sm_scale,
+                self.causal,
+                config=config,
             )
 
         return preproc_noop, fn


### PR DESCRIPTION
Summary:

Add the gfx950-only `tlx_amd_fa_pipelined` TritonBench backend for forward and backward benchmarking. Forward uses the validated prefetch configuration from `amd_fa_pipelined.py`; backward uses a custom autograd bridge to `amd_fa_bwd.fa_backward`, with the required log-sum-exp state generated during untimed backward setup. Package `pytest` for AMD because the backward tutorial module includes its correctness tests.

Citrine also updates the benchmark optimizer to use `foreach=True` for multi-tensor gradient clearing.

## Performance

MI350X, BF16, shape `(B=4, H=48, D=128)`, 3000 repetitions, profiler latency mode. The same process measured PyTorch SDPA, FlexAttention, and TLX.

### OSS setup and commands

Use a Triton build that contains `triton.language.extra.tlx.tutorials.amd_fa_pipelined` and `amd_fa_bwd`; the Triton bundled with a stock PyTorch installation may not contain these tutorials.

```bash
git clone https://github.com/meta-pytorch/tritonbench.git
cd tritonbench
git submodule update --init --recursive
python install.py
python -c 'import triton.language.extra.tlx.tutorials.amd_fa_pipelined'
```

Run N=1024, 2048, 4096, and 8192 in one invocation for each direction:

```bash
for mode in fwd bwd; do
  HIP_VISIBLE_DEVICES=0 python run.py \
    --op flash_attention \
    --only sdpa,flex_attention,tlx_amd_fa_pipelined \
    --mode "$mode" \
    --rep 3000 --sleep 1.0 --metrics tflops \
    --input-id 3 --num-inputs 4 --d-head 128 \
    --latency-measure-mode profiler
done
```

Run N=16384 separately for each direction:

```bash
for mode in fwd bwd; do
  HIP_VISIBLE_DEVICES=0 python run.py \
    --op flash_attention \
    --only sdpa,flex_attention,tlx_amd_fa_pipelined \
    --mode "$mode" \
    --rep 3000 --sleep 1.0 --metrics tflops \
    --seq-len 16384 --seq-len-kv 16384 \
    --num-inputs 1 --d-head 128 \
    --latency-measure-mode profiler
done
```

### Forward throughput

| N | SDPA TFLOPS | FlexAttention TFLOPS | TLX TFLOPS |
| ---: | ---: | ---: | ---: |
| 1024 | 485.393 | 442.831 | **578.137** |
| 2048 | 569.627 | **601.439** | 559.620 |
| 4096 | 622.465 | 687.122 | **709.477** |
| 8192 | 654.293 | 713.918 | **743.982** |
| 16384 | 656.973 | 703.117 | **767.201** |

TLX leads at four of five sequence lengths; FlexAttention leads at N=2048.

### Backward throughput

| N | SDPA TFLOPS | FlexAttention TFLOPS | TLX TFLOPS |
| ---: | ---: | ---: | ---: |
| 1024 | **453.597** | 258.580 | 407.124 |
| 2048 | **524.688** | 177.122 | 354.139 |
| 4096 | **496.430** | 235.118 | 456.160 |
| 8192 | 529.155 | 398.163 | **698.114** |
| 16384 | **689.048** | 171.034 | 376.915 |

Backward performance is shape-sensitive. SDPA/TLX throughput in the same-process multi-backend run showed substantial variance relative to the isolated two-backend sweep.

The generic `triton_tutorial_flash_v2` backend was attempted twice at N=1024 but did not finish AMD LLVM compilation/autotuning after approximately two minutes per attempt, so no measurements are reported.

Differential Revision: D116895083


