### PR TITLE
Support sparse COO inputs in the ATen loader

### DIFF
--- a/test/test_cpu/test_aten_input_loader.py
+++ b/test/test_cpu/test_aten_input_loader.py
@@ -1,0 +1,132 @@
+import unittest
+from types import SimpleNamespace
+
+import torch
+from tritonbench.operator_loader.aten.input_loader import (
+    deserialize_args,
+    deserialize_sparse_tensor,
+    OperatorInputLoader,
+    serialize_sparse_tensor,
+)
+
+
+class AtenInputLoaderTest(unittest.TestCase):
+    def test_hybrid_sparse_tensor_round_trip(self):
+        original = torch.sparse_coo_tensor(
+            torch.tensor([[0, 2, 4]]),
+            torch.randn(3, 4),
+            (5, 4),
+            check_invariants=False,
+        ).coalesce()
+
+        serialized = repr(serialize_sparse_tensor(original))
+        (restored,), _ = deserialize_args(f"(({serialized},), {{}})")
+
+        self.assertEqual(restored.shape, original.shape)
+        self.assertEqual(restored.dtype, original.dtype)
+        self.assertEqual(restored.layout, original.layout)
+        self.assertEqual(restored.sparse_dim(), original.sparse_dim())
+        self.assertEqual(restored.dense_dim(), original.dense_dim())
+        self.assertEqual(restored._nnz(), original._nnz())
+        self.assertTrue(restored.is_coalesced())
+
+    def test_pure_sparse_tensor_round_trip(self):
+        original = torch.sparse_coo_tensor(
+            torch.tensor([[0, 1, 2], [1, 0, 3]]),
+            torch.randn(3),
+            (3, 4),
+            check_invariants=False,
+        )
+
+        serialized = repr(serialize_sparse_tensor(original))
+        (restored,), _ = deserialize_args(f"(({serialized},), {{}})")
+
+        self.assertEqual(restored.shape, original.shape)
+        self.assertEqual(restored.sparse_dim(), 2)
+        self.assertEqual(restored.dense_dim(), 0)
+        self.assertEqual(restored._nnz(), original._nnz())
+        self.assertFalse(restored.is_coalesced())
+
+    def test_legacy_payload_defaults_to_one_sparse_dimension(self):
+        (restored,), _ = deserialize_args(
+            "((ST([5, 4], f32, torch.sparse_coo, False, 3),), {})"
+        )
+
+        self.assertEqual(restored.shape, (5, 4))
+        self.assertEqual(restored.sparse_dim(), 1)
+        self.assertEqual(restored.dense_dim(), 1)
+        self.assertEqual(restored._nnz(), 3)
+
+    def test_empty_sparse_tensor_without_nnz(self):
+        restored = deserialize_sparse_tensor(
+            [0, 4], torch.float32, torch.sparse_coo, True, sparse_dim=1
+        )
+
+        self.assertEqual(restored.shape, (0, 4))
+        self.assertEqual(restored._nnz(), 0)
+        self.assertTrue(restored.is_coalesced())
+
+    def test_rejects_impossible_coalesced_nnz(self):
+        with self.assertRaisesRegex(ValueError, "coalesced tensor cannot have"):
+            deserialize_sparse_tensor(
+                [2, 2],
+                torch.float32,
+                torch.sparse_coo,
+                True,
+                nnz=5,
+                sparse_dim=2,
+            )
+
+    def test_rejects_unsupported_sparse_layout(self):
+        with self.assertRaisesRegex(ValueError, "Unsupported sparse tensor layout"):
+            deserialize_sparse_tensor(
+                [2, 2],
+                torch.float32,
+                torch.sparse_csr,
+                False,
+                nnz=1,
+                sparse_dim=2,
+            )
+
+        with self.assertRaisesRegex(ValueError, "Unsupported sparse tensor layout"):
+            serialize_sparse_tensor(SimpleNamespace(layout=torch.sparse_csr))
+
+    def test_embedding_entries_do_not_block_other_operators(self):
+        input_config = {
+            "aten.add.Tensor": [
+                {
+                    "inputs": "((T([2], f32), T([2], f32)), {})",
+                    "count": 1,
+                }
+            ],
+            "aten.embedding.default": [
+                {
+                    "inputs": "((T([4, 2], f32), T([2], i64)), {})",
+                    "count": 1,
+                }
+            ],
+        }
+
+        loader = OperatorInputLoader("aten.add.Tensor", input_config)
+        inputs = list(loader.get_input_iter()())
+
+        self.assertEqual(len(inputs), 1)
+
+    def test_embedding_operator_remains_rejected(self):
+        input_config = {
+            "aten.embedding.default": [
+                {
+                    "inputs": "((T([4, 2], f32), T([2], i64)), {})",
+                    "count": 1,
+                }
+            ]
+        }
+
+        with self.assertRaisesRegex(
+            RuntimeError, "Embedding inputs not yet implemented"
+        ):
+            OperatorInputLoader("aten.embedding.default", input_config)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tritonbench/operator_loader/aten/input_loader.py
+++ b/tritonbench/operator_loader/aten/input_loader.py
@@ -67,16 +67,66 @@ class FuncCallWrapper:
 
 
 def serialize_sparse_tensor(e):
