### PR TITLE
[ci] remove amd tlx test

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -19,13 +19,6 @@ jobs:
     uses: ./.github/workflows/_linux-test-mi350.yml
     with:
       conda_env: "triton-main"
-  mi350-meta-triton-tlx-test:
-    uses: ./.github/workflows/_linux-test-mi350.yml
-    with:
-      conda_env: "meta-triton"
-      test_module: "test.test_gpu.test_flash_attention_tlx_regression"
-
-
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}


### PR DESCRIPTION
The main tritonbench repo CI does not test against meta-triton by default as we have limited CI resources.

We should use https://github.com/facebookexperimental/triton repo to implement the TLX CI.

cc @bangtianliu 