### PR TITLE
[TLX][AMD] Benchmark optimized Flash Attention forward

### DIFF
--- a/test/test_cpu/test_flash_attention_tlx.py
+++ b/test/test_cpu/test_flash_attention_tlx.py
@@ -1,4 +1,3 @@
-import pytest
 import torch
 from torch._subclasses.fake_tensor import FakeTensorMode
 from tritonbench.operators.flash_attention import operator as flash_attention
@@ -13,140 +12,54 @@ def _make_operator():
     return op
 
 
-def _make_fake_cuda_inputs(shape=(1, 1, 64, 64), devices=None):
-    devices = devices or ("cuda:0",) * 3
-    with FakeTensorMode():
-        return tuple(
-            torch.empty(shape, device=device, dtype=torch.bfloat16)
-            for device in devices
+def _make_fake_cuda_inputs():
+    return tuple(
+        torch.empty(
+            (1, 1, 64, 64),
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
         )
+        for _ in range(3)
+    )
 
 
-def test_tlx_amd_fa_cluster_uses_landed_forward_entrypoint(monkeypatch):
+def test_tlx_amd_fa_cluster_is_registered_forward_only():
     backend = REGISTERED_BENCHMARKS["flash_attention"]["tlx_amd_fa_cluster"]
+
     assert backend.fwd_only
 
-    q = torch.randn(1, 1, 64, 64, dtype=torch.bfloat16, requires_grad=True)
-    k = torch.randn_like(q)
-    v = torch.randn_like(q)
-    expected = torch.empty_like(q)
-    calls = []
+
+def test_tlx_amd_fa_cluster_validates_before_landed_entrypoint(monkeypatch):
+    events = []
+
+    def validate(actual_q, actual_k, actual_v):
+        events.append(("validate", actual_q, actual_k, actual_v))
 
     def cluster_attention(actual_q, actual_k, actual_v, sm_scale, causal):
-        calls.append((actual_q, actual_k, actual_v, sm_scale, causal))
+        events.append(("attention", actual_q, actual_k, actual_v, sm_scale, causal))
         return expected
 
     monkeypatch.setattr(
         flash_attention,
-        "_tlx_amd_fa_cluster",
-        cluster_attention,
-        raising=False,
+        "_validate_tlx_amd_fa_cluster_inputs",
+        validate,
     )
     monkeypatch.setattr(
         flash_attention,
-        "_validate_tlx_amd_fa_cluster_inputs",
-        lambda *args: None,
+        "_tlx_amd_fa_cluster",
+        cluster_attention,
     )
-    op = _make_operator()
 
-    benchmark_fn = op.tlx_amd_fa_cluster(q, k, v)
-
-    outputs = benchmark_fn()
+    with FakeTensorMode():
+        q, k, v = _make_fake_cuda_inputs()
+        expected = torch.empty_like(q)
+        benchmark_fn = _make_operator().tlx_amd_fa_cluster(q, k, v)
+        outputs = benchmark_fn()
 
     assert len(outputs) == 1
     assert outputs[0] is expected
-    assert calls == [(q, k, v, 0.125, True)]
-
-
-@pytest.mark.parametrize(
-    ("q", "k", "v", "message"),
-    [
-        (
-            torch.randn(1, 1, 64, 64, dtype=torch.bfloat16),
-            torch.randn(1, 1, 128, 64, dtype=torch.bfloat16),
-            torch.randn(1, 1, 128, 64, dtype=torch.bfloat16),
-            "same shape",
-        ),
-        (
-            torch.randn(1, 1, 64, 64, dtype=torch.float32),
-            torch.randn(1, 1, 64, 64, dtype=torch.float32),
-            torch.randn(1, 1, 64, 64, dtype=torch.float32),
-            "float16 or bfloat16",
-        ),
-        (
-            torch.randn(1, 1, 64, 64, dtype=torch.bfloat16),
-            torch.randn(1, 1, 64, 64, dtype=torch.float16),
-            torch.randn(1, 1, 64, 64, dtype=torch.float16),
-            "matching dtypes",
-        ),
-        (
-            torch.randn(1, 64, 64, dtype=torch.bfloat16),
-            torch.randn(1, 64, 64, dtype=torch.bfloat16),
-            torch.randn(1, 64, 64, dtype=torch.bfloat16),
-            "rank-4",
-        ),
-    ],
-)
-def test_tlx_amd_fa_cluster_rejects_inputs_outside_landed_contract(
-    monkeypatch, q, k, v, message
-):
-    def unexpected_launch(*args):
-        pytest.fail("cluster attention launched for an unsupported input")
-
-    monkeypatch.setattr(
-        flash_attention,
-        "_tlx_amd_fa_cluster",
-        unexpected_launch,
-    )
-    with pytest.raises(ValueError, match=message):
-        _make_operator().tlx_amd_fa_cluster(q, k, v)
-
-
-def test_tlx_amd_fa_cluster_rejects_unsupported_head_dimension():
-    q, k, v = _make_fake_cuda_inputs(shape=(1, 1, 64, 32))
-
-    with pytest.raises(ValueError, match="head dimension 64 or 128"):
-        flash_attention._validate_tlx_amd_fa_cluster_inputs(q, k, v)
-
-
-def test_tlx_amd_fa_cluster_rejects_cpu_inputs():
-    q = torch.randn(1, 1, 64, 64, dtype=torch.bfloat16)
-    k = torch.randn_like(q)
-    v = torch.randn_like(q)
-
-    with pytest.raises(ValueError, match="same GPU"):
-        flash_attention._validate_tlx_amd_fa_cluster_inputs(q, k, v)
-
-
-def test_tlx_amd_fa_cluster_rejects_inputs_on_different_cuda_devices():
-    q, k, v = _make_fake_cuda_inputs(devices=("cuda:0", "cuda:1", "cuda:0"))
-
-    with pytest.raises(ValueError, match="same GPU"):
-        flash_attention._validate_tlx_amd_fa_cluster_inputs(q, k, v)
-
-
-def test_tlx_amd_fa_cluster_rejects_nonpositive_dimensions():
-    q, k, v = _make_fake_cuda_inputs(shape=(1, 1, 0, 64))
-
-    with pytest.raises(ValueError, match="dimensions must be positive"):
-        flash_attention._validate_tlx_amd_fa_cluster_inputs(q, k, v)
-
-
-def test_tlx_amd_fa_cluster_rejects_zero_sequence_stride():
-    q, k, _ = _make_fake_cuda_inputs()
-    with FakeTensorMode():
-        v = torch.empty((1, 1, 1, 64), device="cuda", dtype=torch.bfloat16).expand(
-            1, 1, 64, 64
-        )
-
-    with pytest.raises(ValueError, match="positive sequence strides"):
-        flash_attention._validate_tlx_amd_fa_cluster_inputs(q, k, v)
-
-
-def test_tlx_amd_fa_cluster_rejects_negative_feature_stride():
-    q, k, v = _make_fake_cuda_inputs()
-    original_strides = k.stride()
-    k.stride = lambda dim: -1 if dim == 3 else original_strides[dim]
-
-    with pytest.raises(ValueError, match="nonnegative K feature"):
-        flash_attention._validate_tlx_amd_fa_cluster_inputs(q, k, v)
+    assert [event[0] for event in events] == ["validate", "attention"]
+    assert all(actual is wanted for actual, wanted in zip(events[0][1:], (q, k, v)))
+    assert all(actual is wanted for actual, wanted in zip(events[1][1:4], (q, k, v)))
+    assert events[1][4:] == (0.125, True)

--- a/test/test_cpu/test_flash_attention_tlx.py
+++ b/test/test_cpu/test_flash_attention_tlx.py
@@ -1,0 +1,152 @@
+import pytest
+import torch
+from torch._subclasses.fake_tensor import FakeTensorMode
+from tritonbench.operators.flash_attention import operator as flash_attention
+from tritonbench.utils.triton_op import REGISTERED_BENCHMARKS
+
+
+def _make_operator():
+    op = flash_attention.Operator.__new__(flash_attention.Operator)
+    op.sm_scale = 0.125
+    op.causal = True
+    op.optims = {}
+    return op
+
+
+def _make_fake_cuda_inputs(shape=(1, 1, 64, 64), devices=None):
+    devices = devices or ("cuda:0",) * 3
+    with FakeTensorMode():
+        return tuple(
+            torch.empty(shape, device=device, dtype=torch.bfloat16)
+            for device in devices
+        )
+
+
+def test_tlx_amd_fa_cluster_uses_landed_forward_entrypoint(monkeypatch):
+    backend = REGISTERED_BENCHMARKS["flash_attention"]["tlx_amd_fa_cluster"]
+    assert backend.fwd_only
+
+    q = torch.randn(1, 1, 64, 64, dtype=torch.bfloat16, requires_grad=True)
+    k = torch.randn_like(q)
+    v = torch.randn_like(q)
+    expected = torch.empty_like(q)
+    calls = []
+
+    def cluster_attention(actual_q, actual_k, actual_v, sm_scale, causal):
+        calls.append((actual_q, actual_k, actual_v, sm_scale, causal))
+        return expected
+
+    monkeypatch.setattr(
+        flash_attention,
+        "_tlx_amd_fa_cluster",
+        cluster_attention,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        flash_attention,
+        "_validate_tlx_amd_fa_cluster_inputs",
+        lambda *args: None,
+    )
+    op = _make_operator()
+
+    benchmark_fn = op.tlx_amd_fa_cluster(q, k, v)
+
+    outputs = benchmark_fn()
+
+    assert len(outputs) == 1
+    assert outputs[0] is expected
+    assert calls == [(q, k, v, 0.125, True)]
+
+
+@pytest.mark.parametrize(
+    ("q", "k", "v", "message"),
+    [
+        (
+            torch.randn(1, 1, 64, 64, dtype=torch.bfloat16),
+            torch.randn(1, 1, 128, 64, dtype=torch.bfloat16),
+            torch.randn(1, 1, 128, 64, dtype=torch.bfloat16),
+            "same shape",
+        ),
+        (
+            torch.randn(1, 1, 64, 64, dtype=torch.float32),
+            torch.randn(1, 1, 64, 64, dtype=torch.float32),
+            torch.randn(1, 1, 64, 64, dtype=torch.float32),
+            "float16 or bfloat16",
+        ),
+        (
+            torch.randn(1, 1, 64, 64, dtype=torch.bfloat16),
+            torch.randn(1, 1, 64, 64, dtype=torch.float16),
+            torch.randn(1, 1, 64, 64, dtype=torch.float16),
+            "matching dtypes",
+        ),
+        (
+            torch.randn(1, 64, 64, dtype=torch.bfloat16),
+            torch.randn(1, 64, 64, dtype=torch.bfloat16),
+            torch.randn(1, 64, 64, dtype=torch.bfloat16),
+            "rank-4",
+        ),
+    ],
+)
+def test_tlx_amd_fa_cluster_rejects_inputs_outside_landed_contract(
+    monkeypatch, q, k, v, message
+):
+    def unexpected_launch(*args):
+        pytest.fail("cluster attention launched for an unsupported input")
+
+    monkeypatch.setattr(
+        flash_attention,
+        "_tlx_amd_fa_cluster",
+        unexpected_launch,
+    )
+    with pytest.raises(ValueError, match=message):
+        _make_operator().tlx_amd_fa_cluster(q, k, v)
+
+
+def test_tlx_amd_fa_cluster_rejects_unsupported_head_dimension():
+    q, k, v = _make_fake_cuda_inputs(shape=(1, 1, 64, 32))
+
+    with pytest.raises(ValueError, match="head dimension 64 or 128"):
+        flash_attention._validate_tlx_amd_fa_cluster_inputs(q, k, v)
+
+
+def test_tlx_amd_fa_cluster_rejects_cpu_inputs():
+    q = torch.randn(1, 1, 64, 64, dtype=torch.bfloat16)
+    k = torch.randn_like(q)
+    v = torch.randn_like(q)
+
+    with pytest.raises(ValueError, match="same GPU"):
+        flash_attention._validate_tlx_amd_fa_cluster_inputs(q, k, v)
+
+
+def test_tlx_amd_fa_cluster_rejects_inputs_on_different_cuda_devices():
+    q, k, v = _make_fake_cuda_inputs(devices=("cuda:0", "cuda:1", "cuda:0"))
+
+    with pytest.raises(ValueError, match="same GPU"):
+        flash_attention._validate_tlx_amd_fa_cluster_inputs(q, k, v)
+
+
+def test_tlx_amd_fa_cluster_rejects_nonpositive_dimensions():
+    q, k, v = _make_fake_cuda_inputs(shape=(1, 1, 0, 64))
+
+    with pytest.raises(ValueError, match="dimensions must be positive"):
+        flash_attention._validate_tlx_amd_fa_cluster_inputs(q, k, v)
+
+
+def test_tlx_amd_fa_cluster_rejects_zero_sequence_stride():
+    q, k, _ = _make_fake_cuda_inputs()
+    with FakeTensorMode():
+        v = torch.empty((1, 1, 1, 64), device="cuda", dtype=torch.bfloat16).expand(
+            1, 1, 64, 64
+        )
+
+    with pytest.raises(ValueError, match="positive sequence strides"):
+        flash_attention._validate_tlx_amd_fa_cluster_inputs(q, k, v)
+
+
+def test_tlx_amd_fa_cluster_rejects_negative_feature_stride():
+    q, k, v = _make_fake_cuda_inputs()
+    original_strides = k.stride()
+    k.stride = lambda dim: -1 if dim == 3 else original_strides[dim]
+
+    with pytest.raises(ValueError, match="nonnegative K feature"):
+        flash_attention._validate_tlx_amd_fa_cluster_inputs(q, k, v)

--- a/tritonbench/operators/flash_attention/operator.py
+++ b/tritonbench/operators/flash_attention/operator.py
@@ -126,12 +126,20 @@ from tritonbench.utils.triton_utils import has_new_tma, has_tlx, has_warp_spec
 
 if has_tlx():
     try:
+        from triton.language.extra.tlx.tutorials.amd_fa_cluster import (
+            attention as _tlx_amd_fa_cluster,
+        )
+    except (ImportError, ModuleNotFoundError):
+        _tlx_amd_fa_cluster = None
+
+    try:
         from triton.language.extra.tlx.tutorials.amd_fa_pipelined import (
             attention as _tlx_amd_fa_pipelined,
         )
     except (ImportError, ModuleNotFoundError):
         _tlx_amd_fa_pipelined = None
 else:
+    _tlx_amd_fa_cluster = None
     _tlx_amd_fa_pipelined = None
 
 if has_tlx() and is_hip_mi350():
@@ -281,6 +289,44 @@ def preproc_noop(*args):
     return args
 
 
+def _validate_tlx_amd_fa_cluster_inputs(q, k, v):
+    if q.ndim != 4 or k.ndim != 4 or v.ndim != 4:
+        raise ValueError(
+            "AMD TLX Flash Attention cluster requires rank-4 Q, K, and V tensors"
+        )
+    if q.shape != k.shape or q.shape != v.shape:
+        raise ValueError(
+            "AMD TLX Flash Attention cluster requires Q, K, and V to have the same shape"
+        )
+    if q.dtype != k.dtype or q.dtype != v.dtype:
+        raise ValueError(
+            "AMD TLX Flash Attention cluster requires Q, K, and V to have matching dtypes"
+        )
+    if any(tensor.dtype not in (torch.float16, torch.bfloat16) for tensor in (q, k, v)):
+        raise ValueError(
+            "AMD TLX Flash Attention cluster requires float16 or bfloat16 inputs"
+        )
+    if q.device != k.device or q.device != v.device or not q.is_cuda:
+        raise ValueError(
+            "AMD TLX Flash Attention cluster requires Q, K, and V on the same GPU"
+        )
+    if any(size <= 0 for size in q.shape):
+        raise ValueError(
+            "AMD TLX Flash Attention cluster dimensions must be positive, "
+            f"got {tuple(q.shape)}"
+        )
+    if q.shape[-1] not in (64, 128):
+        raise ValueError(
+            "AMD TLX Flash Attention cluster requires head dimension 64 or 128"
+        )
+    for name, tensor in (("Q", q), ("K", k), ("V", v)):
+        if tensor.stride(2) <= 0 or tensor.stride(3) < 0:
+            raise ValueError(
+                "AMD TLX Flash Attention cluster requires nonnegative "
+                f"{name} feature and positive sequence strides"
+            )
+
+
 class Operator(BenchmarkOperator):
     DEFAULT_PRECISION = "bf16"
 
@@ -423,6 +469,31 @@ class Operator(BenchmarkOperator):
             )
 
         return preproc_noop, fn
