### PR TITLE
[TLX][AMD] Guard cluster Flash Attention regressions

### DIFF
--- a/.ci/tritonbench/test-gpu.sh
+++ b/.ci/tritonbench/test-gpu.sh
@@ -23,4 +23,4 @@ export TORCHINDUCTOR_COMPILE_THREADS=1
 # best effort disable autotune to speedup test
 export TORCHINDUCTOR_MAX_AUTOTUNE=0
 
-python -m unittest test.test_gpu.main -v
+python -m unittest "${TEST_MODULE:-test.test_gpu.main}" -v

--- a/.github/workflows/_linux-test-mi350.yml
+++ b/.github/workflows/_linux-test-mi350.yml
@@ -7,6 +7,12 @@ on:
         type: string
         description: |
           Conda environment to activate when testing Triton
+      test_module:
+        required: False
+        type: string
+        default: "test.test_gpu.main"
+        description: |
+          Python unittest module to run
 
 jobs:
   linux-test-mi350:
@@ -19,6 +25,7 @@ jobs:
       UV_VENV_DIR: "/workspace/uv_venvs"
       SETUP_SCRIPT: "/workspace/setup_instance.sh"
       CONDA_ENV: ${{ inputs.conda_env }}
+      TEST_MODULE: ${{ inputs.test_module }}
       DOCKER_IMAGE: "ghcr.io/meta-pytorch/tritonbench:rocm-latest"
     steps:
       - name: Checkout Tritonbench
@@ -38,6 +45,7 @@ jobs:
             ${GPU_FLAG:-} \
             --env-file /etc/podinfo/gha-gpu-isolation-settings \
             -e CONDA_ENV \
+            -e TEST_MODULE \
             -e TRITON_HIP_USE_ASYNC_COPY \
             --ipc=host \
             --tty \

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -19,6 +19,11 @@ jobs:
     uses: ./.github/workflows/_linux-test-mi350.yml
     with:
       conda_env: "triton-main"
+  mi350-meta-triton-tlx-test:
+    uses: ./.github/workflows/_linux-test-mi350.yml
+    with:
+      conda_env: "meta-triton"
+      test_module: "test.test_gpu.test_flash_attention_tlx_regression"
 
 
 

--- a/test/test_cpu/test_flash_attention_tlx.py
+++ b/test/test_cpu/test_flash_attention_tlx.py
@@ -1,6 +1,20 @@
+import math
+
+import pytest
 import torch
 from torch._subclasses.fake_tensor import FakeTensorMode
 from tritonbench.operators.flash_attention import operator as flash_attention
+from tritonbench.operators.flash_attention.tlx_cluster_regression import (
+    assert_performance,
+    attention_flops,
+    correctness_cases,
+    MIN_SNR_DB,
+    MIN_TFLOPS,
+    PERFORMANCE_CASE,
+    sample_indices,
+    sampled_fp32_attention,
+    snr_db,
+)
 from tritonbench.utils.triton_op import REGISTERED_BENCHMARKS
 
 
@@ -63,3 +77,94 @@ def test_tlx_amd_fa_cluster_validates_before_landed_entrypoint(monkeypatch):
     assert all(actual is wanted for actual, wanted in zip(events[0][1:], (q, k, v)))
     assert all(actual is wanted for actual, wanted in zip(events[1][1:4], (q, k, v)))
     assert events[1][4:] == (0.125, True)
