### PR TITLE
Add Kimi Delta Attention benchmark

### DIFF
--- a/test/test_gpu/test_kimi_delta_attention.py
+++ b/test/test_gpu/test_kimi_delta_attention.py
@@ -1,0 +1,60 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+import unittest
+
+from tritonbench.operators import load_opbench_by_name
+from tritonbench.utils.parser import get_parser
+
+
+class KimiDeltaAttentionTest(unittest.TestCase):
+    def _run_accuracy(self, mode: str, tolerance: float) -> None:
+        args = [
+            "--op",
+            "kimi_delta_attention",
+            "--mode",
+            mode,
+            "--metrics",
+            "accuracy",
+            "--only",
+            "chunk_kda,kda_ws",
+            "--test-only",
+            "--batch",
+            "1",
+            "--seq-lens",
+            "256",
+            "--heads",
+            "3",
+            "--head-dim",
+            "128",
+            "--atol",
+            str(tolerance),
+            "--rtol",
+            str(tolerance),
+        ]
+        parser = get_parser()
+        tb_args, extra_args = parser.parse_known_args(args)
+        operator_class = load_opbench_by_name(tb_args.op)
+        operator = operator_class(tb_args=tb_args, extra_args=extra_args)
+        operator.run()
+
+        headers, rows = operator.output._table()
+        accuracy_columns = [
+            index for index, header in enumerate(headers) if "accuracy" in header.lower()
+        ]
+        self.assertTrue(accuracy_columns)
+        self.assertTrue(rows)
+        for row in rows:
+            for index in accuracy_columns:
+                if row[index] is not None:
+                    self.assertEqual(int(row[index]), 1)
+
+    def test_forward_accuracy(self) -> None:
+        self._run_accuracy("fwd", 3e-2)
+
+    def test_backward_accuracy(self) -> None:
+        self._run_accuracy("bwd", 5e-2)
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
Summary:
bypass-github-export-checks Meta-internal TritonBench KDA benchmark; the operator depends on Ads MKL/TLX and has no OSS-exportable effective patch.

Add the internal `kimi_delta_attention` TritonBench operator with two shared Ads MKL providers:

- `chunk_kda`: the memory-stable FlashKDA-derived comparison baseline from `ads_mkl/ops/triton/kda_baseline`.
- `kda_ws`: the optimized TLX provider from `ads_mkl/ops/tlx/kda`.

The operator supports `fwd`, `bwd`, and `fwd_bwd`, defaults to the production `(768, 5000/8000/10000/14000, 4, 128)` shapes, and reports latency, TFLOPS, speedup, and accuracy. It preserves BF16 `q/k/v` inputs and FP32 `g/beta`, and explicitly releases forward and backward graphs between providers and shapes so the 14k workload remains runnable.

The benchmark no longer requires GEO package visibility and does not import a production MSL `chunk_kda` implementation directly.

The generic TritonBench GPU matrix limits this TLX/TMEM operator to B200 with Triton beta. H100 and Triton stable combinations omit it, while the dedicated GB300 correctness target remains available.

Reviewed By: jackiexu77

Differential Revision: D117001539


