### PR TITLE
Add Hopper TLX Flash Attention kernel

### DIFF
--- a/tritonbench/metadata/oss_cuda_kernels.yaml
+++ b/tritonbench/metadata/oss_cuda_kernels.yaml
@@ -191,6 +191,9 @@ flash_attention:
     - tilelang
   tk:
     tags: []
+  tlx_fa:
+    tags:
+    - tlx
   triton_tutorial_flash_v2:
     kernels:
     - _attn_fwd_tma_ws_persistent

--- a/tritonbench/operators/flash_attention/operator.py
+++ b/tritonbench/operators/flash_attention/operator.py
@@ -419,7 +419,6 @@ class Operator(BenchmarkOperator):
                 and _tlx_amd_fa_backward is not None
             )
         ),
-        fwd_only=IS_HOPPER,
         tags=["tlx"] + (["amd", "gfx950"] if is_hip_mi350() else []),
     )
     @multi_input_wrapper

--- a/tritonbench/operators/flash_attention/operator.py
+++ b/tritonbench/operators/flash_attention/operator.py
@@ -51,7 +51,7 @@ from tritonbench.kernels.proton_fused_attention import (
 from tritonbench.kernels.triton_fused_attention import (
     attention_opt as triton_tutorial_FA2_opt,
 )
-from tritonbench.utils.env_utils import IS_BLACKWELL, is_hip, is_hip_mi350
+from tritonbench.utils.env_utils import IS_BLACKWELL, IS_HOPPER, is_hip, is_hip_mi350
 from tritonbench.utils.path_utils import add_ld_library_path
 from tritonbench.utils.python_utils import try_import
 from tritonbench.utils.triton_op import is_fbcode
@@ -135,6 +135,18 @@ if has_tlx():
         _validate_tlx_amd_fa_cluster_inputs = None
 
     try:
+        from triton.language.extra.tlx.tutorials.hopper_fa_ws_pipelined_pingpong import (
+            attention as _tlx_hopper_fa,
+        )
+
+        HAS_TLX_HOPPER_FA = True
+    except (ImportError, ModuleNotFoundError) as error:
+        if IS_HOPPER:
+            logger.warning("Hopper TLX Flash Attention is unavailable: %s", error)
+        HAS_TLX_HOPPER_FA = False
+        _tlx_hopper_fa = None
+
+    try:
         from triton.language.extra.tlx.tutorials.amd_fa_pipelined import (
             attention as _tlx_amd_fa_pipelined,
         )
@@ -143,6 +155,8 @@ if has_tlx():
 else:
     _tlx_amd_fa_cluster = None
     _validate_tlx_amd_fa_cluster_inputs = None
+    HAS_TLX_HOPPER_FA = False
+    _tlx_hopper_fa = None
     _tlx_amd_fa_pipelined = None
 
 if has_tlx() and is_hip_mi350():
@@ -398,14 +412,32 @@ class Operator(BenchmarkOperator):
 
     @register_benchmark(
         enabled=(
-            is_hip_mi350()
-            and _tlx_amd_fa_pipelined is not None
-            and _tlx_amd_fa_backward is not None
+            (IS_HOPPER and HAS_TLX_HOPPER_FA)
+            or (
+                is_hip_mi350()
+                and _tlx_amd_fa_pipelined is not None
+                and _tlx_amd_fa_backward is not None
+            )
         ),
-        tags=["tlx", "amd", "gfx950"],
+        fwd_only=IS_HOPPER,
+        tags=["tlx"] + (["amd", "gfx950"] if is_hip_mi350() else []),
     )
     @multi_input_wrapper
-    def tlx_amd_fa_pipelined(self, *args) -> Tuple[Callable, Callable]:
+    def tlx_fa(self, *args) -> Tuple[Callable, Callable]:
+        if IS_HOPPER:
+            if self.D_HEAD < 128:
+                raise NotImplementedError("Skip")
+            if self.causal:
+                raise NotImplementedError("Hopper TLX FA does not support causal attention")
+
+            tlx_attention = _tlx_hopper_fa
+            assert tlx_attention is not None
+
+            def fn(q, k, v):
+                return tlx_attention(q, k, v, self.sm_scale)
+
+            return preproc_noop, fn
+
         tlx_attention = _tlx_amd_fa_pipelined
         assert tlx_attention is not None
         config = {


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookexperimental/triton/pull/3463

Update the Hopper TLX Flash Attention pingpong kernel to use exclusive async tasks for the forward pipeline and add the backward implementation.

The backward path uses a FA3-style `BLOCK_N=128` split across two MMA consumer groups. Each group owns one 64-row K/V slice, accumulates and stores its own `dK`/`dV` slice, and contributes `dQ` through the TMA reduce path. Shared-linear allocations use unpinned NVMMA atom views for TMA and MMA operands.

The final backward optimization was authored by the TLX kernel optimization agent. Its winning candidate improves overlap by consuming the computed probability tile directly for dV and waiting for the reusable dQ store buffer before overwriting it. Remove the stale Hopper forward-only Tritonbench registration so the unified `tlx_fa` backend supports `--mode bwd`.

Backward performance on H100, BF16, head dimension 128:

| Input `(B, H, S_q, S_kv, D)` | `flash_v3` TFLOP/s | `tlx_fa` TFLOP/s | `tlx_fa / flash_v3` |
| --- | ---: | ---: | ---: |
| `(4, 48, 1024, 1024, 128)` | 313.324 | 327.853 | 104.6% |
| `(4, 48, 2048, 2048, 128)` | 434.825 | 433.905 | 99.8% |
| `(4, 48, 4096, 4096, 128)` | 519.827 | 503.016 | 96.8% |
| `(4, 48, 8192, 8192, 128)` | 561.410 | 527.083 | 93.9% |
| **Average** | **457.347** | **447.964** | **97.9%** |

TLX agent authored.

Differential Revision: D118546218
