### PR TITLE
Streamline tritonbench commands torchTLX perf measurement

### DIFF
--- a/tritonbench/operators/addmm/operator.py
+++ b/tritonbench/operators/addmm/operator.py
@@ -13,7 +13,13 @@ from tritonbench.utils.env_utils import (
     is_hip_mi350,
 )
 from tritonbench.utils.python_utils import try_import
-from tritonbench.utils.triton_utils import has_tlx, has_torch_tlx
+from tritonbench.utils.triton_utils import (
+    has_tlx,
+    has_torch_tlx,
+    TORCH_TLX_TAG,
+    TORCH_TLX_TAGS,
+    torch_tlx_inductor_config,
+)
 
 if has_tlx():
     try:
@@ -172,7 +178,7 @@ class Operator(BenchmarkOperator):
     def aten_addmm(self, a, mat1, mat2) -> Callable:
         return lambda: torch.addmm(a, mat1, mat2)
 
-    @register_benchmark()
+    @register_benchmark(tags=["pt2", TORCH_TLX_TAG])
     def pt2_triton_matmul(self, a, mat1, mat2) -> Callable:
         torch._dynamo.reset()
         with inductor_config.patch(
@@ -203,23 +209,17 @@ class Operator(BenchmarkOperator):
             return None
         return lambda: _tlx_addmm_gfx950(a, mat1_in, mat2_in)
 
-    @register_benchmark(enabled=is_hip_mi350() and has_tlx() and has_torch_tlx())
+    @register_benchmark(
+        enabled=is_hip_mi350() and has_tlx() and has_torch_tlx(),
+        tags=TORCH_TLX_TAGS + ["amd", "gfx950"],
+    )
     def torch_tlx_addmm(self, a, mat1, mat2) -> Callable:
-        # Force PT2 to select only TLX templates, excluding stock Triton choices.
-        # force_disable_caches prevents a prior allow-mode or stock-Triton choice
-        # from being reused through the autotune cache.
-        # Gated to AMD MI350x (gfx950), where the TLX addmm template exists.
+        # Gated to AMD MI350x (gfx950), where the TLX addmm templates exist.
         mat1_in = mat1 if mat1.is_contiguous() else mat1.contiguous()
         mat2_in = mat2 if mat2.stride(0) == 1 else mat2.T.contiguous().T
         torch._dynamo.reset()
         with inductor_config.patch(
-            {
-                "max_autotune": True,
-                "max_autotune_gemm_backends": "TRITON",
-                "autotune_fallback_to_aten": False,
-                "force_disable_caches": True,
-                "triton.tlx_mode": "force",
-            }
+            torch_tlx_inductor_config(max_autotune_gemm_backends="TRITON")
         ):
             f = lambda a, mat1, mat2: torch.addmm(a, mat1, mat2)
             compiled = torch.compile(f, dynamic=False)

--- a/tritonbench/operators/flex_attention/operator.py
+++ b/tritonbench/operators/flex_attention/operator.py
@@ -41,7 +41,13 @@ from tritonbench.utils.triton_op import (
     register_metric,
     register_x_val,
 )
-from tritonbench.utils.triton_utils import has_tlx, has_torch_tlx
+from tritonbench.utils.triton_utils import (
+    has_tlx,
+    has_torch_tlx,
+    TORCH_TLX_TAG,
+    TORCH_TLX_TAGS,
+    torch_tlx_inductor_config,
+)
 
 from .mods import (
     causal_mask,
@@ -354,7 +360,7 @@ class Operator(BenchmarkOperator):
             kernel_options=kernel_options,
         )
 
-    @register_benchmark()
+    @register_benchmark(tags=["pt2", TORCH_TLX_TAG])
     def pt2_triton_flex_attention(
         self,
         q: torch.Tensor,
@@ -370,14 +376,23 @@ class Operator(BenchmarkOperator):
         across ops. Enabled by default so it's the standing comparison for
         `torch_tlx_flex_attention` (no `--force` needed). `compiled` remains the
         provider pinned by ci.yaml / accuracy tests / servicelab (they select it
-        via `--only compiled`), so this alias does not affect those runs."""
-        return self.compiled(q, k, v, score_mod, block_mask, mod_type, kernel_options)
+        via `--only compiled`), so this alias does not affect those runs.
+
+        Unlike `compiled`, the returned callable is warmed up here so that
+        torch.compile happens inside the provider body, matching
+        `torch_tlx_flex_attention`. Without this the baseline reports a ~0s
+        provider time and defers compilation into the measured region, which
+        makes any compile-time comparison against TLX meaningless."""
+        fn = self.compiled(q, k, v, score_mod, block_mask, mod_type, kernel_options)
+        fn()
+        return fn
 
     @register_benchmark(
         enabled=(is_nvidia_blackwell() or is_amd_gfx950())
         and has_tlx()
         and has_torch_tlx(),
         fwd_only=True,
+        tags=TORCH_TLX_TAGS + ["nvidia", "b200", "amd", "gfx950"],
     )
     def torch_tlx_flex_attention(
         self,
@@ -389,26 +404,13 @@ class Operator(BenchmarkOperator):
         mod_type: str,
         kernel_options: dict[str, Any],
     ) -> Optional[Callable]:
-        # torch_tlx_<op> convention: PT2 (torch.compile max-autotune) with TLX
-        # "allow" mode, so the TLX flex-attention template competes against the
-        # standard Triton flex template during autotuning. Identical to the
-        # `compiled` max-autotune baseline except for triton.tlx_mode, giving a
-        # clean PT2-vs-PT2+TLX comparison. force_disable_caches forces a real
-        # recompile so the TLX candidate isn't served from the baseline's
-        # autotune cache. Device-agnostic: gated to archs that ship a TLX flex
-        # template -- Nvidia Blackwell (B200) and AMD MI350x (gfx950) -- and
-        # Inductor picks the matching per-device template during autotuning. The
-        # compile is warmed inside the patch so the TLX candidate is selected
-        # while tlx_mode is active.
+        # Device-agnostic: gated to the archs that ship a TLX flex template --
+        # Nvidia Blackwell (B200) and AMD MI350x (gfx950) -- and Inductor picks
+        # the matching per-device template during autotuning. The compile is
+        # warmed inside the patch so the TLX candidate is selected while
+        # tlx_mode is active.
         torch._dynamo.reset()
-        with inductor_config.patch(
-            {
-                "max_autotune": True,
-                "autotune_fallback_to_aten": False,
-                "force_disable_caches": True,
-                "triton.tlx_mode": "allow",
-            }
-        ):
+        with inductor_config.patch(torch_tlx_inductor_config()):
             compiled_fn = torch.compile(
                 flex_attention, fullgraph=True, dynamic=self.dynamic
             )

--- a/tritonbench/operators/gemm/operator.py
+++ b/tritonbench/operators/gemm/operator.py
@@ -21,7 +21,13 @@ if False:
         blackwell_matmul_tma_persistent,
         blackwell_matmul_tma_persistent_splitk,
     )
-from tritonbench.utils.triton_utils import has_tlx, has_torch_tlx
+from tritonbench.utils.triton_utils import (
+    has_tlx,
+    has_torch_tlx,
+    TORCH_TLX_TAG,
+    TORCH_TLX_TAGS,
+    torch_tlx_inductor_config,
+)
 
 if has_tlx():
     from triton.language.extra.tlx.tutorials.blackwell_gemm_2cta import (
@@ -404,7 +410,7 @@ class Operator(BenchmarkOperator):
         else:
             return lambda: hstu_triton_matmul_kernel(a, b)
 
-    @register_benchmark()
+    @register_benchmark(tags=["pt2", TORCH_TLX_TAG])
     def pt2_triton_matmul(self, a, b, bias) -> Callable:
         torch._dynamo.reset()
         inductor_config_patch = {
@@ -427,23 +433,16 @@ class Operator(BenchmarkOperator):
 
         return lambda: compiled(a, b)
 
-    @register_benchmark(enabled=IS_BLACKWELL and has_tlx() and has_torch_tlx())
+    @register_benchmark(
+        enabled=IS_BLACKWELL and has_tlx() and has_torch_tlx(),
+        tags=TORCH_TLX_TAGS + ["nvidia", "b200"],
+    )
     def torch_tlx_mm(self, a, b, bias) -> Callable:
-        # torch_tlx_<op> convention: PT2 (torch.compile max-autotune, TRITON
-        # backend) with TLX "allow" mode, so TLX templates compete against the
-        # standard Triton templates during autotuning. Identical to the
-        # pt2_triton_matmul baseline except for triton.tlx_mode, giving a clean
-        # PT2-vs-PT2+TLX comparison. force_disable_caches forces a real recompile
-        # so the TLX candidates aren't served from the baseline's autotune cache.
         torch._dynamo.reset()
-        inductor_config_patch = {
-            "max_autotune": True,
-            "max_autotune_gemm_backends": "TRITON",
-            "autotune_fallback_to_aten": False,
-            "autotune_num_choices_displayed": self.inductor_autotune_num_choices_displayed,
-            "force_disable_caches": True,
-            "triton.tlx_mode": "allow",
-        }
+        inductor_config_patch = torch_tlx_inductor_config(
+            max_autotune_gemm_backends="TRITON",
+            autotune_num_choices_displayed=self.inductor_autotune_num_choices_displayed,
+        )
         if self.template_filter_regex is not None:
             inductor_config_patch["test_configs.autotune_choice_name_regex"] = (
                 self.template_filter_regex

--- a/tritonbench/utils/list_operator_details.py
+++ b/tritonbench/utils/list_operator_details.py
@@ -48,6 +48,7 @@ def get_backends_for_operators(operators: List[str]) -> Dict[str, Dict[str, Dict
                 "enabled": backend_config.enabled,
                 "fwd_only": backend_config.fwd_only,
                 "ci": backend_config.ci,
+                "tags": backend_config.tags or [],
             }
 
     return result
@@ -92,10 +93,13 @@ def format_backend_entry(backend_name: str, backend_info: Dict[str, any]) -> str
 
     status_str = f" [{', '.join(status_indicators)}]" if status_indicators else ""
 
+    tags = backend_info.get("tags") or []
+    tags_str = f" tags={{{','.join(tags)}}}" if tags else ""
+
     if label != backend_name:
-        return f"{INDENT2}{backend_name} (label: {label}){status_str}"
+        return f"{INDENT2}{backend_name} (label: {label}){status_str}{tags_str}"
     else:
-        return f"{INDENT2}{backend_name}{status_str}"
+        return f"{INDENT2}{backend_name}{status_str}{tags_str}"
 
 
 def format_metrics_section(

--- a/tritonbench/utils/parser.py
+++ b/tritonbench/utils/parser.py
@@ -201,6 +201,12 @@ def get_parser(args=None):
         help="Specify one or multiple kernel implementations to run.",
     )
     parser.add_argument(
+        "--tags",
+        default=None,
+        help="Select kernel implementations by tag (comma-separated, OR semantics). "
+        "Tags are declared via @register_benchmark(tags=[...]). Unions with --only.",
+    )
+    parser.add_argument(
         "--skip",
         default=None,
         help="Specify one or multiple kernel implementations to skip.",

--- a/tritonbench/utils/run_utils.py
+++ b/tritonbench/utils/run_utils.py
@@ -27,6 +27,8 @@ from tritonbench.utils.env_utils import (
     is_fbcode,
     is_h100,
     is_hip,
+    is_hip_mi300,
+    is_hip_mi350,
     is_meta_triton,
     is_triton_beta,
     is_triton_main,
@@ -79,6 +81,8 @@ ENV_CHECK_MAP = {
         "b200": is_blackwell,
         "cuda": is_cuda,
         "hip": is_hip,
+        "mi300x": is_hip_mi300,
+        "mi350x": is_hip_mi350,
         "xpu": is_xpu,
     },
     "channels": {
@@ -971,6 +975,11 @@ def _run_config_entry(
         override_envs=override_envs,
         capture_output=capture_output,
         benchmark_group_name=benchmark_group_name,
+        **(
+            {"timeout_s": int(benchmark_config["timeout"])}
+            if "timeout" in benchmark_config
+            else {}
+        ),
     )
     return False
 
@@ -1120,8 +1129,12 @@ def run_in_task(
         )
         return 0
     except subprocess.TimeoutExpired:
-        logger.warning(
-            f"[{log_prefix}] Benchmark {benchmark_name} timed out after {timeout_s} seconds."
+        # Logged at ERROR, not WARNING: --simple-output drops the logger to
+        # ERROR above, and a timeout that is silently swallowed looks identical
+        # to a benchmark that produced no results.
+        logger.error(
+            f"[{log_prefix}] Benchmark {benchmark_name} timed out after {timeout_s} "
+            "seconds and produced no results. Raise it with `timeout:` in the run config."
         )
         return 0
     except subprocess.CalledProcessError as e:

--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -232,6 +232,33 @@ def _split_params_by_comma(params: Optional[str]) -> List[str]:
     return [x.strip() for x in params.split(",")] if "," in params else [params]
 
 
+def _resolve_backend_selection(
+    op_name: str, only: List[str], tags: List[str]
+) -> List[str]:
+    """Expand --tags into backend names and union them with --only.
+
+    A backend matches if it carries any of the requested tags. Registration is
+    independent of the runtime device, so this deliberately returns backends
+    that are disabled here (e.g. an AMD-only backend on an NVIDIA host); the
+    caller's enabled-check drops them with a warning.
+    """
+    if not tags:
+        return only
+    backends = REGISTERED_BENCHMARKS.get(op_name, {})
+    tagged = [
+        name
+        for name, backend in backends.items()
+        if backend.tags and any(t in backend.tags for t in tags)
+    ]
+    if not tagged:
+        logger.warning(
+            f"No backend of operator {op_name} matches tag(s) {','.join(tags)}. "
+            f"Available tags: {sorted({t for b in backends.values() for t in (b.tags or [])})}"
+        )
+    # dict.fromkeys preserves order and removes duplicates across the two sources
+    return list(dict.fromkeys(only + tagged))
+
+
 def _find_op_name_from_module_path(module_path: str) -> str:
     PATH_PREFIX = "tritonbench.operators."
     # We have a separate operator loader for aten operator benchmark.
@@ -889,7 +916,11 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
             BASELINE_BENCHMARKS[self.name] = _split_params_by_comma(
                 self.tb_args.baseline
             )
-        self._only = _split_params_by_comma(self.tb_args.only)
+        self._only = _resolve_backend_selection(
+            self.name,
+            _split_params_by_comma(self.tb_args.only),
+            _split_params_by_comma(getattr(self.tb_args, "tags", None)),
+        )
         self._skip = _split_params_by_comma(self.tb_args.skip)
         self._force = self.tb_args.force
         self._only_match_mode = self.tb_args.only_match_mode
@@ -2501,7 +2532,13 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
         op_task_args.extend(copy.deepcopy(sys.argv))
         op_task_args = remove_cmd_parameter(op_task_args, "--op")
         op_task_args = add_cmd_parameter(op_task_args, "--op", self.name)
-        for override_option in ["--only", "--input-id", "--num-inputs", "--metrics"]:
+        for override_option in [
+            "--only",
+            "--tags",
+            "--input-id",
+            "--num-inputs",
+            "--metrics",
+        ]:
             op_task_args = remove_cmd_parameter(op_task_args, override_option)
         op_task_args.extend(
             [
@@ -2693,7 +2730,13 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
         from tritonbench.operators.op_task import OpTask
 
         op_task_args = copy.deepcopy(self._raw_extra_args)
-        for override_option in ["--only", "--input-id", "--num-inputs", "--metrics"]:
+        for override_option in [
+            "--only",
+            "--tags",
+            "--input-id",
+            "--num-inputs",
+            "--metrics",
+        ]:
             op_task_args = remove_cmd_parameter(op_task_args, override_option)
         op_task_args.extend(
             [

--- a/tritonbench/utils/triton_utils.py
+++ b/tritonbench/utils/triton_utils.py
@@ -2,6 +2,7 @@
 
 import functools
 import importlib.util
+from typing import Any, Dict
 
 import triton.language as tl
 
@@ -51,6 +52,41 @@ def has_torch_tlx():
         return hasattr(inductor_config.triton, "tlx_mode")
     except (ImportError, AttributeError):
         return False
+
+
+#: Tag shared by the whole torchTLX perf comparison set for an operator: the
+#: `torch_tlx_<op>` provider plus the `pt2_*` baseline it is measured against.
+#: `--tags torch_tlx` therefore selects a complete comparison in one flag, and
+#: stays correct as new TLX providers are added.
+TORCH_TLX_TAG = "torch_tlx"
+
+#: Full tag set for a `torch_tlx_<op>` provider. Operators append their own
+#: hardware tags (e.g. "amd", "gfx950") matching the provider's `enabled` gate.
+TORCH_TLX_TAGS = ["tlx", TORCH_TLX_TAG, "pt2"]
+
+
+def torch_tlx_inductor_config(**overrides: Any) -> Dict[str, Any]:
+    """Inductor config patch shared by every `torch_tlx_<op>` provider.
+
+    PT2 max-autotune with TLX "allow" mode, so TLX templates compete against the
+    standard Triton templates during autotuning. Identical to the matching `pt2_*`
+    baseline except for `triton.tlx_mode` -- that single difference is what makes
+    the reported speedup a clean PT2-vs-PT2+TLX comparison. `force_disable_caches`
+    forces a real recompile so TLX candidates are not served from the baseline's
+    autotune cache.
+
+    Perf benchmarks always use "allow"; "force" mode is reserved for correctness
+    tests, where the point is to exercise the TLX template rather than to let it
+    win autotuning on merit.
+    """
+    config: Dict[str, Any] = {
+        "max_autotune": True,
+        "autotune_fallback_to_aten": False,
+        "force_disable_caches": True,
+        "triton.tlx_mode": "allow",
+    }
+    config.update(overrides)
+    return config
 
 
 def has_experimental_descriptor():


### PR DESCRIPTION
Summary:
Adds a one-command torchTLX perf harness to tritonbench, plus the tag-based
backend selection it needs, and closes the MI350x `bmm` coverage gap.
- **One-command harness**: `benchmarks/fb/torchtlx/run.sh <op> [--file <shape-file>]` — auto-detects arch (compute capability / gfx target), picks buck vs OSS `run.py`, forces cold compiles, tees a log, and prints speedup + compile-time tables at the end.
- **`--tags` backend selection**: new tritonbench flag selecting backends by tag (OR semantics, unions with `--only`, shown by `--list-backends`); `--tags torch_tlx` resolves to the `torch_tlx_<op>` provider plus the `pt2_*` baseline it is measured against, so one flag works for every op:
```
op              --only ... you would otherwise write                with tags
--------------  --------------------------------------------------  ----------------
gemm            pt2_triton_matmul,torch_tlx_mm                       --tags torch_tlx
addmm           pt2_triton_matmul,torch_tlx_addmm                    --tags torch_tlx
bmm             pt2_triton_bmm,torch_tlx_bmm                         --tags torch_tlx
flex_attention  pt2_triton_flex_attention,torch_tlx_flex_attention   --tags torch_tlx
```
- **Shape-file discovery**: `run.sh <op> --help` walks `input_configs/` and lists every config declaring that op — gemm 40, addmm 18, bmm 6, flex_attention 2 — instead of a hand-maintained table, so it also works in an OSS checkout with no `fb/` dir.
- **Shared TLX inductor config**: `torch_tlx_inductor_config()` replaces four hand-rolled copies of the max-autotune + `tlx_mode="allow"` + `force_disable_caches` patch; `addmm` moves from `force` to `allow` so perf runs measure a template that won autotuning on merit.
- **Coverage gap closed**: registers `torch_tlx_bmm` (MI350x gfx950 warp-pipe template), re-enables `pt2_triton_bmm` as its baseline, and adds a placeholder MI350x `flex_attention` shape file.
- **Fair baselines**: `pt2_triton_flex_attention` and `pt2_triton_bmm` now warm up inside the provider body like the TLX providers, so compilation is not deferred into the measured region.
- **Compile time without a metric**: scraped from the per-shape `Took <ms>ms to get benchmark function` log lines — for these providers `--metrics compile_time` times an already-compiled call and falls back to a subtraction that goes negative.
- **Run-config plumbing**: `mi300x`/`mi350x` device gates, a per-entry `timeout:` field, and timeouts logged at ERROR so `--simple-output` cannot swallow them.

Reviewed By: xuzhao9, beginner137

Differential Revision: D117163593