+
+    @register_benchmark(
+        enabled=is_hip_mi350() and _tlx_amd_fa_cluster is not None,
+        fwd_only=True,
+        tags=["tlx", "amd", "gfx950"],
+    )
+    @multi_input_wrapper
+    def tlx_amd_fa_cluster(self, *args) -> Tuple[Callable, Callable]:
+        tlx_attention = _tlx_amd_fa_cluster
+        assert tlx_attention is not None
+
+        def preproc(q, k, v):
+            _validate_tlx_amd_fa_cluster_inputs(q, k, v)
+            return q, k, v
+
+        def fn(q, k, v):
+            return tlx_attention(
+                q,
+                k,
+                v,
+                self.sm_scale,
+                self.causal,
+            )
+
+        return preproc, fn
 
     @register_benchmark(enabled=HAS_CUDA_124 and has_new_tma())
     @multi_input_wrapper

--- a/tritonbench/operators/flash_attention/operator.py
+++ b/tritonbench/operators/flash_attention/operator.py
@@ -127,10 +127,12 @@ from tritonbench.utils.triton_utils import has_new_tma, has_tlx, has_warp_spec
 if has_tlx():
     try:
         from triton.language.extra.tlx.tutorials.amd_fa_cluster import (
+            _validate_cluster_inputs as _validate_tlx_amd_fa_cluster_inputs,
             attention as _tlx_amd_fa_cluster,
         )
     except (ImportError, ModuleNotFoundError):
         _tlx_amd_fa_cluster = None
