### PR TITLE
[docker] fix triton docker build

### DIFF
--- a/.ci/triton/triton_install_utils.sh
+++ b/.ci/triton/triton_install_utils.sh
@@ -63,6 +63,20 @@ checkout_triton() {
     cd -
 }
 
+# find_package(<pkg> CONFIG) probes many layouts under every prefix:
+#   <prefix>/, <prefix>/cmake/, <prefix>/<name>*/, <prefix>/<name>*/cmake/,
+#   <prefix>/(lib|lib64|share)/cmake/<name>*/, <prefix>/(lib|lib64|share)/<name>*/ ...
+# so a fixed pair of paths is not enough to tell whether a prefix ships an LLVM.
+# rocm-sdk for example puts CMAKE_PREFIX_PATH at .../_rocm_sdk_devel/lib/cmake, one
+# level below the install root, and its config lands in <prefix>/llvm/.
+prefix_provides_llvm() {
+    CMAKE_SEARCH_PREFIX=$1
+    [ -d "${CMAKE_SEARCH_PREFIX}" ] || return 1
+    [ -n "$(find "${CMAKE_SEARCH_PREFIX}" -maxdepth 5 \
+            \( -name 'LLVMConfig.cmake' -o -name 'MLIRConfig.cmake' -o -name 'LLDConfig.cmake' \) \
+            -print -quit 2>/dev/null)" ]
+}
+
 # Some base images (e.g. rocm/pytorch) export LLVM_DIR or put their own LLVM on
 # CMAKE_PREFIX_PATH. Both outrank the HINTS that MLIRConfig.cmake uses to find the
 # prebuilt LLVM Triton downloads, so cmake silently loads the system LLVM instead.
