### PR TITLE
Add the gfx950 TLX HSTU kernel to the tutorials and call it from tritonbench (#1245)

### DIFF
--- a/tritonbench/operators/ragged_attention/operator.py
+++ b/tritonbench/operators/ragged_attention/operator.py
@@ -9,6 +9,7 @@ from tritonbench.utils.env_utils import (
     IS_BLACKWELL,
     is_cuda,
     is_fbcode,
+    is_hip_mi350,
 )
 from tritonbench.utils.input import input_filter
 from tritonbench.utils.triton_op import (
@@ -103,6 +104,37 @@ try:
 except Exception:
     HAS_HSTU_SELF_ATTN = False
 
+# gfx950 (MI350X) TLX HSTU self-attention, from the same tutorials directory.
+# Separate try block from the Blackwell import above so neither disables the
+# other: only one of the two ever has usable hardware in a given run.
+# Defined unconditionally: parse_op_args() reads them to build --tlx-gfx950-bwd-variant
+# regardless of platform. The `isdir` check below can fail *without* raising -- the
+# tutorials module imports fine under the fbcode triton while hstu_self_attn/ is not
+# materialized on disk -- so relying on the `except` branch to define them left them
+# unbound and NameError'd the whole operator on non-gfx950 CI.
+HAS_HSTU_TLX_GFX950 = False
+HSTU_GFX950_BWD_VARIANTS: dict = {}
+HSTU_GFX950_DEFAULT_BWD_VARIANT: str = ""
+try:
+    import os as _os
+    import sys as _sys
+
+    import triton.language.extra.tlx.tutorials as _tlx_tut
+
+    _hstu_self_dir = _os.path.join(list(_tlx_tut.__path__)[0], "hstu_self_attn")
+    if _os.path.isdir(_hstu_self_dir):
+        if _hstu_self_dir not in _sys.path:
+            _sys.path.insert(0, _hstu_self_dir)
+        from tlx_gfx950_ragged_hstu_attention import (
+            BWD_VARIANTS as HSTU_GFX950_BWD_VARIANTS,
+            DEFAULT_BWD_VARIANT as HSTU_GFX950_DEFAULT_BWD_VARIANT,
+            tlx_gfx950_hstu_mha,
+        )
+
+        HAS_HSTU_TLX_GFX950 = True
+except Exception:
+    HAS_HSTU_TLX_GFX950 = False
+
 
 def parse_op_args(args: List[str]):
     parser = argparse.ArgumentParser()
@@ -123,6 +155,17 @@ def parse_op_args(args: List[str]):
     parser.add_argument("--sampling-alpha", type=float, default=1.7)
     parser.add_argument("--causal", action="store_true")
     parser.add_argument("--attn-mask-type", type=str, default="lower_triangular")
+    parser.add_argument(
+        "--tlx-gfx950-bwd-variant",
+        type=str,
+        default=None,
+        choices=sorted(HSTU_GFX950_BWD_VARIANTS) or None,
+        help=(
+            "Backward schedule for the hstu_tlx_gfx950 backend "
+            f"(default: {HSTU_GFX950_DEFAULT_BWD_VARIANT or 'n/a'}). "
+            "Forward is identical across variants."
+        ),
+    )
     parser.add_argument(
         "--config",
         type=str,
@@ -182,6 +225,9 @@ class Operator(BenchmarkOperator):
             self.attn_mask_type = args.attn_mask_type
         self.causal = args.causal
         self.sampling_alpha = args.sampling_alpha
+        self.tlx_gfx950_bwd_variant = (
+            args.tlx_gfx950_bwd_variant or HSTU_GFX950_DEFAULT_BWD_VARIANT
+        )
         self.requires_grad = not (self.mode == Mode.FWD_NO_GRAD)
 
     @register_benchmark(enabled=is_cuda(), baseline=True)
@@ -250,6 +296,85 @@ class Operator(BenchmarkOperator):
             max_attn_len=self.max_attn_len,
             contextual_seq_len=self.contextual_seq_len,
             causal=True,
+        )
+
+    def _hstu_tlx_gfx950(
+        self, bwd_variant, q, k, v, seq_offsets, num_targets, max_seq_len
+    ):
+        # gfx950 TLX HSTU. `attn_scale=None` makes the kernel fold 1/max_seq_len
+        # into the silu itself, which is what the `hstu` baseline does -- and the
+        # FA-schedule backwards reject an explicit attn_scale outright.
+        #
+        # The FA-schedule variants additionally require the plain causal HSTU
+        # path: num_targets set, no contextual prefix / max_attn_len /
+        # full_attn_size, no length sorting, silu heads only, Dq=Dv=128. Run with
+        # the operator defaults (--target-size 20 --attn-dim 128 --hidden-dim 128)
+        # or pick `default` / `native_mfma_*` for the unconstrained backward.
+        return lambda: tlx_gfx950_hstu_mha(
+            max_seq_len=max_seq_len,
+            alpha=self.alpha,
+            q=q,
+            k=k,
+            v=v,
+            seq_offsets=seq_offsets,
+            attn_scale=None,
+            num_targets=num_targets,
+            invalid_attn_mask_type=self.attn_mask_type,
+            max_attn_len=self.max_attn_len,
+            contextual_seq_len=self.contextual_seq_len,
+            full_attn_size=0,
+            sort_by_length=False,
+            num_softmax_heads=0,
+            bwd_variant=bwd_variant,
+        )
+
+    @register_benchmark(
+        enabled=HAS_HSTU_TLX_GFX950 and is_hip_mi350(),
+        tags=["tlx", "amd", "gfx950"],
+    )
+    def hstu_tlx_gfx950(self, q, k, v, seq_offsets, num_targets, max_seq_len, sparsity):
+        # Backward schedule from --tlx-gfx950-bwd-variant; defaults to the
+        # BN128 resident-K mask-peel variant, which is the fastest at N >= 2048.
+        return self._hstu_tlx_gfx950(
+            self.tlx_gfx950_bwd_variant,
+            q,
+            k,
+            v,
+            seq_offsets,
+            num_targets,
+            max_seq_len,
+        )
+
+    @register_benchmark(
+        enabled=HAS_HSTU_TLX_GFX950 and is_hip_mi350(),
+        tags=["tlx", "amd", "gfx950"],
+    )
+    def hstu_tlx_gfx950_bn256(
+        self, q, k, v, seq_offsets, num_targets, max_seq_len, sparsity
+    ):
+        # BN256 direct-load FA schedule: still the best backward at N == 1024.
+        return self._hstu_tlx_gfx950(
+            "kv_parallel_fa_schedule_bn256_direct_qdo_g2l",
+            q,
+            k,
+            v,
+            seq_offsets,
+            num_targets,
+            max_seq_len,
+        )
+
+    @register_benchmark(
+        enabled=HAS_HSTU_TLX_GFX950 and is_hip_mi350(),
+        tags=["tlx", "amd", "gfx950"],
+    )
+    def hstu_tlx_gfx950_ordinary_dot(
+        self, q, k, v, seq_offsets, num_targets, max_seq_len, sparsity
+    ):
+        # Ordinary-dot dQ backward with the kernel's own kv_parallel heuristic.
+        # The one variant with no FA-schedule preconditions, so it is the
+        # backend to use for masked / contextual / softmax-head shapes.
+        return self._hstu_tlx_gfx950(
+            "default", q, k, v, seq_offsets, num_targets, max_seq_len
         )
 
     def _hstu_self_autows(


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookexperimental/triton/pull/3264

Ports the gfx950 TLX ragged HSTU attention template (fwd + bwd) into the Triton
TLX tutorials as a standalone kernel with no fbcode dependencies, and registers
it as tritonbench ragged_attention backends. The point is to make the kernel
runnable outside buck, from an OSS Triton checkout, while keeping fbsource the
source of truth.

Review in this order. Start with the beta triton side. hstu_self_attn/stubs.py
grows the leaf helpers the kernel needs from hammer/ops/triton/utils.py
(get_use_rtz, pid_swizzle and their tl.constexpr globals). Then the kernel,
hstu_self_attn/tlx_gfx950_ragged_hstu_attention.py: it is a near-verbatim copy
of hammer/v2/ops/triton/template/tlx_gfx950_ragged_hstu_attention.py at
D117155561, and every substantive edit is on the dependency boundary -- fbcode
imports redirected at stubs; the backward demoted from a hammer:: custom op to
a plain function (it is only ever called from Function.backward under
inference_mode, and registering that namespace here would collide with hammer
if both are loaded); and a local _switch_to_contiguous_if_needed in place of
stubs.switch_to_contiguous_if_needed, which always copies and would therefore
silently drop the in-place dq/dk/dv gradients. Next the new gfx950 case in
testing/test_correctness.py, and the BUCK.template change that gives
py_tlx_amd_tutorial_correctness the HSTU_SELF_ATTN_TEST_RESOURCES it now needs
-- hstu_self_attn is a directory of standalone scripts with bare
intra-directory imports, so the .py files have to be materialized on disk for
the sys.path insertion to resolve. BUCK is regenerated, not hand-edited.

Finish with the tritonbench operator.

Variants
--------
The kernel exposes BWD_VARIANTS plus a tlx_gfx950_hstu_mha entry point shaped
like the sibling tlx_bw_hstu_mha, so all eleven backward schedules are
reachable by name. They split across two code paths: the six fa_schedule ones
launch _tlx_gfx950_hstu_fa_schedule_bwd_kernel with hard-coded launch
parameters (num_warps=4, num_stages=1, matrix_instr_nonkdim=16, waves_per_eu=0,
no autotuning at all), while default / kv_parallel / native_mfma_4wave /
native_mfma_8wave / kv_parallel_native_mfma_4wave go through the autotuned
_tlx_gfx950_ragged_hstu_attn_bwd.

    default                                       kv_parallel_fa_schedule_direct_qdo_g2l
    native_mfma_4wave                             kv_parallel_fa_schedule_mask_peel
    native_mfma_8wave                             kv_parallel_fa_schedule_mask_peel_resident_k
    kv_parallel                                   kv_parallel_fa_schedule_bn256
    kv_parallel_native_mfma_4wave                 kv_parallel_fa_schedule_bn256_direct_qdo_g2l
    kv_parallel_fa_schedule

Three tritonbench backends are registered, gated on is_hip_mi350() and modelled
on the AMD TLX flash-attention ones: hstu_tlx_gfx950 (the target of the new
--tlx-gfx950-bwd-variant flag, which reaches all eleven), hstu_tlx_gfx950_bn256,
and hstu_tlx_gfx950_ordinary_dot (the only variant with no fa_schedule
preconditions, so it is the one that covers masked / contextual / softmax-head
shapes). All pass attn_scale=None so the kernel folds 1/max_seq_len into the
silu, matching the hstu baseline; the fa_schedule variants reject an explicit
attn_scale outright.

Perf
----
Repro, from the tritonbench checkout:

  python run.py --op ragged_attention --mode bwd --num-inputs 3 \
    --min-seq-len-log2 10 --max-seq-len-log2 12 --metrics latency,tflops \
    --only hstu_tlx_gfx950 --tlx-gfx950-bwd-variant <name>

MI350X, idle GPU, clocks pinned at 2200 MHz via denoise.sh (note its default of
2100 costs ~14% on this kernel), B512/H4/D128 bf16, sparsity 0.95, target 20.
Backward latency in ms, best variant per length against the D116849000 base:

  N       base    best     speedup   best variant
  1024    6.47    5.57     1.160x    kv_parallel_native_mfma_4wave
  2048   23.70   17.98     1.318x    kv_parallel_fa_schedule_mask_peel_resident_k
  4096   94.16   53.54     1.759x    kv_parallel_fa_schedule_mask_peel_resident_k

Two caveats measured here and worth carrying: the autotuned variants are noisy
at N=2048 across repeats (default read 18.1 / 22.2 / 50.8 ms on three runs), so
single-shot numbers from that path are not trustworthy; and the fa_schedule
family lands at a near-constant 1.19x (N=4096) / 1.23x (N=2048) of the absolute
numbers quoted upstream, while the base reproduces to within 0.6%. That offset
is not a porting or toolchain artifact -- the fa_schedule kernel is not
autotuned, and buck and OSS compile it to byte-identical ISA and measure it
within 0.2%.

Reviewed By: yaoyj11

Differential Revision: D117241494


