### PR TITLE
[power] add p50 and mean bar to histogram

### DIFF
--- a/tritonbench/components/power/charts.py
+++ b/tritonbench/components/power/charts.py
@@ -1,8 +1,7 @@
 import csv
 import logging
 import os
-import signal
-import subprocess
+import statistics
 import time
 
 import matplotlib.pyplot as plt
@@ -105,7 +104,23 @@ def plot_latencies(output_dir, gpu_id, metrics: "BenchmarkOperatorResult") -> No
         plt.figure(figsize=(10, 6))
         for backend in result_dict[x_val]:
             latency_times = result_dict[x_val][backend].latency.times[1:]
-            plt.hist(latency_times, bins=50, alpha=0.5, label=backend)
+            _, _, patches = plt.hist(latency_times, bins=50, alpha=0.5, label=backend)
+            if latency_times:
+                color = patches[0].get_facecolor()
+                p50 = statistics.median(latency_times)
+                mean = statistics.fmean(latency_times)
+                plt.axvline(
+                    p50,
+                    color=color,
+                    linestyle="--",
+                    label=f"{backend} p50 ({p50:.3f} ms)",
+                )
+                plt.axvline(
+                    mean,
+                    color=color,
+                    linestyle=":",
+                    label=f"{backend} mean ({mean:.3f} ms)",
+                )
         plt.legend()
         plt.xlabel("Latency (ms)")
         plt.ylabel("Count")


### PR DESCRIPTION
Test plan:

```
python run.py --op gemm --only aten_matmul --num-inputs 1 --power-chart --output-dir=/tmp/test_aten_matmul_latency --metrics latency --rep 3000 --warmup 1000
```


<img width="2552" height="1638" alt="image" src="https://github.com/user-attachments/assets/c99b8ec5-44e5-4d6f-bc97-a6985a26ff23" />
