### PR TITLE
[addmm][torch_tlx] fix col-major on amd

### DIFF
--- a/tritonbench/operators/addmm/operator.py
+++ b/tritonbench/operators/addmm/operator.py
@@ -209,6 +209,8 @@ class Operator(BenchmarkOperator):
         # force_disable_caches prevents a prior allow-mode or stock-Triton choice
         # from being reused through the autotune cache.
         # Gated to AMD MI350x (gfx950), where the TLX addmm template exists.
+        mat1_in = mat1 if mat1.is_contiguous() else mat1.contiguous()
+        mat2_in = mat2 if mat2.stride(0) == 1 else mat2.T.contiguous().T
         torch._dynamo.reset()
         with inductor_config.patch(
             {
@@ -221,8 +223,8 @@ class Operator(BenchmarkOperator):
         ):
             f = lambda a, mat1, mat2: torch.addmm(a, mat1, mat2)
             compiled = torch.compile(f, dynamic=False)
-            compiled(a, mat1, mat2)
-        return lambda: compiled(a, mat1, mat2)
+            compiled(a, mat1_in, mat2_in)
+        return lambda: compiled(a, mat1_in, mat2_in)
 
     @register_benchmark(enabled=False)
     def pt2_addmm_maxautotune(self, a, mat1, mat2) -> Callable:


### PR DESCRIPTION
torch_tlx addmm only supports col-major on amd

Error:

```
          File "/workspace/uv_venvs/meta-triton/lib/python3.12/site-packages/torch/_inductor/async_compile.py", line 513, in triton
            kernel.precompile(
          File "/workspace/uv_venvs/meta-triton/lib/python3.12/site-packages/torch/_inductor/runtime/triton_heuristics.py", line 623, in precompile
            self._precompile_worker()
          File "/workspace/uv_venvs/meta-triton/lib/python3.12/site-packages/torch/_inductor/runtime/triton_heuristics.py", line 645, in _precompile_worker
            compile_results.append(self._precompile_config(c))
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
          File "/workspace/uv_venvs/meta-triton/lib/python3.12/site-packages/torch/_inductor/runtime/triton_heuristics.py", line 1087, in _precompile_config
            binary = triton.compile(*compile_args, **compile_kwargs)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          File "/home/runner/_work/triton/triton/python/triton/compiler/compiler.py", line 381, in compile
            module = src.make_ir(target, options, codegen_fns, module_map, context)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          File "/home/runner/_work/triton/triton/python/triton/compiler/compiler.py", line 89, in make_ir
            return ast_to_ttir(self.fn, self, context=context, options=options, codegen_fns=codegen_fns,
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        torch._inductor.exc.InductorError: CompilationError: at 107:61:
            b_base = offs_n[:, None] * stride_bn          # B as (BLOCK_N, BLOCK_K): n is the row of the [N,K] view


            # --- async_load direct-to-LDS warp-pipe path (USE_ASYNC=1: K % 8 == 0, 16-byte-aligned rows) ---
            K_ITERS = K // BLOCK_K   # FULL K-tiles only; the partial-K tail is handled after the pipeline

            k_lo = 0
            n_iters = K_ITERS


            smemA = tlx.local_alloc((BLOCK_M, BLOCK_K), tlx.dtype_of(A), NUM_BUFFERS)
            smemB = tlx.local_alloc((BLOCK_N, BLOCK_K), tlx.dtype_of(B), NUM_BUFFERS)   # holds Bᵀ tile
                                                                     ^
        NameError('B is not defined')

        Set TORCHDYNAMO_VERBOSE=1 for the internal stack trace (please do this especially if you're reporting a bug to PyTorch). For even more developer context, set TORCH_LOGS="+dynamo"

        WARNING:tritonbench.utils.triton_op:Failing input: --input-id 0 --num-inputs 1 --input-sample-mode first-k

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/runner/_work/triton/triton/tritonbench/test/test_gpu/main.py", line 232, in test_case
    _run_one_operator(op=operator, args=args, in_task=in_task)
  File "/home/runner/_work/triton/triton/tritonbench/test/test_gpu/main.py", line 197, in _run_one_operator
    opbench.run()
  File "/home/runner/_work/triton/triton/tritonbench/test/test_gpu/main.py", line 183, in run
    self.op.run()
  File "/home/runner/_work/triton/triton/tritonbench/tritonbench/operators/op_task.py", line 154, in run
    self.worker.run(
  File "/home/runner/_work/triton/triton/tritonbench/tritonbench/components/workers/subprocess_worker.py", line 174, in run
    self._run(snippet)
  File "/home/runner/_work/triton/triton/tritonbench/tritonbench/components/workers/subprocess_worker.py", line 346, in _run
    subprocess_rpc.SerializedException.raise_from(
  File "/home/runner/_work/triton/triton/tritonbench/tritonbench/components/workers/subprocess_rpc.py", line 485, in raise_from
    raise e from ChildTraceException(traceback_str)
tritonbench.components.workers.subprocess_rpc.UnserializableException: ("<class 'torch._inductor.exc.InductorError'>", '(\'CompilationError: at 107:61:\\n    b_base = offs_n[:, None] * stride_bn          # B as (BLOCK_N, BLOCK_K): n is the row of the [N,K] view\\n\\n\\n    # --- async_load direct-to-LDS warp-pipe path (USE_ASYNC=1: K % 8 == 0, 16-byte-aligned rows) ---\\n    K_ITERS = K // BLOCK_K   # FULL K-tiles only; the partial-K tail is handled after the pipeline\\n\\n    k_lo = 0\\n    n_iters = K_ITERS\\n\\n\\n    smemA = tlx.local_alloc((BLOCK_M, BLOCK_K), tlx.dtype_of(A), NUM_BUFFERS)\\n    smemB = tlx.local_alloc((BLOCK_N, BLOCK_K), tlx.dtype_of(B), NUM_BUFFERS)   # holds Bᵀ tile\\n                                                             ^\\nNameError(\\\'B is not defined\\\')\\n\\nSet TORCHDYNAMO_VERBOSE=1 for the internal stack trace (please do this especially if you\\\'re reporting a bug to PyTorch). For even more developer context, set TORCH_LOGS="+dynamo"\\n\',)')

```