+
+
+def test_tlx_amd_fa_cluster_regression_matrix():
+    cases = correctness_cases()
+    d128 = [case for case in cases if case.head_dim == 128]
+    d64 = [case for case in cases if case.head_dim == 64]
+
+    assert len(cases) == 28
+    assert {
+        (case.dtype, case.batch, case.heads, case.seq_len, case.head_dim, case.causal)
+        for case in d128
+    } == {
+        (dtype, 16384 // seq_len, 64, seq_len, 128, causal)
+        for dtype in (torch.float16, torch.bfloat16)
+        for causal in (False, True)
+        for seq_len in (512, 1024, 2048, 4096, 8192, 16384)
+    }
+    assert {
+        (case.dtype, case.batch, case.heads, case.seq_len, case.head_dim, case.causal)
+        for case in d64
+    } == {
+        (dtype, 16, 64, 1024, 64, causal)
+        for dtype in (torch.float16, torch.bfloat16)
+        for causal in (False, True)
+    }
+    assert PERFORMANCE_CASE in d128
+    assert PERFORMANCE_CASE.dtype == torch.bfloat16
+    assert not PERFORMANCE_CASE.causal
+    assert (
+        PERFORMANCE_CASE.batch,
+        PERFORMANCE_CASE.heads,
+        PERFORMANCE_CASE.seq_len,
+        PERFORMANCE_CASE.head_dim,
+    ) == (1, 64, 16384, 128)
+
+
+def test_tlx_amd_fa_cluster_regression_helpers():
+    expected = torch.ones(16)
+    perturbed = expected.clone()
+    perturbed[0] = 2.0
+
+    assert math.isinf(snr_db(expected, expected))
+    assert snr_db(perturbed, expected) < MIN_SNR_DB
+    assert sample_indices(1) == (0,)
+    assert sample_indices(8) == (0, 4, 7)
+    assert attention_flops(PERFORMANCE_CASE) == 4 * 1 * 64 * 16384 * 16384 * 128
+    causal_case = PERFORMANCE_CASE.__class__(
+        dtype=torch.bfloat16,
+        batch=2,
+        heads=4,
+        seq_len=512,
+        head_dim=128,
+        causal=True,
+    )
+    assert attention_flops(causal_case) == 2 * 2 * 4 * 512 * 513 * 128
+
+    with pytest.raises(
+        AssertionError, match=r"924\.9 TFLOP/s.*925\.0 TFLOP/s.*1010\.5 TFLOP/s"
+    ):
+        assert_performance(924.9)
+    assert MIN_TFLOPS == 925.0
+    assert_performance(MIN_TFLOPS)
+
+    for invalid_tflops in (float("nan"), float("inf"), float("-inf"), 0.0):
+        with pytest.raises(AssertionError, match="finite and positive"):
+            assert_performance(invalid_tflops)
+
+
+@pytest.mark.parametrize("causal", [False, True])
+def test_tlx_amd_fa_cluster_sampled_fp32_reference_matches_full_attention(causal):
+    torch.manual_seed(17)
+    q = torch.randn((2, 2, 5, 3), dtype=torch.float32)
+    k = torch.randn_like(q)
+    v = torch.randn_like(q)
+    scale = 0.375
+    scores = torch.matmul(q, k.transpose(-1, -2)) * scale
+    if causal:
+        positions = torch.arange(q.shape[2])
+        scores.masked_fill_(positions[None, :] > positions[:, None], float("-inf"))
+    full_reference = torch.matmul(torch.softmax(scores, dim=-1), v)
+
+    actual_rows, reference_rows = sampled_fp32_attention(
+        full_reference,
+        q,
+        k,
+        v,
+        scale,
+        causal,
+    )
+
+    torch.testing.assert_close(actual_rows, reference_rows)

--- a/test/test_gpu/test_flash_attention_tlx_regression.py
+++ b/test/test_gpu/test_flash_attention_tlx_regression.py
@@ -1,0 +1,148 @@
+import gc
+import math
+import os
+import statistics
+import subprocess
+import sys
+import unittest
+
+import torch
+import torch.nn.functional as F
+import triton
+from tritonbench.operators.flash_attention import operator as flash_attention
+from tritonbench.operators.flash_attention.tlx_cluster_regression import (
+    assert_performance,
+    attention_flops,
+    correctness_cases,
+    MIN_SNR_DB,
+    PERFORMANCE_CASE,
+    REFERENCE_TFLOPS,
+    sampled_fp32_attention,
+    snr_db,
+)
+from tritonbench.utils.env_utils import is_hip_mi350
+
+
+_REGRESSION_WORKER = "TRITONBENCH_TLX_AMD_FA_CLUSTER_REGRESSION_WORKER"
+_TEST_CLASS = (
+    "test.test_gpu.test_flash_attention_tlx_regression.TestTlxAmdFaClusterRegression"
+)
+_LLVM_OPT = "disable-machine-sink"
+
+
+@unittest.skipUnless(is_hip_mi350(), "requires an MI350/gfx950 GPU")
+class TestTlxAmdFaClusterRegression(unittest.TestCase):
+    def _run_isolated(self):
+        test_name = self._testMethodName
+        if os.environ.get(_REGRESSION_WORKER) == test_name:
+            self.assertEqual(os.environ.get("DISABLE_LLVM_OPT"), _LLVM_OPT)
+            return False
+
+        # LLVM command-line options are process-global, so compile the tuned
+        # variants in a child process instead of affecting later GPU tests.
+        env = os.environ.copy()
+        env[_REGRESSION_WORKER] = test_name
+        env["DISABLE_LLVM_OPT"] = _LLVM_OPT
+        result = subprocess.run(
+            [sys.executable, "-m", "unittest", f"{_TEST_CLASS}.{test_name}", "-v"],
+            check=False,
+            capture_output=True,
+            env=env,
+            text=True,
+        )
+        if result.returncode != 0:
+            self.fail(
+                "isolated regression check failed:\n"
+                f"stdout:\n{result.stdout}\n"
+                f"stderr:\n{result.stderr}"
+            )
+        print(result.stdout)
+        return True
+
+    def _attention(self):
+        attention = flash_attention._tlx_amd_fa_cluster
+        if attention is None:
+            self.fail("the meta-triton environment must provide tlx_amd_fa_cluster")
+        return attention
+
+    def _check_case(self, case):
+        attention = self._attention()
+        torch.manual_seed(42)
+        shape = (case.batch, case.heads, case.seq_len, case.head_dim)
+        q = torch.randn(shape, dtype=case.dtype, device="cuda")
+        k = torch.randn_like(q)
+        v = torch.randn_like(q)
+        scale = 1.0 / math.sqrt(case.head_dim)
+        out = attention(q, k, v, scale, case.causal)
+        reference = F.scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            is_causal=case.causal,
+            scale=scale,
+        )
+
+        self.assertTrue(torch.isfinite(out).all().item())
+        measured_snr = snr_db(out, reference)
+        self.assertGreaterEqual(
+            measured_snr,
+            MIN_SNR_DB,
+            f"{case}: {measured_snr:.2f} dB SNR is below the {MIN_SNR_DB:.2f} dB floor",
+        )
+        actual_rows, reference_rows = sampled_fp32_attention(
+            out,
+            q,
+            k,
+            v,
+            scale,
+            case.causal,
+        )
+        torch.testing.assert_close(actual_rows, reference_rows, atol=2e-2, rtol=2e-2)
+
+        del q, k, v, out, reference, actual_rows, reference_rows
+        gc.collect()
+        torch.cuda.empty_cache()
+
+    def test_numerical_matrix(self):
+        if self._run_isolated():
+            return
+
+        for case in correctness_cases():
+            with self.subTest(case=case):
+                self._check_case(case)
+
+    def test_performance(self):
+        if self._run_isolated():
+            return
+
+        attention = self._attention()
+        case = PERFORMANCE_CASE
+        torch.manual_seed(42)
+        shape = (case.batch, case.heads, case.seq_len, case.head_dim)
+        q = torch.randn(shape, dtype=case.dtype, device="cuda")
+        k = torch.randn_like(q)
+        v = torch.randn_like(q)
+        scale = 1.0 / math.sqrt(case.head_dim)
+
+        fn = lambda: attention(q, k, v, scale, case.causal)
+        out = fn()
+        reference = F.scaled_dot_product_attention(q, k, v, scale=scale)
+        self.assertTrue(torch.isfinite(out).all().item())
+        measured_snr = snr_db(out, reference)
+        self.assertGreaterEqual(measured_snr, MIN_SNR_DB)
+        actual_rows, reference_rows = sampled_fp32_attention(
+            out, q, k, v, scale, case.causal
+        )
+        torch.testing.assert_close(actual_rows, reference_rows, atol=2e-2, rtol=2e-2)
+
+        latencies_ms = [
+            triton.testing.do_bench(fn, warmup=500, rep=500, return_mode="median")
+            for _ in range(3)
+        ]
+        median_ms = statistics.median(latencies_ms)
+        measured_tflops = attention_flops(case) * 1e-12 / (median_ms * 1e-3)
+        print(
+            f"\nTLX AMD FA cluster: windows_ms={latencies_ms}, median_ms={median_ms:.4f}, "
+            f"throughput={measured_tflops:.1f} TFLOP/s, reference={REFERENCE_TFLOPS:.1f} TFLOP/s"
+        )
+        assert_performance(measured_tflops)