@@ -78,8 +92,7 @@ drop_system_llvm_from_cmake_env() {
     KEPT_PREFIX_PATH=""
     IFS=':' read -r -a CMAKE_PREFIXES <<< "${CMAKE_PREFIX_PATH}"
     for CMAKE_PREFIX in "${CMAKE_PREFIXES[@]}"; do
-        if [ -e "${CMAKE_PREFIX}/lib/cmake/llvm/LLVMConfig.cmake" ] || \
-           [ -e "${CMAKE_PREFIX}/LLVMConfig.cmake" ]; then
+        if prefix_provides_llvm "${CMAKE_PREFIX}"; then
             echo "Dropping ${CMAKE_PREFIX} from CMAKE_PREFIX_PATH: it would shadow Triton's LLVM"
             continue
         fi

--- a/.ci/triton/triton_install_utils.sh
+++ b/.ci/triton/triton_install_utils.sh
@@ -63,9 +63,39 @@ checkout_triton() {
     cd -
 }
 
+# Some base images (e.g. rocm/pytorch) export LLVM_DIR or put their own LLVM on
+# CMAKE_PREFIX_PATH. Both outrank the HINTS that MLIRConfig.cmake uses to find the
+# prebuilt LLVM Triton downloads, so cmake silently loads the system LLVM instead.
+# When that LLVM is built without the NVPTX target, find_package(MLIR) then fails with
+# "The following imported targets are referenced, but are missing: LLVMNVPTXCodeGen
+# LLVMNVPTXDesc LLVMNVPTXInfo".
+drop_system_llvm_from_cmake_env() {
+    unset LLVM_DIR
+    unset LLVM_ROOT
+    if [ -z "${CMAKE_PREFIX_PATH:-}" ]; then
+        return 0
+    fi
+    KEPT_PREFIX_PATH=""
+    IFS=':' read -r -a CMAKE_PREFIXES <<< "${CMAKE_PREFIX_PATH}"
+    for CMAKE_PREFIX in "${CMAKE_PREFIXES[@]}"; do
+        if [ -e "${CMAKE_PREFIX}/lib/cmake/llvm/LLVMConfig.cmake" ] || \
+           [ -e "${CMAKE_PREFIX}/LLVMConfig.cmake" ]; then
+            echo "Dropping ${CMAKE_PREFIX} from CMAKE_PREFIX_PATH: it would shadow Triton's LLVM"
+            continue
+        fi
+        KEPT_PREFIX_PATH="${KEPT_PREFIX_PATH:+${KEPT_PREFIX_PATH}:}${CMAKE_PREFIX}"
+    done
+    if [ -z "${KEPT_PREFIX_PATH}" ]; then
+        unset CMAKE_PREFIX_PATH
+    else
+        export CMAKE_PREFIX_PATH="${KEPT_PREFIX_PATH}"
+    fi
+}
+
 install_triton() {
     TRITON_INSTALL_DIR=$1
     cd "${TRITON_INSTALL_DIR}"
+    drop_system_llvm_from_cmake_env
     # install main triton
     if [ -n "${UV_VENV_DIR:-}" ]; then
         uv pip install ninja cmake wheel pybind11; # build-time dependencies

--- a/.ci/triton/triton_install_utils.sh
+++ b/.ci/triton/triton_install_utils.sh
@@ -35,7 +35,8 @@ clone_triton() {
     TRITON_INSTALL_DIRNAME=$(basename "${TRITON_INSTALL_DIR}")
     TRITON_INSTALL_BASEDIR=$(dirname "${TRITON_INSTALL_DIR}")
     cd "${TRITON_INSTALL_BASEDIR}"
-    git clone "https://github.com/${REPO}.git" "${TRITON_INSTALL_DIRNAME}"
+    # clone submodules (e.g., third_party/sleef required by the cpu backend)
+    git clone --recurse-submodules "https://github.com/${REPO}.git" "${TRITON_INSTALL_DIRNAME}"
 }
 
 update_triton() {
@@ -57,6 +58,8 @@ checkout_triton() {
         # truncate the branch to the earliest commit of the current day
         git checkout $(git rev-list --reverse --since=midnight HEAD | head -n 1)
     fi
+    # the checked-out commit may point to different submodule revisions
+    git submodule update --init --recursive
     cd -
 }
 

--- a/.ci/tritonbench/cleanup-build.sh
+++ b/.ci/tritonbench/cleanup-build.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -xeuo pipefail
+
+# Remove Triton build-time downloads that are not needed at runtime.
+#
+# Triton caches the prebuilt LLVM, the NVIDIA toolchain and nlohmann/json under
+# ${TRITON_HOME:-${HOME}}/.triton. These are only read while cmake configures and
+# builds: ptxas & friends are copied into third_party/*/backend/ and libtriton.so is
+# written to python/triton/_C/, both inside the Triton checkout. Dropping them saves
+# a few GB per LLVM pin in the docker images.
+#
+# Run this in the same docker layer as the build, otherwise the space is not reclaimed.
+
+# Mirrors get_triton_cache_path() in Triton's setup.py
+TRITON_CACHE_PATH="${TRITON_HOME:-${HOME:?}}/.triton"
+
+if [ ! -e "${TRITON_CACHE_PATH}" ]; then
+    echo "No Triton cache at ${TRITON_CACHE_PATH}, nothing to clean up"
+    exit 0
+fi
+
+# Keep the "cache" subdirectory: that is the runtime JIT cache, not a download.
+for SUBDIR in llvm json nvidia; do
+    rm -rf "${TRITON_CACHE_PATH:?}/${SUBDIR}"
+done
+
+du -sh "${TRITON_CACHE_PATH}"

--- a/.ci/tritonbench/install-pytorch-source.sh
+++ b/.ci/tritonbench/install-pytorch-source.sh
@@ -12,23 +12,50 @@ if [ -z "${WORKSPACE_DIR:-}" ] || [ ! -e "${WORKSPACE_DIR}" ]; then
     exit 1
 fi
 
+PYTORCH_REPO_URL="https://github.com/pytorch/pytorch.git"
+
+# The checkout is only used to resolve the branch and commit time of the
+# installed pytorch nightly, so it must be an upstream pytorch/pytorch clone.
+is_upstream_pytorch_clone() {
+    CHECKOUT_DIR=$1
+    REMOTE_URL=$(git -C "${CHECKOUT_DIR}" config --get remote.origin.url 2>/dev/null) || return 1
+    case "${REMOTE_URL}" in
+        *pytorch/pytorch*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
 
 update_pytorch() {
     PYTORCH_INSTALL_DIR=$1
     cd "${PYTORCH_INSTALL_DIR}"
-    git checkout main
-    git pull origin main
+    # the checkout may be shallow or single-branch, make sure main is fetchable
+    if [ "$(git rev-parse --is-shallow-repository)" == "true" ]; then
+        git fetch --unshallow origin
+    fi
+    git remote set-branches origin '*'
+    git fetch origin main
+    git checkout -B main origin/main
     git submodule sync
     git submodule update --init --recursive
     git fetch origin nightly
 }
 
 
-if [ -e "${WORKSPACE_DIR}/pytorch" ]; then
-    # the pytorch repo is already cloned, update it
-    update_pytorch "${WORKSPACE_DIR}/pytorch"
-else
-    git clone https://github.com/pytorch/pytorch.git "${WORKSPACE_DIR}/pytorch"
+PYTORCH_INSTALL_DIR="${WORKSPACE_DIR}/pytorch"
+# Some base docker images (e.g. rocm/pytorch) ship their own pytorch checkout
+# at this path. It can be a fork or a partial clone that we can't update from
+# upstream, in which case keep it untouched and use our own directory.
+if [ -e "${PYTORCH_INSTALL_DIR}" ] && ! is_upstream_pytorch_clone "${PYTORCH_INSTALL_DIR}"; then
+    echo "WARNING: ${PYTORCH_INSTALL_DIR} is not an upstream pytorch checkout, cloning to ${WORKSPACE_DIR}/pytorch-src instead"
+    PYTORCH_INSTALL_DIR="${WORKSPACE_DIR}/pytorch-src"
 fi
 
-echo "export TRITONBENCH_PYTORCH_REPO_PATH=/workspace/pytorch" >> "${SETUP_SCRIPT}"
+if is_upstream_pytorch_clone "${PYTORCH_INSTALL_DIR}"; then
+    # the pytorch repo is already cloned, update it
+    update_pytorch "${PYTORCH_INSTALL_DIR}"
+else
+    rm -rf "${PYTORCH_INSTALL_DIR}"
+    git clone "${PYTORCH_REPO_URL}" "${PYTORCH_INSTALL_DIR}"
+fi
+
+echo "export TRITONBENCH_PYTORCH_REPO_PATH=${PYTORCH_INSTALL_DIR}" >> "${SETUP_SCRIPT}"

--- a/docker/tritonbench-nightly.dockerfile
+++ b/docker/tritonbench-nightly.dockerfile
@@ -34,7 +34,9 @@ RUN git clone --recurse-submodules -b "${TRITONBENCH_BRANCH}" --single-branch \
     https://github.com/meta-pytorch/tritonbench "${WORKSPACE_DIR}/tritonbench"
 
 # Install and setup env
-RUN cd ${WORKSPACE_DIR}/tritonbench && bash ./.ci/tritonbench/setup-env.sh --cuda --triton-main --meta-triton --test-nvidia-driver
+# cleanup-build.sh must run in this layer, otherwise the downloads are not reclaimed
+RUN cd ${WORKSPACE_DIR}/tritonbench && bash ./.ci/tritonbench/setup-env.sh --cuda --triton-main --meta-triton --test-nvidia-driver && \
+    bash ./.ci/tritonbench/cleanup-build.sh
 
 # Check the installed version of nightly if needed
 RUN cd ${WORKSPACE_DIR}/tritonbench && \

--- a/docker/tritonbench-rocm-nightly.dockerfile
+++ b/docker/tritonbench-rocm-nightly.dockerfile
@@ -24,7 +24,9 @@ RUN git clone --recurse-submodules -b "${TRITONBENCH_BRANCH}" --single-branch \
 # AMD will segfault on MI350 due to an LLVM bug: [llvm/llvm-project#193499](https://github.com/llvm/llvm-project/pull/193499)
 # commit 90cd5e2abb74c on llvm-head branch fixes the segfault
 # The bump was merged in https://github.com/triton-lang/triton/pull/10523
-RUN cd /workspace/tritonbench && bash ./.ci/tritonbench/setup-env.sh --hip --triton-main --meta-triton
+# cleanup-build.sh must run in this layer, otherwise the downloads are not reclaimed
+RUN cd /workspace/tritonbench && bash ./.ci/tritonbench/setup-env.sh --hip --triton-main --meta-triton && \
+    bash ./.ci/tritonbench/cleanup-build.sh
 
 # Output setup script for inspection
 RUN cat "${SETUP_SCRIPT}"


### PR DESCRIPTION
NVIDIA Docker: checkout all submodules. Clean up LLVM used during the build to save space

AMD Docker: strip LLVM from base image and use Triton's own LLVM. Set PyTorch Dir. Cleanup LLVM used during the build to save space.

Test plan:

CI