### PR TITLE
[do_bench] Cap CUDAGraph benchmark repetitions

### DIFF
--- a/test/test_cpu/test_do_bench.py
+++ b/test/test_cpu/test_do_bench.py
@@ -1,0 +1,23 @@
+import unittest
+
+from tritonbench.components.do_bench.run import (
+    MAX_CUDAGRAPH_REPEAT,
+    _get_cudagraph_n_repeat,
+)
+
+
+class CudaGraphRepeatTest(unittest.TestCase):
+    def test_caps_repeat_count(self):
+        self.assertEqual(
+            _get_cudagraph_n_repeat(rep=100, estimate_ms=0.01),
+            MAX_CUDAGRAPH_REPEAT,
+        )
+
+    def test_preserves_repeat_count_below_cap(self):
+        self.assertEqual(_get_cudagraph_n_repeat(rep=100, estimate_ms=0.2), 500)
+
+    def test_handles_zero_estimate(self):
+        self.assertEqual(
+            _get_cudagraph_n_repeat(rep=100, estimate_ms=0),
+            MAX_CUDAGRAPH_REPEAT,
+        )

--- a/tritonbench/components/do_bench/run.py
+++ b/tritonbench/components/do_bench/run.py
@@ -26,6 +26,8 @@ except ImportError:
     triton = None
 
 NS_TO_MS = 1e-6
+# Keep HIP/CUDA graph capture from expanding to tens of thousands of nodes.
+MAX_CUDAGRAPH_REPEAT = 1000
 logger = logging.getLogger(__name__)
 # Kernel name for L2 cache clearing - we want to exclude this from latency measurements
 # On NVIDIA: FillFunctor<int>, on AMD/ROCm: FillFunctor<float> with [clone .kd] suffix
@@ -40,6 +42,12 @@ def _is_cache_clear_kernel(name: str) -> bool:
     with [clone .kd] suffix) variants.
     """
     return "vectorized_elementwise_kernel" in name and "FillFunctor" in name
+
+
+def _get_cudagraph_n_repeat(rep: int, estimate_ms: float) -> int:
+    if estimate_ms <= 0:
+        return MAX_CUDAGRAPH_REPEAT
+    return min(MAX_CUDAGRAPH_REPEAT, max(1, int(rep / estimate_ms)))
 
 
 class Latency:
@@ -233,7 +241,7 @@ def _do_bench_cudagraph_with_cache_clear(
         estimate_ms = start_event.elapsed_time(end_event) / 5
         _, rep = resolve_warmup_and_rep(None, rep, estimate_ms)
 
-        n_repeat = 1000 if estimate_ms == 0 else max(1, int(rep / estimate_ms))
+        n_repeat = _get_cudagraph_n_repeat(rep, estimate_ms)
 
         g = torch.cuda.CUDAGraph()
         with torch.cuda.graph(g):


### PR DESCRIPTION
## Summary

- cap the number of iterations captured by `_do_bench_cudagraph_with_cache_clear` at 1,000
- preserve the adaptive repeat count when it is below the cap
- add CPU unit coverage for capped, uncapped, and zero-duration estimates

## Motivation

The current adaptive timing logic still computes `n_repeat = rep / estimate_ms` without an upper bound. Fast kernels can therefore expand into graphs with tens of thousands of kernel and cache-clear nodes. On MI350X, HIP graph capture can terminate the benchmark process with SIGSEGV while constructing these oversized graphs.

PR #1040 reduced the default measurement window for fast kernels, but it did not provide a hard graph-size bound. The outer 10 replay attempts continue to provide multiple latency samples after this cap is applied.

This resurfaced in Helion's MI350X nightly benchmark run: https://github.com/pytorch/helion/actions/runs/32825465848

## Testing

- `python3 -m py_compile tritonbench/components/do_bench/run.py test/test_cpu/test_do_bench.py`
- `git diff --check`
- Runtime unit test not executed locally because the host environment does not have PyTorch installed; CI should run `test.test_cpu.test_do_bench`.