--- a/tritonbench/operators/flash_attention/tlx_cluster_regression.py
+++ b/tritonbench/operators/flash_attention/tlx_cluster_regression.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import torch
+
+
+REFERENCE_TFLOPS = 1010.5
+MIN_TFLOPS = 925.0
+MIN_SNR_DB = 35.0
+
+
+@dataclass(frozen=True)
+class AttentionCase:
+    dtype: torch.dtype
+    batch: int
+    heads: int
+    seq_len: int
+    head_dim: int
+    causal: bool
+
+
+_DTYPES = (torch.float16, torch.bfloat16)
+_MASKS = (False, True)
+_D128_SEQUENCE_LENGTHS = (512, 1024, 2048, 4096, 8192, 16384)
+
+
+def correctness_cases() -> tuple[AttentionCase, ...]:
+    d128 = tuple(
+        AttentionCase(dtype, 16384 // seq_len, 64, seq_len, 128, causal)
+        for dtype in _DTYPES
+        for causal in _MASKS
+        for seq_len in _D128_SEQUENCE_LENGTHS
+    )
+    d64 = tuple(
+        AttentionCase(dtype, 16, 64, 1024, 64, causal)
+        for dtype in _DTYPES
+        for causal in _MASKS
+    )
+    return d128 + d64
+
+
+PERFORMANCE_CASE = AttentionCase(
+    dtype=torch.bfloat16,
+    batch=1,
+    heads=64,
+    seq_len=16384,
+    head_dim=128,
+    causal=False,
+)
+
+
+def attention_flops(case: AttentionCase) -> float:
+    attended_pairs = (
+        case.seq_len * (case.seq_len + 1) // 2 if case.causal else case.seq_len**2
+    )
+    return 4.0 * case.batch * case.heads * attended_pairs * case.head_dim
+
+
+def snr_db(actual: torch.Tensor, expected: torch.Tensor) -> float:
+    actual = actual.float()
+    expected = expected.float()
+    signal = torch.linalg.vector_norm(expected)
+    noise = torch.linalg.vector_norm(actual - expected)
+    if noise.item() == 0.0:
+        return float("inf")
+    if signal.item() == 0.0:
+        return float("-inf")
+    return float(20.0 * torch.log10(signal / noise))
+
+
+def sample_indices(size: int) -> tuple[int, ...]:
+    if size <= 0:
+        raise ValueError(f"size must be positive, got {size}")
+    return tuple(dict.fromkeys((0, size // 2, size - 1)))
+
+
+def sampled_fp32_attention(
+    actual: torch.Tensor,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    scale: float,
+    causal: bool,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    batch_indices = sample_indices(q.shape[0])
+    head_indices = sample_indices(q.shape[1])
+    query_indices = sample_indices(q.shape[2])
+    query_positions = torch.tensor(query_indices, device=q.device)
+    key_positions = torch.arange(k.shape[2], device=q.device)
+    actual_rows = []
+    reference_rows = []
+    for batch in batch_indices:
+        for head in head_indices:
+            q_rows = q[batch, head, query_positions].float()
+            k_rows = k[batch, head].float()
+            v_rows = v[batch, head].float()
+            scores = torch.matmul(q_rows, k_rows.transpose(0, 1)) * scale
+            if causal:
+                scores.masked_fill_(
+                    key_positions[None, :] > query_positions[:, None],
+                    float("-inf"),
+                )
+            reference_rows.append(torch.matmul(torch.softmax(scores, dim=-1), v_rows))
+            actual_rows.append(actual[batch, head, query_positions].float())
+    return torch.cat(actual_rows), torch.cat(reference_rows)
+
+
+def assert_performance(measured_tflops: float) -> None:
+    if not math.isfinite(measured_tflops) or measured_tflops <= 0.0:
+        raise AssertionError(
+            f"invalid throughput: {measured_tflops} TFLOP/s; expected a finite and positive value"
+        )
+    if measured_tflops < MIN_TFLOPS:
+        raise AssertionError(
+            f"PERF REGRESSION: {measured_tflops:.1f} TFLOP/s < "
+            f"{MIN_TFLOPS:.1f} TFLOP/s floor "
+            f"({REFERENCE_TFLOPS:.1f} TFLOP/s reference)"
+        )


### PR DESCRIPTION
## Summary

This PR adds dedicated regression coverage for the optimized gfx950 TLX cluster Flash Attention
forward provider.

- Check all 24 D128 FP16/BF16, causal/non-causal configurations from the optimization matrix.
- Add four D64 smoke configurations across both dtypes and mask modes.
- Require finite output, at least 35 dB SNR against SDPA, and sampled agreement with an explicit
  FP32 attention reference.
- Add a performance guard for BF16 `(B=1, H=64, N=16384, D=128, non-causal)`.
- Run the suite in a focused MI350 `meta-triton` CI job.

Both GPU tests compile in isolated child processes with
`DISABLE_LLVM_OPT=disable-machine-sink`. This matches the optimized configuration without leaking
the process-global LLVM option into unrelated tests.

## Performance guard

| Config | Reference | Local verification | Required floor |
| --- | ---: | ---: | ---: |
| `BF16, B=1, H=64, N=16384, D=128, non-causal` | 1010.5 TFLOP/s | 990.0 TFLOP/s | 925.0 TFLOP/s |

Timing uses the median of three independent windows, each with 500 ms warmup and 500 ms
measurement. The floor retains a clear separation from the 772.5 TFLOP/s pre-optimization result
while allowing for observed MI350 device variation.

## Test plan

- `python -m pytest -s --tb=short test/test_cpu/test_flash_attention_tlx.py` — 6 passed
- `python -m unittest test.test_gpu.test_flash_attention_tlx_regression -v` — 2 passed
  - numerical matrix: all 28 configurations passed
  - performance: 990.0 TFLOP/s
- Pinned `ufmt` check: passed
- Workflow YAML parsing: passed
- `bash -n .ci/tritonbench/test-gpu.sh`: passed
- `git diff --check upstream/main...HEAD`: passed