### PR TITLE
Add variable-length attention shapes to TritonBench

### DIFF
--- a/test/test_cpu/test_workload_shapes.py
+++ b/test/test_cpu/test_workload_shapes.py
@@ -1,0 +1,83 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+
+import unittest
+
+from tritonbench.utils.workload_shapes import (
+    DENSE_SWIGLU_SHAPES,
+    DENSE_SDPA_GROUPS,
+    DENSE_SDPA_SHAPES,
+    GEMM_SHAPES,
+    JAGGED_DENSE_BMM_SHAPES,
+    LINEAR_RESIDUAL_SHAPES,
+    MMA_GROUPS,
+    MOE_SWIGLU_SHAPES,
+    VARLEN_ATTENTION_GROUPS,
+    VARLEN_CROSS_ATTENTION_SHAPES,
+    VARLEN_SELF_ATTENTION_SHAPES,
+    expand_shape_names,
+    make_balanced_lengths,
+)
+
+
+class ExpandShapeNamesTest(unittest.TestCase):
+    def test_expands_dense_group(self) -> None:
+        self.assertEqual(
+            list(DENSE_SDPA_SHAPES),
+            expand_shape_names("dense_sdpa", DENSE_SDPA_SHAPES, DENSE_SDPA_GROUPS),
+        )
+
+    def test_expands_mixed_varlen_selection(self) -> None:
+        selected = expand_shape_names(
+            "varlen_cross,varlen_self_max",
+            {**VARLEN_CROSS_ATTENTION_SHAPES, **VARLEN_SELF_ATTENTION_SHAPES},
+            VARLEN_ATTENTION_GROUPS,
+        )
+        self.assertEqual(
+            [*VARLEN_CROSS_ATTENTION_SHAPES, "varlen_self_max"], selected
+        )
+
+    def test_rejects_unknown_shape(self) -> None:
+        with self.assertRaisesRegex(ValueError, "unknown --config"):
+            expand_shape_names("missing", DENSE_SDPA_SHAPES, DENSE_SDPA_GROUPS)
+
+    def test_non_attention_catalogs_cover_mma_shapes(self) -> None:
+        self.assertEqual(4, len(DENSE_SWIGLU_SHAPES))
+        self.assertEqual(4, len(MOE_SWIGLU_SHAPES))
+        self.assertEqual(8, len(LINEAR_RESIDUAL_SHAPES))
+        self.assertEqual(8, len(JAGGED_DENSE_BMM_SHAPES))
+        self.assertEqual(11, len(GEMM_SHAPES))
+        self.assertEqual(tuple(GEMM_SHAPES), MMA_GROUPS["gemm"])
+
+
+class MakeBalancedLengthsTest(unittest.TestCase):
+    def test_preserves_shape(self) -> None:
+        cases = [
+            ("cross", 80900, 768, 300),
+            ("self", 944906, 768, 3200),
+            ("single", 16, 1, 16),
+        ]
+        for name, total_tokens, batch, max_seqlen in cases:
+            with self.subTest(name=name):
+                lengths = make_balanced_lengths(total_tokens, batch, max_seqlen)
+
+                self.assertEqual(batch, len(lengths))
+                self.assertEqual(total_tokens, sum(lengths))
+                self.assertEqual(max_seqlen, max(lengths))
+                self.assertGreaterEqual(min(lengths), 1)
+
+    def test_rejects_invalid_shape(self) -> None:
+        cases = [
+            ("zero_batch", 10, 0, 10),
+            ("too_few_tokens", 3, 4, 4),
+            ("too_many_tokens", 17, 4, 4),
+            ("single_mismatch", 15, 1, 16),
+        ]
+        for name, total_tokens, batch, max_seqlen in cases:
+            with self.subTest(name=name), self.assertRaises(ValueError):
+                make_balanced_lengths(total_tokens, batch, max_seqlen)

--- a/tritonbench/operators/varlen_attention/__init__.py
+++ b/tritonbench/operators/varlen_attention/__init__.py
@@ -1,0 +1,2 @@
+from .operator import Operator
+