+        _validate_tlx_amd_fa_cluster_inputs = None
 
     try:
         from triton.language.extra.tlx.tutorials.amd_fa_pipelined import (
@@ -140,6 +142,7 @@ if has_tlx():
         _tlx_amd_fa_pipelined = None
 else:
     _tlx_amd_fa_cluster = None
+    _validate_tlx_amd_fa_cluster_inputs = None
     _tlx_amd_fa_pipelined = None
 
 if has_tlx() and is_hip_mi350():
@@ -289,44 +292,6 @@ def preproc_noop(*args):
     return args
 
 
-def _validate_tlx_amd_fa_cluster_inputs(q, k, v):
-    if q.ndim != 4 or k.ndim != 4 or v.ndim != 4:
-        raise ValueError(
-            "AMD TLX Flash Attention cluster requires rank-4 Q, K, and V tensors"
-        )
-    if q.shape != k.shape or q.shape != v.shape:
-        raise ValueError(
-            "AMD TLX Flash Attention cluster requires Q, K, and V to have the same shape"
-        )
-    if q.dtype != k.dtype or q.dtype != v.dtype:
-        raise ValueError(
-            "AMD TLX Flash Attention cluster requires Q, K, and V to have matching dtypes"
-        )
-    if any(tensor.dtype not in (torch.float16, torch.bfloat16) for tensor in (q, k, v)):
-        raise ValueError(
-            "AMD TLX Flash Attention cluster requires float16 or bfloat16 inputs"
-        )
-    if q.device != k.device or q.device != v.device or not q.is_cuda:
-        raise ValueError(
-            "AMD TLX Flash Attention cluster requires Q, K, and V on the same GPU"
-        )
-    if any(size <= 0 for size in q.shape):
-        raise ValueError(
-            "AMD TLX Flash Attention cluster dimensions must be positive, "
-            f"got {tuple(q.shape)}"
-        )
-    if q.shape[-1] not in (64, 128):
-        raise ValueError(
-            "AMD TLX Flash Attention cluster requires head dimension 64 or 128"
-        )
-    for name, tensor in (("Q", q), ("K", k), ("V", v)):
-        if tensor.stride(2) <= 0 or tensor.stride(3) < 0:
-            raise ValueError(
-                "AMD TLX Flash Attention cluster requires nonnegative "
-                f"{name} feature and positive sequence strides"
-            )
-
-
 class Operator(BenchmarkOperator):
     DEFAULT_PRECISION = "bf16"
 
@@ -471,17 +436,23 @@ class Operator(BenchmarkOperator):
         return preproc_noop, fn
 
     @register_benchmark(
-        enabled=is_hip_mi350() and _tlx_amd_fa_cluster is not None,
+        enabled=(
+            is_hip_mi350()
+            and _tlx_amd_fa_cluster is not None
+            and _validate_tlx_amd_fa_cluster_inputs is not None
+        ),
         fwd_only=True,
         tags=["tlx", "amd", "gfx950"],
     )
     @multi_input_wrapper
     def tlx_amd_fa_cluster(self, *args) -> Tuple[Callable, Callable]:
         tlx_attention = _tlx_amd_fa_cluster
+        validate_inputs = _validate_tlx_amd_fa_cluster_inputs
         assert tlx_attention is not None
+        assert validate_inputs is not None
 
         def preproc(q, k, v):
-            _validate_tlx_amd_fa_cluster_inputs(q, k, v)
+            validate_inputs(q, k, v)
             return q, k, v
 
         def fn(q, k, v):


### PR DESCRIPTION
Summary:

Reference FWD attention PR: https://github.com/facebookexperimental/triton/pull/2892

Use the landed optimized gfx950 cluster Flash Attention implementation for real TritonBench forward measurements.

This adds a separate `tlx_amd_fa_cluster` provider that:

- imports both `attention` and the landed `_validate_cluster_inputs` helper from `amd_fa_cluster`;
- is enabled only on MI350 when both landed symbols are available, preventing an older/partial tutorial module from being benchmarked accidentally;
- is marked forward-only, independently of backward tutorial availability;
- delegates input-contract checks to the tutorial validator during preprocessing, before benchmark timing; and
- preserves the landed dispatcher/autotuner by forwarding only Q, K, V, `sm_scale`, and `causal`, with no fixed launch configuration.

The existing `tlx_amd_fa_pipelined` forward/backward provider remains available for comparison.

The portable CPU tests cover TritonBench-owned behavior: forward-only registration and the complete `preproc -> validator -> attention` route, including call order and exact arguments. They use FakeTensor CUDA inputs. The validator and attention functions are recording stubs in that test because the default CPU-test Triton may predate #2892 and therefore cannot import the landed private validator; landed-Triton and MI350 runs exercise the real symbols.

## Performance

AMD MI350X, PyTorch `2.13.0+rocm7.1`, BF16, `B=4`, `H=48`, `D=64`. Each shape/mask pair was measured in an isolated TritonBench process. `torch.backends.cuda.preferred_rocm_fa_library()` reports `AOTriton`, so the SDPA column below is AOTriton.

| Mask | N | AOTriton SDPA (TFLOP/s) | TLX pipelined (TFLOP/s) | TLX cluster (TFLOP/s) | Cluster vs pipelined | Cluster vs AOTriton SNR* |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| non-causal | 512 | 207.955 | 344.148 | 355.152 | +3.2% | >= 40.56 dB |
| non-causal | 1024 | 316.425 | 517.877 | 524.411 | +1.3% | >= 40.56 dB |
| non-causal | 2048 | 566.801 | 589.895 | 607.558 | +3.0% | >= 40.56 dB |
| non-causal | 4096 | 631.724 | 647.213 | 653.305 | +0.9% | >= 40.56 dB |
| non-causal | 8192 | 673.171 | 675.044 | 684.174 | +1.4% | >= 40.56 dB |
| causal | 512 | 74.1185 | 137.424 | 142.532 | +3.7% | >= 40.56 dB |
| causal | 1024 | 150.417 | 223.539 | 308.987 | +38.2% | >= 40.56 dB |
| causal | 2048 | 258.213 | 271.946 | 437.886 | +61.0% | >= 40.56 dB |
| causal | 4096 | 359.008 | 302.229 | 543.949 | +80.0% | >= 40.56 dB |
| causal | 8192 | 586.615 | 313.780 | 619.024 | +97.3% | >= 40.56 dB |

*The minimum cluster-vs-AOTriton SNR across the sweep was 40.56 dB.

The cluster provider improves on the existing pipelined provider by 0.9%-3.2% for non-causal attention and 3.7%-97.3% for causal attention across this sweep.

Strict elementwise `allclose` can fail at long shapes because of rare AOTriton reference outliers rather than TLX corruption. For sampled worst rows at `N=8192`, the cluster output was substantially closer to a float32 reference:

- non-causal: AOTriton absolute error `3.2437e-2`; cluster absolute error `3.37e-5`;
- causal: AOTriton absolute error `9.6317e-2`; cluster absolute error `1.56e-4`.

The cluster provider intentionally leaves `config` unset. First use may run Triton autotuning; normal benchmark warmup absorbs it, while `--warmup 0` or first-call metrics such as peak memory can include tuning overhead.

## Test plan

- Default/stale-Triton focused CPU test: `2 passed`
- Landed-Triton focused CPU test: `2 passed`
- Full `test/test_cpu`: `96 passed`, plus 3 pre-existing dependency-pin failures
  - the failures expect `transformers==5.0.0rc3` while current `main` specifies `transformers==5.5.0`;
  - the same three failures reproduce on clean `main`
- Remaining CPU suite with the stale dependency-pin file excluded: `93 passed`
- Pinned `ufmt==2.9.1` on both changed files: clean
- Python `compileall` on both changed files: clean
- `git diff --check`: clean
