### PR TITLE
[abtest] Support `--power-chart` in abtest mode

### DIFF
--- a/test/test_cpu/test_ab_test_interrupt.py
+++ b/test/test_cpu/test_ab_test_interrupt.py
@@ -19,7 +19,7 @@ class AbTestInterruptTest(unittest.TestCase):
         """Run the A/B loop with the Nth repeat raising KeyboardInterrupt."""
         started = []
 
-        def fake_run_ab_test(args, extra_args, run_func):
+        def fake_run_ab_test(args, extra_args, run_func, output_dirs=None):
             started.append(len(started) + 1)
             if len(started) == interrupt_on:
                 raise KeyboardInterrupt

--- a/test/test_cpu/test_ab_test_json.py
+++ b/test/test_cpu/test_ab_test_json.py
@@ -1,6 +1,7 @@
 """Tests for the A/B mode ``--output-json`` report."""
 
 import json
+import os
 import random
 import sys
 import tempfile
@@ -9,6 +10,7 @@ from collections import OrderedDict
 from pathlib import Path
 from unittest.mock import patch
 
+import tritonbench.utils.run_utils as run_utils
 from tritonbench.components.do_bench.run import Latency
 from tritonbench.utils.ab_test import (
     AB_COMPARISON_KEY,
@@ -223,6 +225,33 @@ class AbTestJsonTest(unittest.TestCase):
             with open(path) as f:
                 loaded = json.load(f, parse_constant=_reject)
         self.assertEqual(loaded, report)
+
+
+class AbPowerDirTest(unittest.TestCase):
+    """The per-side, per-repeat directories a --power-chart A/B run writes to."""
+
+    def test_layout_is_side_then_repeat(self):
+        with tempfile.TemporaryDirectory() as root:
+            dirs = run_utils._ab_power_dirs(root, None, 1, has_side_b=True)
+            self.assertEqual(
+                dirs,
+                {
+                    "a": os.path.join(root, "side_a_repeat_1"),
+                    "b": os.path.join(root, "side_b_repeat_1"),
+                },
+            )
+            # The directories exist: the power manager and the per-op json dump
+            # both write into them without creating them first.
+            for path in dirs.values():
+                self.assertTrue(Path(path).is_dir())
+
+    def test_single_side_and_multi_mode(self):
+        with tempfile.TemporaryDirectory() as root:
+            dirs = run_utils._ab_power_dirs(root, "bwd", 7, has_side_b=False)
+            self.assertEqual(dirs, {"a": os.path.join(root, "bwd", "side_a_repeat_7")})
+
+    def test_no_power_chart_leaves_output_dir_alone(self):
+        self.assertIsNone(run_utils._ab_power_dirs(None, None, 1, has_side_b=True))
 
 
 if __name__ == "__main__":

--- a/tritonbench/utils/ab_test.py
+++ b/tritonbench/utils/ab_test.py
@@ -185,7 +185,14 @@ def merge_global_args(base_args: List[str], side_args: List[str]) -> List[str]:
 def update_args_with_global(
     base_args: argparse.Namespace, global_args: List[str]
 ) -> argparse.Namespace:
-    """Update base args with global arguments from A/B config."""
+    """Update base args with global arguments from A/B config.
+
+    Only the options the side actually specifies are applied. They are parsed
+    straight into a copy of the base namespace, which argparse fills in without
+    touching attributes that are already set -- so a base flag the side is
+    silent about (``--power-chart``, ``--cudagraph``, ``--sleep 1.0``, ...)
+    survives instead of being reset to the parser default.
+    """
     if not global_args:
         return argparse.Namespace(**vars(base_args))
 
@@ -195,12 +202,7 @@ def update_args_with_global(
     # Parse global args and update the namespace
     temp_parser = get_parser()
     try:
-        parsed_globals, _ = temp_parser.parse_known_args(global_args)
-
-        # Update the namespace with new global values
-        for key, value in vars(parsed_globals).items():
-            if value is not None and key not in ["side_a", "side_b"]:
-                setattr(updated_args, key, value)
+        temp_parser.parse_known_args(global_args, namespace=updated_args)
 
     except SystemExit as e:
         # If parsing fails, keep original args
@@ -494,6 +496,7 @@ def _side_report(
     config_args: List[str],
     latency_entries: List[LatencyEntry],
     is_side_a: bool = True,
+    power_output_dir: Optional[str] = None,
 ) -> Dict[str, Any]:
     """JSON report of one side: its configuration and its per-cell metrics.
 
@@ -505,6 +508,9 @@ def _side_report(
     -- the descriptive statistics of those samples (mean, median, stddev, CV,
     IQR, confidence intervals). ``latency_entries`` are the shared analyses;
     ``is_side_a`` picks which half of each one to report.
+
+    ``power_output_dir`` is recorded on every cell when ``--power-chart`` ran,
+    so a repeat's measurements point at the power trace taken alongside them.
     """
     side_globals, side_ops = separate_global_and_op_args(config_args)
     # Both sides inherit the command line's args and the side's own override
@@ -526,6 +532,8 @@ def _side_report(
             side_stats = stats_by_cell.get((backend, x_val))
             if side_stats is not None:
                 cell.update(_json_safe(asdict(side_stats)))
+            if power_output_dir:
+                cell["power_output_dir"] = power_output_dir
             key = _metric_key(result.op_name, result.op_mode, backend, x_val)
             metrics[key] = cell
 
@@ -540,6 +548,7 @@ def _side_report(
 def report_single_side_results(
     result_a: BenchmarkOperatorResult,
     config_a_args: List[str],
+    power_dirs: Optional[Dict[str, str]] = None,
 ) -> Optional[Dict[str, Any]]:
     """Report a single configuration (only --side-a was specified).
 
@@ -575,7 +584,14 @@ def report_single_side_results(
         latency_entries = _collect_latency_analyses(result_dict_a, x_vals, backends)
         _log_latency_analysis(latency_entries, x_val_name, two_sided=False)
 
-    return {SIDE_A_KEY: _side_report(result_a, config_a_args, latency_entries)}
+    return {
+        SIDE_A_KEY: _side_report(
+            result_a,
+            config_a_args,
+            latency_entries,
+            power_output_dir=(power_dirs or {}).get("a"),
+        )
+    }
 
 
 def compare_ab_results(
@@ -583,6 +599,7 @@ def compare_ab_results(
     result_b: Optional[BenchmarkOperatorResult],
     config_a_args: List[str],
     config_b_args: Optional[List[str]] = None,
+    power_dirs: Optional[Dict[str, str]] = None,
 ) -> Optional[Dict[str, Any]]:
     """Compare A/B test results.
 
@@ -596,7 +613,7 @@ def compare_ab_results(
         return None
 
     if result_b is None:
-        return report_single_side_results(result_a, config_a_args)
+        return report_single_side_results(result_a, config_a_args, power_dirs)
 
     # Check if both results have data
     if not result_a.result or not result_b.result:
@@ -801,12 +818,21 @@ def compare_ab_results(
     if latency_comparison:
         comparison_report["latency_comparison"] = latency_comparison
 
+    power_dirs = power_dirs or {}
     return {
         SIDE_A_KEY: _side_report(
-            result_a, config_a_args, latency_entries, is_side_a=True
+            result_a,
+            config_a_args,
+            latency_entries,
+            is_side_a=True,
+            power_output_dir=power_dirs.get("a"),
         ),
         SIDE_B_KEY: _side_report(
-            result_b, config_b_args or [], latency_entries, is_side_a=False
+            result_b,
+            config_b_args or [],
+            latency_entries,
+            is_side_a=False,
+            power_output_dir=power_dirs.get("b"),
         ),
         AB_COMPARISON_KEY: comparison_report,
     }
@@ -915,12 +941,19 @@ def write_ab_json(output_json: str, report: Dict[str, Any]) -> None:
 
 
 def run_ab_test(
-    base_args: argparse.Namespace, base_extra_args: List[str], _run_func
+    base_args: argparse.Namespace,
+    base_extra_args: List[str],
+    _run_func,
+    output_dirs: Optional[Dict[str, str]] = None,
 ) -> Tuple[BenchmarkOperatorResult, Optional[BenchmarkOperatorResult]]:
     """Run the A/B test and return both results.
 
     Side B is optional: when ``--side-b`` is not specified only side A runs and
     the second result is None.
+
+    ``output_dirs`` optionally maps ``"a"``/``"b"`` to the ``--output-dir`` that
+    side should write to. The power chart names its files after the benchmark,
+    so without a directory of its own each side would overwrite the other's.
     """
 
     # Parse A and B configurations
@@ -967,6 +1000,8 @@ def run_ab_test(
 
     # Update args with global parameters
     args_a = update_args_with_global(base_args, global_a_args)
+    if output_dirs and output_dirs.get("a"):
+        args_a.output_dir = output_dirs["a"]
 
     # Combine extra_args with operator-specific args only
     extra_args_a = base_extra_args + op_a_args
@@ -991,6 +1026,8 @@ def run_ab_test(
         return result_a, None
 
     args_b = update_args_with_global(base_args, global_b_args)
+    if output_dirs and output_dirs.get("b"):
+        args_b.output_dir = output_dirs["b"]
     extra_args_b = base_extra_args + op_b_args
 
     lines = ["", "=" * 60, f"Running Side B: {' '.join(config_b_args)}"]

--- a/tritonbench/utils/run_utils.py
+++ b/tritonbench/utils/run_utils.py
@@ -488,6 +488,28 @@ def _add_mode_suffix(filepath: str, mode: str) -> str:
     return f"{base}_{mode}{ext}"
 
 
+def _ab_power_dirs(
+    power_root: Optional[str],
+    mode: Optional[str],
+    repeat: int,
+    has_side_b: bool,
+) -> Optional[Dict[str, str]]:
+    """One power-chart output directory per side of one A/B repeat.
+
+    Laid out as ``<root>/[<mode>/]side_<x>_repeat_<n>``. Returns None when
+    ``--power-chart`` was not requested, which leaves --output-dir alone.
+    """
+    if not power_root:
+        return None
+    parent = os.path.join(power_root, mode) if mode else power_root
+    dirs = {}
+    for side in ["a"] + (["b"] if has_side_b else []):
+        path = os.path.join(parent, f"side_{side}_repeat_{repeat}")
+        os.makedirs(path, exist_ok=True)
+        dirs[side] = path
+    return dirs
+
+
 def _run_in_task_single_mode(
     op: str,
     mode: str,
@@ -607,6 +629,16 @@ def tritonbench_run(args: Optional[List[str]] = None):
 
         ab_repeat = args.ab_repeat or 1
 
+        # The power chart names its files after the benchmark, not the run, so
+        # every side of every repeat needs an --output-dir of its own or they
+        # all overwrite one another and only the last survives.
+        power_root = None
+        if getattr(args, "power_chart", False):
+            power_root = args.output_dir or tempfile.mkdtemp(
+                prefix="tritonbench_power_"
+            )
+            logger.info(f"[tritonbench] Power chart output root: {power_root}")
+
         lockdown_enabled = args.gpu_lockdown or (args.gpu_lock_clock_mhz is not None)
         with gpu_lockdown(lockdown_enabled, args.gpu_lock_clock_mhz):
             for mode in modes:
@@ -636,11 +668,23 @@ def tritonbench_run(args: Optional[List[str]] = None):
                                 f"A/B repeat {repeat + 1}/{ab_repeat}\n"
                                 f"{'=' * 60}"
                             )
+                        power_dirs = _ab_power_dirs(
+                            power_root,
+                            mode if len(modes) > 1 else None,
+                            repeat + 1,
+                            args.side_b is not None,
+                        )
                         try:
-                            result_a, result_b = run_ab_test(args, extra_args, _run)
+                            result_a, result_b = run_ab_test(
+                                args, extra_args, _run, output_dirs=power_dirs
+                            )
                             reports.append(
                                 compare_ab_results(
-                                    result_a, result_b, config_a_args, config_b_args
+                                    result_a,
+                                    result_b,
+                                    config_a_args,
+                                    config_b_args,
+                                    power_dirs=power_dirs,
                                 )
                             )
                         except KeyboardInterrupt:

--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -1153,8 +1153,6 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
                 self.tb_args.output_dir,
             )
             power_manager_task.start()
-            if not self.tb_args.repcnt:
-                self.tb_args.repcnt = DEFAULT_POWER_REPCNT
         try:
             if "proton" in self.required_metrics:
                 import triton.profiler as proton


### PR DESCRIPTION
Support testing a config with power chart output and repeat `--ab-repeat <X>` times.

Test plan:

```
$ python run.py --op gemm --only tlx_matmul_ws --metrics latency,tflops  --output-dir /tmp/gemm_power_d7  --rep 3000 --sleep 1.0 --force --layout nt --shapes 1024x12800x1152 --power-chart   --side-a="" --ab-repeat 20   --output-json /tmp/gemm_power_d7/gemm_20.json
```