-    if isinstance(e, torch._subclasses.FakeTensor):
-        return FuncCallWrapper("ST", list(e.shape), e.dtype, e.layout, e.is_coalesced())
-    else:
-        return FuncCallWrapper(
-            "ST", list(e.shape), e.dtype, e.layout, e.is_coalesced(), e._nnz()
+    if e.layout != torch.sparse_coo:
+        raise ValueError(f"Unsupported sparse tensor layout: {e.layout}")
+    nnz = None if isinstance(e, torch._subclasses.FakeTensor) else e._nnz()
+    return FuncCallWrapper(
+        "ST",
+        list(e.shape),
+        e.dtype,
+        e.layout,
+        e.is_coalesced(),
+        nnz,
+        sparse_dim=e.sparse_dim(),
+    )
+
+
+def deserialize_sparse_tensor(
+    size, dtype, layout, is_coalesced, nnz=None, sparse_dim=None
+):
+    if layout != torch.sparse_coo:
+        raise ValueError(f"Unsupported sparse tensor layout: {layout}")
+
+    # Existing serialized DLRM inputs predate sparse_dim metadata and contain
+    # hybrid COO gradients with one sparse dimension.
+    if sparse_dim is None:
+        sparse_dim = 1
+    if not 1 <= sparse_dim <= len(size):
+        raise ValueError(
+            f"sparse_dim must be between 1 and {len(size)}, got {sparse_dim}"
         )
 
+    nnz = 0 if nnz is None else nnz
+    sparse_numel = math.prod(size[:sparse_dim])
+    if nnz < 0:
+        raise ValueError(f"nnz must be non-negative, got {nnz}")
+    if nnz > 0 and sparse_numel == 0:
+        raise ValueError(
+            "A sparse tensor with an empty sparse dimension cannot have nnz"
+        )
+    if is_coalesced and nnz > sparse_numel:
+        raise ValueError(
+            f"A coalesced tensor cannot have {nnz} entries in a sparse space "
+            f"of size {sparse_numel}"
+        )
 
-def deserialize_sparse_tensor(size, dtype, layout, is_coalesced, nnz=None):
-    raise NotImplementedError("Sparse Tensor generation is not implemented.")
+    linear_indices = torch.arange(nnz, dtype=torch.int64)
+    indices = []
+    for dim_size in reversed(size[:sparse_dim]):
+        indices.append(linear_indices.remainder(dim_size))
+        linear_indices = torch.div(linear_indices, dim_size, rounding_mode="floor")
+    indices = torch.stack(list(reversed(indices)))
+
+    values = deserialize_tensor([nnz, *size[sparse_dim:]], dtype)
+    out = torch.sparse_coo_tensor(
+        indices,
+        values,
+        size,
+        dtype=dtype,
+        is_coalesced=False,
+        check_invariants=False,
+    )
+    return out.coalesce() if is_coalesced else out
 
 
 def deserialize_tensor(size, dtype, stride=None):
@@ -174,13 +224,13 @@ class OperatorInputLoader:
                 inps = inputs["inputs"]
                 op_inps[inps] += cnt
             self.operator_db[operator] = op_inps
-            if "embedding" in str(operator):
-                raise RuntimeError(
-                    "Embedding inputs not yet implemented, input data cannot be randomized"
-                )
         if self.op_name not in self.operator_db:
             raise RuntimeError(
                 f"Could not find {self.op_name} in {list(input_config.keys())}."
+            )
+        if "embedding" in self.op_name:
+            raise RuntimeError(
+                "Embedding inputs not yet implemented, input data cannot be randomized"
             )
 
     def get_input_iter(


### PR DESCRIPTION
## Summary

- generate sparse COO tensors from serialized ATen input metadata instead of raising `NotImplementedError`
- preserve `sparse_dim` in newly serialized inputs while remaining compatible with the existing one-sparse-dimension DLRM payloads
- preserve shape, dtype, layout, nnz, dense dimensions, and coalesced state
- reject embedding inputs only when the requested operator is itself an embedding operator, so unrelated operators in the same input file remain loadable
- add CPU coverage for hybrid and pure COO tensors, legacy payloads, empty tensors, validation errors, and mixed embedding configs

Addresses the sparse-input portion of #270.

## Testing

- `python -m unittest test.test_cpu.test_aten_input_loader -v` (8 passed)
- adjacent CPU unit modules for device utilities, environment utilities, entropy comparison, and online regression (51 passed)
- loaded the repository's real `torchbench_train/dlrm_train.json` metadata for `aten.add_.Tensor` (15 payloads, including 6 sparse payloads)
- `ufmt check tritonbench/operator_loader/aten/input_loader.py test/test_cpu/test_aten_input_loader.py`
- `git diff --check`

The official `test.test_cpu.main` suite passed 5 of 6 tests locally. Its `layer_norm` test could not import because Triton does not provide a macOS wheel; the other five tests passed.