--- a/tritonbench/operators/varlen_attention/operator.py
+++ b/tritonbench/operators/varlen_attention/operator.py
@@ -1,0 +1,230 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+
+"""Variable-length attention benchmarks with synthetic inputs."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from typing import Any, Callable, Generator
+
+import torch
+from tritonbench.utils.triton_op import (
+    BenchmarkOperator,
+    BenchmarkOperatorMetrics,
+    Mode,
+    register_benchmark,
+    register_metric,
+    register_x_val,
+)
+from tritonbench.utils.workload_shapes import (
+    VARLEN_ATTENTION_GROUPS,
+    VARLEN_CROSS_ATTENTION_SHAPES,
+    VARLEN_SELF_ATTENTION_SHAPES,
+    VarlenAttentionShape,
+    expand_shape_names,
+    make_balanced_lengths,
+)
+
+try:
+    from flash_attn.flash_attn_interface import flash_attn_varlen_func
+
+    HAS_FLASH_ATTN = True
+except ImportError as error:
+    logging.getLogger(__name__).warning("flash_ck is unavailable: %s", error)
+    HAS_FLASH_ATTN = False
+
+
+SHAPES: dict[str, VarlenAttentionShape] = {
+    **VARLEN_CROSS_ATTENTION_SHAPES,
+    **VARLEN_SELF_ATTENTION_SHAPES,
+}
+
+
+def parse_op_args(args: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--config",
+        type=str,
+        default="varlen_cross",
+        help=(
+            "Comma-separated config or group names: "
+            f"{','.join((*VARLEN_ATTENTION_GROUPS, *SHAPES))}"
+        ),
+    )
+    return parser.parse_args(args)
+
+
+def _make_offsets(
+    total_tokens: int,
+    batch: int,
+    max_seqlen: int,
+    device: torch.device | str,
+) -> torch.Tensor:
+    lengths = make_balanced_lengths(total_tokens, batch, max_seqlen)
+    lengths_tensor = torch.tensor(lengths, dtype=torch.int32, device=device)
+    return torch.cat(
+        [torch.zeros(1, dtype=torch.int32, device=device), lengths_tensor.cumsum(0)]
+    )
+
+
+class Operator(BenchmarkOperator):
+    DEFAULT_PRECISION = "bf16"
+    DEFAULT_METRICS = ["latency", "tflops", "accuracy"]
+
+    def __init__(
+        self,
+        tb_args: argparse.Namespace,
+        extra_args: list[str] | None = None,
+    ) -> None:
+        super().__init__(tb_args, extra_args=extra_args)
+        args = parse_op_args(self.extra_args)
+        self.config_names = expand_shape_names(
+            args.config, SHAPES, VARLEN_ATTENTION_GROUPS
+        )
+
+    @register_benchmark(
+        enabled=HAS_FLASH_ATTN,
+        baseline=True,
+        label="FlashAttention varlen (CK on AMD)",
+    )
+    def flash_ck(
+        self,
+        _config_name: str,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        cu_seqlens_q: torch.Tensor,
+        cu_seqlens_k: torch.Tensor,
+        max_seqlen_q: int,
+        max_seqlen_k: int,
+        causal: bool,
+    ) -> Callable[[], torch.Tensor]:
+        def fn() -> torch.Tensor:
+            return flash_attn_varlen_func(
+                q,
+                k,
+                v,
+                cu_seqlens_q,
+                cu_seqlens_k,
+                max_seqlen_q,
+                max_seqlen_k,
+                dropout_p=0.0,
+                softmax_scale=q.shape[-1] ** -0.5,
+                causal=causal,
+            )
+
+        return fn
+
+    def get_input_iter(self) -> Generator:
+        requires_grad = self.mode != Mode.FWD_NO_GRAD
+        for name in self.config_names:
+            shape = SHAPES[name]
+            cu_seqlens_q = _make_offsets(
+                shape.total_q, shape.batch, shape.max_seqlen_q, self.device
+            )
+            cu_seqlens_k = _make_offsets(
+                shape.total_kv, shape.batch, shape.max_seqlen_kv, self.device
+            )
+
+            q = torch.randn(
+                shape.total_q,
+                shape.num_heads,
+                shape.head_dim,
+                device=self.device,
+                dtype=self.dtype,
+                requires_grad=requires_grad,
+            )
+            k = torch.randn(
+                shape.total_kv,
+                shape.num_heads,
+                shape.head_dim,
+                device=self.device,
+                dtype=self.dtype,
+                requires_grad=requires_grad,
+            )
+            if shape.causal:
+                v_storage = torch.randn(
+                    shape.total_kv,
+                    3,
+                    shape.num_heads,
+                    shape.head_dim,
+                    device=self.device,
+                    dtype=self.dtype,
+                )
+                v = v_storage[:, 0].detach().requires_grad_(requires_grad)
+            else:
+                v = torch.randn(
+                    shape.total_kv,
+                    shape.num_heads,
+                    shape.head_dim,
+                    device=self.device,
+                    dtype=self.dtype,
+                    requires_grad=requires_grad,
+                )
+            yield (
+                name,
+                q,
+                k,
+                v,
+                cu_seqlens_q,
+                cu_seqlens_k,
+                shape.max_seqlen_q,
+                shape.max_seqlen_kv,
+                shape.causal,
+            )
+
+    @register_x_val(
+        label="(name, total_q, total_kv, B, H, D, max_q, max_kv, causal)"
+    )
+    def get_x_val(self, example_inputs: tuple[Any, ...]) -> tuple[Any, ...]:
+        name, q, k, _v, cu_q, _cu_k, max_q, max_kv, causal = example_inputs
+        return (
+            name,
+            q.shape[0],
+            k.shape[0],
+            cu_q.numel() - 1,
+            q.shape[1],
+            q.shape[2],
+            max_q,
+            max_kv,
+            causal,
+        )
+
+    @register_metric(x_only=True)
+    def flops(
+        self,
+        fn_name: str,
+        example_inputs: tuple[Any, ...],
+        metrics: BenchmarkOperatorMetrics,
+    ) -> float:
+        del fn_name, metrics
+        name = example_inputs[0]
+        shape = SHAPES[name]
+        q_lengths = make_balanced_lengths(
+            shape.total_q, shape.batch, shape.max_seqlen_q
+        )
+        kv_lengths = make_balanced_lengths(
+            shape.total_kv, shape.batch, shape.max_seqlen_kv
+        )
+        if shape.causal:
+            attention_pairs = sum(length * (length + 1) // 2 for length in q_lengths)
+        else:
+            attention_pairs = sum(
+                q_len * kv_len for q_len, kv_len in zip(q_lengths, kv_lengths)
+            )
+        flops = 4.0 * shape.num_heads * shape.head_dim * attention_pairs
+        if self.mode == Mode.BWD:
+            flops *= 2.5
+        elif self.mode == Mode.FWD_BWD:
+            flops *= 3.5
+        return flops
+
+    def get_grad_to_none(self, args: tuple[Any, ...]) -> list[torch.Tensor]:
+        return [args[1], args[2], args[3]]

--- a/tritonbench/utils/workload_shapes.py
+++ b/tritonbench/utils/workload_shapes.py
@@ -1,0 +1,234 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class DenseAttentionShape:
+    batch: int
+    seqlen_q: int
+    seqlen_kv: int
+    num_heads: int
+    head_dim: int
+    causal: bool
+
+
+@dataclass(frozen=True)
+class VarlenAttentionShape:
+    total_q: int
+    total_kv: int
+    batch: int
+    num_heads: int
+    head_dim: int
+    max_seqlen_q: int
+    max_seqlen_kv: int
+    causal: bool
+
+
+@dataclass(frozen=True)
+class SwiGLUShape:
+    tokens: int
+    input_dim: int
+    hidden_dim: int
+    experts: int | None = None
+
+
+@dataclass(frozen=True)
+class LinearResidualShape:
+    tokens: int
+    input_dim: int
+    output_dim: int
+
+
+@dataclass(frozen=True)
+class JaggedDenseBmmShape:
+    total_tokens: int
+    batch: int
+    max_seqlen: int
+    n: int
+    k: int
+
+
+@dataclass(frozen=True)
+class GemmShape:
+    op: str
+    m: int
+    n: int
+    k: int
+    layout_a: str
+    layout_b: str
+
+
+DENSE_SDPA_SHAPES: dict[str, DenseAttentionShape] = {
+    "dense_sdpa_min": DenseAttentionShape(3139, 10, 10, 8, 128, False),
+    "dense_sdpa_p50": DenseAttentionShape(4045, 10, 10, 8, 128, False),
+    "dense_sdpa_p90": DenseAttentionShape(4433, 10, 10, 8, 128, False),
+    "dense_sdpa_max": DenseAttentionShape(5095, 10, 10, 8, 128, False),
+}
+
+
+VARLEN_CROSS_ATTENTION_SHAPES: dict[str, VarlenAttentionShape] = {
+    "varlen_cross_min": VarlenAttentionShape(
+        62780, 946279, 768, 4, 128, 300, 3200, False
+    ),
+    "varlen_cross_p50": VarlenAttentionShape(
+        80900, 940737, 768, 4, 128, 300, 3200, False
+    ),
+    "varlen_cross_p90": VarlenAttentionShape(
+        88660, 944840, 768, 4, 128, 300, 3200, False
+    ),
+    "varlen_cross_max": VarlenAttentionShape(
+        101900, 946104, 768, 4, 128, 300, 3200, False
+    ),
+    "varlen_cross_max_q": VarlenAttentionShape(
+        84880, 945242, 768, 4, 128, 400, 3200, False
+    ),
+}
+
+
+VARLEN_SELF_ATTENTION_SHAPES: dict[str, VarlenAttentionShape] = {
+    "varlen_self_min": VarlenAttentionShape(
+        925210, 925210, 768, 4, 128, 3200, 3200, True
+    ),
+    "varlen_self_p50": VarlenAttentionShape(
+        944906, 944906, 768, 4, 128, 3200, 3200, True
+    ),
+    "varlen_self_p90": VarlenAttentionShape(
+        946581, 946581, 768, 4, 128, 3200, 3200, True
+    ),
+    "varlen_self_max": VarlenAttentionShape(
+        948456, 948456, 768, 4, 128, 3200, 3200, True
+    ),
+}
+
+
+DENSE_SWIGLU_SHAPES: dict[str, SwiGLUShape] = {
+    "dense_swiglu_min": SwiGLUShape(925210, 512, 2048),
+    "dense_swiglu_p50": SwiGLUShape(944906, 512, 2048),
+    "dense_swiglu_p90": SwiGLUShape(946581, 512, 2048),
+    "dense_swiglu_max": SwiGLUShape(948456, 512, 2048),
+}
+
+MOE_SWIGLU_SHAPES: dict[str, SwiGLUShape] = {
+    "moe_swiglu_min": SwiGLUShape(29011, 1024, 2736, 40),
+    "moe_swiglu_p50": SwiGLUShape(30296, 1024, 2736, 40),
+    "moe_swiglu_p90": SwiGLUShape(30767, 1024, 2736, 40),
+    "moe_swiglu_max": SwiGLUShape(31144, 1024, 2736, 40),
+}
+
+LINEAR_RESIDUAL_SHAPES: dict[str, LinearResidualShape] = {
+    f"linear_{input_dim}x512_{percentile}": LinearResidualShape(
+        tokens, input_dim, 512
+    )
+    for input_dim in (512, 2048)
+    for percentile, tokens in (
+        ("min", 925210),
+        ("p50", 944906),
+        ("p90", 946581),
+        ("max", 948456),
+    )
+}
+
+JAGGED_DENSE_BMM_SHAPES: dict[str, JaggedDenseBmmShape] = {
+    f"jagged_bmm_n{n}_{percentile}": JaggedDenseBmmShape(
+        total_tokens, 768, max_seqlen, n, 512
+    )
+    for n in (224, 1664)
+    for percentile, total_tokens, max_seqlen in (
+        ("min", 830389, 3087),
+        ("p50", 850554, 3082),
+        ("p90", 852404, 3087),
+        ("max", 854091, 3086),
+    )
+}
+
+GEMM_SHAPES: dict[str, GemmShape] = {
+    "gemm_addmm_768x851968x256": GemmShape(
+        "addmm", 768, 851968, 256, "row", "column"
+    ),
+    "gemm_768x256x851968": GemmShape("mm", 768, 256, 851968, "row", "row"),
+    "gemm_851968x256x768": GemmShape("mm", 851968, 256, 768, "column", "row"),
+    "gemm_512x256x98304": GemmShape("mm", 512, 256, 98304, "column", "row"),
+    "gemm_98304x256x512": GemmShape("mm", 98304, 256, 512, "row", "row"),
+    "gemm_768x256x114688": GemmShape("mm", 768, 256, 114688, "row", "row"),
+    "gemm_addmm_768x114688x256": GemmShape(
+        "addmm", 768, 114688, 256, "row", "column"
+    ),
+    "gemm_114688x256x768": GemmShape("mm", 114688, 256, 768, "column", "row"),
+    "gemm_addmm_98304x512x256": GemmShape(
+        "addmm", 98304, 512, 256, "row", "column"
+    ),
+    "gemm_43500x1024x1024": GemmShape("mm", 43500, 1024, 1024, "row", "row"),
+    "gemm_1024x1024x43500": GemmShape("mm", 1024, 1024, 43500, "column", "row"),
+}
+
+
+DENSE_SDPA_GROUPS: dict[str, tuple[str, ...]] = {
+    "dense_sdpa": tuple(DENSE_SDPA_SHAPES),
+}
+
+VARLEN_ATTENTION_GROUPS: dict[str, tuple[str, ...]] = {
+    "varlen_cross": tuple(VARLEN_CROSS_ATTENTION_SHAPES),
+    "varlen_self": tuple(VARLEN_SELF_ATTENTION_SHAPES),
+    "varlen_all": (
+        *VARLEN_CROSS_ATTENTION_SHAPES,
+        *VARLEN_SELF_ATTENTION_SHAPES,
+    ),
+}
+
+MMA_GROUPS: dict[str, tuple[str, ...]] = {
+    "dense_swiglu": tuple(DENSE_SWIGLU_SHAPES),
+    "moe_swiglu": tuple(MOE_SWIGLU_SHAPES),
+    "linear_residual": tuple(LINEAR_RESIDUAL_SHAPES),
+    "jagged_bmm": tuple(JAGGED_DENSE_BMM_SHAPES),
+    "gemm": tuple(GEMM_SHAPES),
+}
+
+
+def expand_shape_names(
+    value: str,
+    shapes: dict[str, object],
+    groups: dict[str, tuple[str, ...]],
+) -> list[str]:
+    names: list[str] = []
+    for item in value.split(","):
+        name = item.strip()
+        if name in groups:
+            names.extend(groups[name])
+        elif name in shapes:
+            names.append(name)
+        else:
+            known = ",".join((*groups, *shapes))
+            raise ValueError(f"unknown --config {name!r}; known: {known}")
+    return names
+
+
+def make_balanced_lengths(
+    total_tokens: int,
+    batch: int,
+    max_seqlen: int,
+) -> list[int]:
+    if batch <= 0 or max_seqlen <= 0:
+        raise ValueError("batch and max_seqlen must be positive")
+    if total_tokens < batch or total_tokens > batch * max_seqlen:
+        raise ValueError(
+            f"total_tokens={total_tokens} is outside [{batch}, {batch * max_seqlen}]"
+        )
+    if batch == 1:
+        if total_tokens != max_seqlen:
+            raise ValueError("a single sequence must have total_tokens == max_seqlen")
+        return [max_seqlen]
+
+    remaining = total_tokens - max_seqlen
+    base, extra = divmod(remaining, batch - 1)
+    if base < 1 or base + (1 if extra else 0) > max_seqlen:
+        raise ValueError("cannot preserve both total_tokens and max_seqlen")
+    return [max_seqlen, *([base + 1] * extra), *([base] * (batch - 1 - extra))]


### PR DESCRIPTION
Summary:
Adds a reusable shape catalog for dense and variable-length attention, SwiGLU, linear-residual, jagged BMM, and GEMM workloads using generic configuration names.

Adds an OSS-discoverable `varlen_attention` operator for benchmarking the FlashAttention CK backend. Inputs default to BF16 and Q/K/V are generated with `torch.randn` directly on the target GPU; no captured input tensors are stored or loaded.

For each variable-length shape, the generator assigns one sequence the configured maximum length, distributes the remaining tokens as evenly as possible across the other sequences, and constructs `int32` offsets with a cumulative sum. This preserves the requested total-token, batch-size, and maximum-sequence-length dimensions while keeping all tensor contents synthetic.

Differential Revision: D117394044


