### PR TITLE
[ciq] stripe nccl envs from benchmark mode

### DIFF
--- a/benchmarks/common.py
+++ b/benchmarks/common.py
@@ -41,6 +41,35 @@ from tritonbench.utils.path_utils import REPO_PATH
 
 BENCHMARKS_OUTPUT_DIR = REPO_PATH.joinpath(".benchmarks")
 
+# When a benchmark driver is itself launched by torchrun (e.g. on MAST), its
+# torchelastic env vars would otherwise be inherited by every benchmark
+# subprocess it spawns. Tritonbench's set_torchrun_env() keys off
+# TORCHELASTIC_RUN_ID + LOCAL_RANK: it would init a NCCL process group (which
+# these single-GPU drivers have no use for, and which fails outright when no
+# NCCL net plugin is available) and reset CUDA_VISIBLE_DEVICES to LOCAL_RANK,
+# overriding whichever GPU the driver picked for the subprocess.
+TORCHRUN_ENV_VARS = (
+    "LOCAL_RANK",
+    "RANK",
+    "GROUP_RANK",
+    "ROLE_RANK",
+    "LOCAL_WORLD_SIZE",
+    "WORLD_SIZE",
+    "GROUP_WORLD_SIZE",
+    "ROLE_WORLD_SIZE",
+    "ROLE_NAME",
+    "MASTER_ADDR",
+    "MASTER_PORT",
+)
+
+
+def strip_torchrun_env(env):
+    """Drop the torchelastic/torchrun variables from `env`, in place."""
+    for key in list(env):
+        if key in TORCHRUN_ENV_VARS or key.startswith("TORCHELASTIC_"):
+            del env[key]
+    return env
+
 
 def post_run_callback(
     logger, benchmark_group_name, benchmark, output_file, output_files, disabled

--- a/benchmarks/compileiq_autotune/objective.py
+++ b/benchmarks/compileiq_autotune/objective.py
@@ -52,6 +52,7 @@ def run_tritonbench_in_temp_dir(
             knobs_file=knobs_file,
             config_file=tritonbench_config,
             mock=False,
+            verbose=verbose,
         )
     return results
 

--- a/benchmarks/compileiq_autotune/run.py
+++ b/benchmarks/compileiq_autotune/run.py
@@ -1,4 +1,5 @@
 import argparse
+import functools
 import logging
 import os
 import subprocess
@@ -146,6 +147,7 @@ def search(
     tritonbench_config,
     search_space,
     has_manifold=False,
+    verbose=False,
 ):
     # Remove the .yaml extension
     tritonbench_config_name = os.path.splitext(tritonbench_config)[0]
@@ -195,8 +197,13 @@ def search(
         problem_type=problem_type,
         num_objectives=1,
     )
+    # The RAY workers are separate processes, so the flag has to travel with the
+    # objective function itself rather than through module state.
+    objective = (
+        functools.partial(objective_func, verbose=True) if verbose else objective_func
+    )
     tuner = Search(
-        objective_function=objective_func,
+        objective_function=objective,
         search_space=search_space_bin,
         search_config=main_config,
         worker_type=WorkerTypes.RAY,
@@ -291,6 +298,11 @@ def get_parser():
         type=str,
         default=DEFAULT_SEARCH_SPACE,
         help="The CompileIQ ptxas search space. Either a local path or a manifold:// URI.",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help=f"Save the full stdout/stderr of every Tritonbench run to {REPO_WORK_DIR}.",
     )
     return parser
 
@@ -388,6 +400,7 @@ def run(args: Optional[List[str]] = None):
             tritonbench_config=args.tritonbench_config,
             search_space=args.search_space,
             has_manifold=has_manifold,
+            verbose=args.verbose,
         )
 
 

--- a/benchmarks/compileiq_autotune/run.py
+++ b/benchmarks/compileiq_autotune/run.py
@@ -270,6 +270,27 @@ def search(
                 f"[tritonbench_compileiq] Failed to extract best configs or write validation script: {e}"
             )
 
+        # In verbose mode the work dir holds the full stdout/stderr of every
+        # Tritonbench run, so ship the whole thing to the manifold mount.
+        if verbose:
+            verbose_target = os.path.join(target_path, REPO_WORK_DIR.name)
+            logger.info(
+                f"[tritonbench_compileiq] Uploading {REPO_WORK_DIR} to manifold mount: {verbose_target}"
+            )
+            try:
+                subprocess.run(["mkdir", "-p", target_path], check=True)
+                subprocess.run(
+                    ["cp", "-r", str(REPO_WORK_DIR), verbose_target],
+                    check=True,
+                )
+                logger.info(
+                    f"[tritonbench_compileiq] Upload complete: {MANIFOLD_URI_PREFIX}/{manifold_path}/{REPO_WORK_DIR.name}"
+                )
+            except subprocess.CalledProcessError as e:
+                logger.error(
+                    f"[tritonbench_compileiq] Failed to upload {REPO_WORK_DIR} to manifold: {e}"
+                )
+
 
 def get_parser():
     parser = argparse.ArgumentParser(description="Top level for the CompileIQ Search.")
@@ -302,7 +323,8 @@ def get_parser():
     parser.add_argument(
         "--verbose",
         action="store_true",
-        help=f"Save the full stdout/stderr of every Tritonbench run to {REPO_WORK_DIR}.",
+        help=f"Save the full stdout/stderr of every Tritonbench run to {REPO_WORK_DIR}, "
+        "and upload that directory to the manifold mount at the end of a MAST job.",
     )
     return parser
 

--- a/benchmarks/compileiq_autotune/run.py
+++ b/benchmarks/compileiq_autotune/run.py
@@ -2,6 +2,7 @@ import argparse
 import functools
 import logging
 import os
+import shutil
 import subprocess
 import sys
 from typing import List, Optional
@@ -110,25 +111,35 @@ def write_validate_script(output_dir, tritonbench_config, acf_file):
     """Write a validate.sh into output_dir that re-applies an ACF config and re-runs
     the ptxas check for the search's tritonbench config.
 
+    The tritonbench config file is copied into output_dir alongside validate.sh,
+    so validation runs with the copied config in the same directory instead of
+    reaching back into the tritonbench checkout.
+
     TRITONBENCH_ROOT and CIQ_ACF can be overridden via env vars; they default to a
     local tritonbench checkout and the best extracted ACF file respectively.
     """
+    os.makedirs(output_dir, exist_ok=True)
+    config_basename = os.path.basename(tritonbench_config)
+    shutil.copy(
+        os.path.join(TRITONBENCH_CONFIGS_DIR, tritonbench_config),
+        os.path.join(output_dir, config_basename),
+    )
+    acf_basename = os.path.basename(acf_file)
     script = f"""CURDIR=$PWD
 
 if [ -z ${{TRITONBENCH_ROOT:-}} ]; then
   TRITONBENCH_ROOT=$HOME/local/tritonbench
 fi
 
-TRITONBENCH_CONFIGS_DIR=$TRITONBENCH_ROOT/benchmarks/run_config
-TRITONBENCH_CONFIG_FILE={tritonbench_config}
+TRITONBENCH_CONFIG_FILE={config_basename}
 
 if [ ! -f $CURDIR/$CIQ_ACF ]; then
-  CIQ_ACF="{acf_file}"
+  CIQ_ACF="{acf_basename}"
 fi
 
 cd $TRITONBENCH_ROOT
 
-PTXAS_OPTIONS="--apply-controls=$CURDIR/$CIQ_ACF" TRITONBENCH_RUN_CONFIG="$TRITONBENCH_CONFIGS_DIR/$TRITONBENCH_CONFIG_FILE" python -m benchmarks.ptxas_check.run
+PTXAS_OPTIONS="--apply-controls=$CURDIR/$CIQ_ACF" TRITONBENCH_RUN_CONFIG="$CURDIR/$TRITONBENCH_CONFIG_FILE" python -m benchmarks.ptxas_check.run
 
 cd -
 """

--- a/benchmarks/compileiq_autotune/shim.py
+++ b/benchmarks/compileiq_autotune/shim.py
@@ -93,6 +93,23 @@ def extract_performance_metric(output):
     return float(last_line.split()[-1])
 
 
+def save_verbose_logs(stdout, stderr, output_dir=REPO_WORK_DIR):
+    """Dump the full, untruncated tritonbench output to `output_dir`.
+
+    The timestamp carries microseconds because the search runs one benchmark per
+    GPU in parallel, and several of them can finish within the same second.
+    """
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    log_files = []
+    for stream_name, content in (("stdout", stdout), ("stderr", stderr)):
+        log_file = output_dir.joinpath(f"tritonbench_{stream_name}_{timestamp}.log")
+        log_file.write_text(content or "")
+        log_files.append(str(log_file))
+    return log_files
+
+
 def truncate_output(
     output, limit=int(os.environ.get("TRITONBENCH_COMPILEIQ_LOG_CHARS", "2048"))
 ):
@@ -174,9 +191,19 @@ def run_tritonbench(
             )
             truncated_output_stdout = truncate_output(output.stdout)
             truncated_output_stderr = truncate_output(output.stderr)
+            if verbose:
+                print(
+                    f"[GPU ID {GPU_ID}] Saved Tritonbench output to: "
+                    f"{save_verbose_logs(output.stdout, output.stderr)}"
+                )
         except subprocess.TimeoutExpired as e:
             truncated_output_stdout = truncate_output(e.stdout)
             truncated_output_stderr = truncate_output(e.stderr)
+            if verbose:
+                print(
+                    f"[GPU ID {GPU_ID}] Saved Tritonbench output to: "
+                    f"{save_verbose_logs(e.stdout, e.stderr)}"
+                )
             error_msg = f"[GPU ID {GPU_ID}] Timeout ({RUN_TIMEOUT_SEC}s) running Tritonbench. stdout: {truncated_output_stdout}, stderr: {truncated_output_stderr}"
             print(error_msg)
             raise RuntimeError(error_msg)

--- a/benchmarks/compileiq_autotune/shim.py
+++ b/benchmarks/compileiq_autotune/shim.py
@@ -10,7 +10,7 @@ import pandas as pd
 import yaml
 from compileiq.utils.helpers import save_compiler_config
 
-from ..common import REPO_PATH
+from ..common import REPO_PATH, strip_torchrun_env
 
 REPO_WORK_DIR = Path("/tmp/tritonbench_compileiq_search")
 DEFAULT_CONFIG_FILE = "gemm_config_3.yaml"
@@ -20,26 +20,6 @@ CONTEXT_FILE = "context.json"
 # the kernel on its first launch, and every such candidate burns the whole timeout on
 # a GPU, so keep it close to the expected runtime rather than generously large.
 RUN_TIMEOUT_SEC = int(os.environ.get("TRITONBENCH_COMPILEIQ_TIMEOUT", "360"))
-
-# On MAST the search driver is launched by torchrun, and its torchelastic env
-# vars would otherwise be inherited by every benchmark subprocess we spawn.
-# Tritonbench's set_torchrun_env() keys off TORCHELASTIC_RUN_ID + LOCAL_RANK: it
-# would init a NCCL process group (which the search has no use for, and which
-# fails outright when no NCCL net plugin is available) and reset
-# CUDA_VISIBLE_DEVICES to LOCAL_RANK, pinning every Ray worker to the same GPU.
-TORCHRUN_ENV_VARS = (
-    "LOCAL_RANK",
-    "RANK",
-    "GROUP_RANK",
-    "ROLE_RANK",
-    "LOCAL_WORLD_SIZE",
-    "WORLD_SIZE",
-    "GROUP_WORLD_SIZE",
-    "ROLE_WORLD_SIZE",
-    "ROLE_NAME",
-    "MASTER_ADDR",
-    "MASTER_PORT",
-)
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -139,18 +119,6 @@ def truncate_output(
     return output[-min(limit, len(output)) :]
 
 
-def strip_torchrun_env(env):
-    """Drop the torchelastic/torchrun variables from `env`, in place.
-
-    Each candidate is a plain single-GPU benchmark on the GPU Ray gave the
-    worker, so it must not inherit the driver's distributed rendezvous.
-    """
-    for key in list(env):
-        if key in TORCHRUN_ENV_VARS or key.startswith("TORCHELASTIC_"):
-            del env[key]
-    return env
-
-
 def write_encrypted_knobs(config: dict | bytes, knobs_file: str):
     """
     To be used if encrypted knobs are provided.
@@ -188,6 +156,8 @@ def run_tritonbench(
     else:
         knobs_env = ""
 
+    # Each candidate is a plain single-GPU run on the GPU Ray assigned to this
+    # worker, so it must not inherit the driver's torchrun rendezvous.
     cmd_env = strip_torchrun_env(os.environ.copy())
     assert os.path.exists(f"{workdir}/{config_file}")
     assert os.path.exists(REPO_PATH.joinpath("run.py")), (

--- a/benchmarks/compileiq_autotune/shim.py
+++ b/benchmarks/compileiq_autotune/shim.py
@@ -21,6 +21,26 @@ CONTEXT_FILE = "context.json"
 # a GPU, so keep it close to the expected runtime rather than generously large.
 RUN_TIMEOUT_SEC = int(os.environ.get("TRITONBENCH_COMPILEIQ_TIMEOUT", "360"))
 
+# On MAST the search driver is launched by torchrun, and its torchelastic env
+# vars would otherwise be inherited by every benchmark subprocess we spawn.
+# Tritonbench's set_torchrun_env() keys off TORCHELASTIC_RUN_ID + LOCAL_RANK: it
+# would init a NCCL process group (which the search has no use for, and which
+# fails outright when no NCCL net plugin is available) and reset
+# CUDA_VISIBLE_DEVICES to LOCAL_RANK, pinning every Ray worker to the same GPU.
+TORCHRUN_ENV_VARS = (
+    "LOCAL_RANK",
+    "RANK",
+    "GROUP_RANK",
+    "ROLE_RANK",
+    "LOCAL_WORLD_SIZE",
+    "WORLD_SIZE",
+    "GROUP_WORLD_SIZE",
+    "ROLE_WORLD_SIZE",
+    "ROLE_NAME",
+    "MASTER_ADDR",
+    "MASTER_PORT",
+)
+
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
@@ -119,6 +139,18 @@ def truncate_output(
     return output[-min(limit, len(output)) :]
 
 
+def strip_torchrun_env(env):
+    """Drop the torchelastic/torchrun variables from `env`, in place.
+
+    Each candidate is a plain single-GPU benchmark on the GPU Ray gave the
+    worker, so it must not inherit the driver's distributed rendezvous.
+    """
+    for key in list(env):
+        if key in TORCHRUN_ENV_VARS or key.startswith("TORCHELASTIC_"):
+            del env[key]
+    return env
+
+
 def write_encrypted_knobs(config: dict | bytes, knobs_file: str):
     """
     To be used if encrypted knobs are provided.
@@ -156,7 +188,7 @@ def run_tritonbench(
     else:
         knobs_env = ""
 
-    cmd_env = os.environ.copy()
+    cmd_env = strip_torchrun_env(os.environ.copy())
     assert os.path.exists(f"{workdir}/{config_file}")
     assert os.path.exists(REPO_PATH.joinpath("run.py")), (
         f"run.py not found in {REPO_PATH}"

--- a/benchmarks/power_analysis/run.py
+++ b/benchmarks/power_analysis/run.py
@@ -5,6 +5,11 @@ Perform power and performance analysis on a Triton kernel.
 import argparse
 import logging
 import os
+import re
+import subprocess
+import tempfile
+
+import yaml
 
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -16,62 +21,118 @@ from ..common import setup_tritonbench_cwd
 
 setup_tritonbench_cwd()
 
-from tritonbench.utils.run_utils import load_operator_by_args
+from tritonbench.utils.run_utils import load_operator_by_args, run_config
 
-REPCNT = 2000
-
-
-workloads = [
-    # gemm
-    [
-        "--op",
-        "gemm",
-        "--only",
-        "aten_matmul,triton_tutorial_matmul,triton_blackwell_warpspec_persistent_matmul",
-        "--m",
-        "4096",
-        "--n",
-        "4096",
-        "--k",
-        "4096",
-        "--repcnt",
-        "2000",
-        "--force",
-    ],
-    # blackwell_attention
-    # rms norm
-    [
-        "--op",
-        "rms_norm",
-        "--only",
-        "triton_tutorial_rms_norm",
-        "--repcnt",
-        "2000",
-        "--force",
-    ],
-    #
-]
-
+# Manifold bucket path (without the ``manifold://`` scheme) that receives the
+# uploaded power-analysis output directories.
+MANIFOLD_DEST = "tc_bench_ci/tree/power_analysis"
 
 def get_parser():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--repcnt", type=int, default=REPCNT)
+    parser.add_argument(
+        "--tritonbench-config",
+        type=str,
+        required=True,
+        default=None,
+        help="Path to a tritonbench config file (e.g. benchmarks/run_config/*.yaml). "
+        "The config is rewritten with power-analysis flags appended to its "
+        "common args and then run.",
+    )
+    parser.add_argument(
+        "--repeat",
+        type=int,
+        default=20,
+        help="Number of A/B repeats. Fills the --ab-repeat value appended to "
+        "the config's common args.",
+    )
     return parser
 
 
-if __name__ == "__main__":
+def build_power_common_args(output_dir, repeat):
+    """Power-analysis flags appended to the config's common args."""
+    result_json = os.path.join(output_dir, "result.json")
+    # NOTE: --side-a must use the bare `--side-a=` form, not `--side-a=""`.
+    # Common args are split on spaces with no shell involved, so quotes would
+    # survive literally: argparse would see the value '""', which parses to a
+    # phantom empty-string arg that operators reject with
+    # "run.py: error: unrecognized arguments: ".
+    return (
+        "--power-chart "
+        f"--ab-repeat={repeat} "
+        "--side-a= "
+        f"--output-json {result_json} "
+        f"--output-dir={output_dir}"
+    )
+
+
+def get_output_dir():
+    """Tmp dir holding this run's rewritten config and outputs.
+
+    Under MAST (``MAST_HPC_JOB_NAME`` set) the dir is named after the MAST
+    job ID so runs are identifiable; otherwise a unique
+    ``tritonbench_power_analysis_<XXXXX>`` dir is created.
+    """
+    mast_job_id = os.environ.get("MAST_HPC_JOB_NAME")
+    if mast_job_id:
+        output_dir = os.path.join(
+            tempfile.gettempdir(),
+            re.sub(r"[^A-Za-z0-9_.-]", "_", mast_job_id),
+        )
+        os.makedirs(output_dir, exist_ok=True)
+        return output_dir
+    return tempfile.mkdtemp(prefix="tritonbench_power_analysis_")
+
+
+def rewrite_config_with_power_args(config_path, output_dir, repeat):
+    """Copy `config_path` into `output_dir` with power flags in common args.
+
+    Returns the path of the rewritten config file.
+    """
+    with open(config_path, "r") as f:
+        config = yaml.safe_load(f) or {}
+    common_args = (config.get("common_args") or "").strip()
+    extra_args = build_power_common_args(output_dir, repeat)
+    config["common_args"] = f"{common_args} {extra_args}".strip()
+    rewritten_path = os.path.join(output_dir, os.path.basename(config_path))
+    with open(rewritten_path, "w") as f:
+        # A wide width keeps each arg string on a single line. The default
+        # width (80) folds long scalars into continuation lines, turning them
+        # into multi-line strings in the rewritten config.
+        yaml.safe_dump(config, f, width=4096)
+    return rewritten_path
+
+
+def upload_to_manifold(local_dir):
+    """Recursively upload `local_dir` under MANIFOLD_DEST."""
+    dest = f"{MANIFOLD_DEST}/{os.path.basename(local_dir)}"
+    cmd = ["manifold", "putr", local_dir, dest]
+    logger.info(f"Uploading {local_dir} to manifold://{dest}")
+    subprocess.run(cmd, check=True)
+    logger.info(f"Upload complete: manifold://{dest}")
+
+
+def run_with_config(config_path, repeat):
+    """Run power analysis for a tritonbench config file.
+
+    Rewrites the config with power-analysis flags, runs tritonbench with it,
+    then uploads the output dir to manifold. Returns the output dir.
+    """
+    if not os.path.exists(config_path):
+        raise FileNotFoundError(f"Tritonbench config file not found: {config_path}")
+    output_dir = get_output_dir()
+    logger.info(f"Power analysis output dir: {output_dir}")
+    rewritten_config = rewrite_config_with_power_args(config_path, output_dir, repeat)
+    logger.info(f"Rewritten tritonbench config: {rewritten_config}")
+    run_config(rewritten_config, [])
+    upload_to_manifold(output_dir)
+    return output_dir
+
+
+def run(argv=None):
     parser = get_parser()
-    args = parser.parse_args()
-    tb_args = [
-        "--op",
-        "gemm",
-        "--num-inputs",
-        "1",
-        "--only",
-        "triton_tutorial_matmul",
-        "--repcnt",
-        "2000",
-        "--power-chart",
-    ]
-    opbench = load_operator_by_args(tb_args)
-    opbench.run()
+    args = parser.parse_args(argv)
+    return run_with_config(args.tritonbench_config, args.repeat)
+
+
+if __name__ == "__main__":
+    run()

--- a/benchmarks/power_analysis/run.py
+++ b/benchmarks/power_analysis/run.py
@@ -7,6 +7,7 @@ import logging
 import os
 import re
 import subprocess
+import sys
 import tempfile
 
 import yaml
@@ -102,6 +103,21 @@ def rewrite_config_with_power_args(config_path, output_dir, repeat):
     return rewritten_path
 
 
+def unset_nccl_envs():
+    """Remove NCCL_* variables from the environment.
+
+    Stale NCCL plugin/config vars (e.g. from the launcher environment) can
+    break the benchmark subprocesses, which inherit os.environ. Returns the
+    removed vars so the caller can restore them afterwards.
+    """
+    removed = {}
+    for key in [key for key in os.environ if key.startswith("NCCL_")]:
+        removed[key] = os.environ.pop(key)
+    if removed:
+        logger.info(f"Unset NCCL env vars: {sorted(removed)}")
+    return removed
+
+
 def upload_to_manifold(local_dir):
     """Recursively upload `local_dir` under MANIFOLD_DEST."""
     dest = f"{MANIFOLD_DEST}/{os.path.basename(local_dir)}"
@@ -123,7 +139,11 @@ def run_with_config(config_path, repeat):
     logger.info(f"Power analysis output dir: {output_dir}")
     rewritten_config = rewrite_config_with_power_args(config_path, output_dir, repeat)
     logger.info(f"Rewritten tritonbench config: {rewritten_config}")
-    run_config(rewritten_config, [])
+    removed_nccl_envs = unset_nccl_envs()
+    try:
+        run_config(rewritten_config, [])
+    finally:
+        os.environ.update(removed_nccl_envs)
     upload_to_manifold(output_dir)
     return output_dir
 
@@ -135,4 +155,4 @@ def run(argv=None):
 
 
 if __name__ == "__main__":
-    run()
+    run(sys.argv[1:])

--- a/benchmarks/power_analysis/run.py
+++ b/benchmarks/power_analysis/run.py
@@ -139,11 +139,8 @@ def run_with_config(config_path, repeat):
     logger.info(f"Power analysis output dir: {output_dir}")
     rewritten_config = rewrite_config_with_power_args(config_path, output_dir, repeat)
     logger.info(f"Rewritten tritonbench config: {rewritten_config}")
-    removed_nccl_envs = unset_nccl_envs()
-    try:
-        run_config(rewritten_config, [])
-    finally:
-        os.environ.update(removed_nccl_envs)
+    cmd_env = strip_torchrun_env(os.environ.copy())
+    run_config(rewritten_config, extra_envs=cmd_env, override_envs=True)
     upload_to_manifold(output_dir)
     return output_dir
 

--- a/benchmarks/power_analysis/run.py
+++ b/benchmarks/power_analysis/run.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
 
-from ..common import setup_tritonbench_cwd
+from ..common import setup_tritonbench_cwd, strip_torchrun_env
 
 setup_tritonbench_cwd()
 
@@ -140,7 +140,7 @@ def run_with_config(config_path, repeat):
     rewritten_config = rewrite_config_with_power_args(config_path, output_dir, repeat)
     logger.info(f"Rewritten tritonbench config: {rewritten_config}")
     cmd_env = strip_torchrun_env(os.environ.copy())
-    run_config(rewritten_config, extra_envs=cmd_env, override_envs=True)
+    run_config(rewritten_config, [], extra_envs=cmd_env, override_envs=True)
     upload_to_manifold(output_dir)
     return output_dir
 

--- a/benchmarks/ptxas_check/run.py
+++ b/benchmarks/ptxas_check/run.py
@@ -13,7 +13,10 @@ Usage:
 import argparse
 import json
 import os
+import re
+import subprocess
 import sys
+import tempfile
 from typing import Any, Dict, List, Optional, Tuple
 
 import torch
@@ -236,15 +239,100 @@ def compare_outputs(dir_a: str, dir_b: str) -> Tuple[bool, List[str]]:
     return len(issues) == 0, issues
 
 
+def parse_validate_sh(validate_sh_path: str) -> Tuple[str, str]:
+    """Read a CompileIQ validate.sh, returning (acf_file, config_file) basenames.
+
+    Both files are expected to sit in the same directory as validate.sh.
+    """
+    with open(validate_sh_path, "r") as f:
+        content = f.read()
+    acf_match = re.search(r'CIQ_ACF="([^"]+)"', content)
+    config_match = re.search(r"TRITONBENCH_CONFIG_FILE=([^\s]+)", content)
+    if not acf_match or not config_match:
+        raise ValueError(
+            f"Could not parse ACF/config file names from {validate_sh_path}"
+        )
+    acf_file = acf_match.group(1).strip().strip("\"'")
+    config_file = config_match.group(1).strip().strip("\"'")
+    if not acf_file or not config_file:
+        raise ValueError(
+            f"Could not parse ACF/config file names from {validate_sh_path}"
+        )
+    return os.path.basename(acf_file), os.path.basename(config_file)
+
+
+def resolve_manifold_path(
+    manifold_path: str, dest_dir: Optional[str] = None
+) -> Tuple[str, str]:
+    """Download a manifold:// dir holding validate.sh and its referenced files.
+
+    Returns the (PTXAS_OPTIONS value, tritonbench run config path) derived by
+    reading validate.sh, both pointing at the downloaded copies.
+    """
+    if not manifold_path.startswith("manifold://"):
+        raise ValueError(
+            f"manifold path must start with 'manifold://': {manifold_path}"
+        )
+    stripped = manifold_path[len("manifold://") :]
+    dest = dest_dir or tempfile.mkdtemp(prefix="ptxas_check_manifold_")
+    os.makedirs(dest, exist_ok=True)
+    subprocess.run(["manifold", "getr", stripped, dest], check=True)
+    top_level = os.path.join(dest, "validate.sh")
+    if os.path.isfile(top_level):
+        validate_sh = top_level
+    else:
+        validate_sh = None
+        for root, _, files in os.walk(dest):
+            if "validate.sh" in files:
+                validate_sh = os.path.join(root, "validate.sh")
+                break
+    if validate_sh is None:
+        raise FileNotFoundError(
+            f"validate.sh not found under {dest} downloaded from {manifold_path}"
+        )
+    acf_name, config_name = parse_validate_sh(validate_sh)
+    base_dir = os.path.dirname(validate_sh)
+    acf_path = os.path.join(base_dir, acf_name)
+    config_path = os.path.join(base_dir, config_name)
+    missing = [p for p in (acf_path, config_path) if not os.path.isfile(p)]
+    if missing:
+        raise FileNotFoundError(
+            f"Files referenced by {validate_sh} are missing: {missing}"
+        )
+    return f"--apply-controls={acf_path}", config_path
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description="PTXAS Options Compatibility Check",
         usage="%(prog)s [options] -- <tritonbench args>",
     )
+    parser.add_argument(
+        "--manifold-path",
+        type=str,
+        default=None,
+        help="Manifold path (manifold://...) holding validate.sh with its ACF "
+        "and tritonbench config. Downloads it and validates by reading "
+        "validate.sh, overriding PTXAS_OPTIONS/TRITONBENCH_RUN_CONFIG.",
+    )
     args, extra_args = parser.parse_known_args()
 
     if "--" in extra_args:
         extra_args.remove("--")
+
+    if args.manifold_path is not None:
+        try:
+            ptxas_value, config_value = resolve_manifold_path(args.manifold_path)
+        except (
+            ValueError,
+            FileNotFoundError,
+            subprocess.CalledProcessError,
+            OSError,
+        ) as e:
+            print(f"[ptxas-check] ERROR: {e}")
+            return 1
+        os.environ["PTXAS_OPTIONS"] = ptxas_value
+        os.environ["TRITONBENCH_RUN_CONFIG"] = config_value
 
     ptxas_options = os.environ.get("PTXAS_OPTIONS", None)
     if ptxas_options is None:

--- a/benchmarks/ptxas_check/run.py
+++ b/benchmarks/ptxas_check/run.py
@@ -18,7 +18,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import torch
 
-from ..common import setup_output_dir, setup_tritonbench_cwd
+from ..common import setup_output_dir, setup_tritonbench_cwd, strip_torchrun_env
 
 
 setup_tritonbench_cwd()
@@ -279,14 +279,16 @@ def main() -> int:
     print("[ptxas-check] === Run 1: WITH PTXAS_OPTIONS ===")
     output_dir_with = os.path.join(output_dir, "with_ptxas_options")
     os.mkdir(output_dir_with)
-    env_with = os.environ.copy()
+    # Both runs are plain single-GPU benchmarks; passed to run_tritonbench with
+    # override_envs=True, so this dict is verbatim the subprocess environment.
+    env_with = strip_torchrun_env(os.environ.copy())
     rc1 = run_tritonbench(config_file, extra_args, output_dir_with, env_with)
     print()
 
     print("[ptxas-check] === Run 2: WITHOUT PTXAS_OPTIONS ===")
     output_dir_without = os.path.join(output_dir, "without_ptxas_options")
     os.mkdir(output_dir_without)
-    env_without = os.environ.copy()
+    env_without = strip_torchrun_env(os.environ.copy())
     env_without.pop("PTXAS_OPTIONS", None)
     rc2 = run_tritonbench(config_file, extra_args, output_dir_without, env_without)
     print()

--- a/benchmarks/run_config/gemm_tlx_matmul_ws_nt.yaml
+++ b/benchmarks/run_config/gemm_tlx_matmul_ws_nt.yaml
@@ -1,6 +1,6 @@
 gemm_tlx_matmul_ws_nt:
   args:
-    --op gemm --only tlx_matmul_ws --metrics tflops --rep 3000 --sleep 1.0 --force --layout nt --shapes 1024x12800x1152 --simple-output --cudagraph
+    --op gemm --only tlx_matmul_ws --metrics tflops --rep 3000 --sleep 1.0 --force --layout nt --shapes 1024x12800x1152 --simple-output
   envs:
     TRITON_ALWAYS_COMPILE=1
 

--- a/benchmarks/run_config/gemm_tlx_matmul_ws_nt.yaml
+++ b/benchmarks/run_config/gemm_tlx_matmul_ws_nt.yaml
@@ -3,4 +3,3 @@ gemm_tlx_matmul_ws_nt:
     --op gemm --only tlx_matmul_ws --metrics tflops --rep 3000 --sleep 1.0 --force --layout nt --shapes 1024x12800x1152 --simple-output
   envs:
     TRITON_ALWAYS_COMPILE=1
-

--- a/tritonbench/components/do_bench/run.py
+++ b/tritonbench/components/do_bench/run.py
@@ -49,7 +49,7 @@ class Latency:
         self.times = self._remove_outliers_iqr(times) if remove_outliers else times
 
     def __str__(self):
-        """By default, use p50"""
+        """By default, use mean"""
         return self.to_str()
 
     def _remove_outliers_iqr(self, data):
@@ -133,7 +133,7 @@ class Latency:
             other.p50 // self.p50 if isinstance(other, Latency) else other // self.p50
         )
 
-    def to_str(self, mode="p50") -> str:
+    def to_str(self, mode="mean") -> str:
         if mode == "p50":
             return str(self.p50)
         elif mode == "with_variance":

--- a/tritonbench/components/do_bench/run.py
+++ b/tritonbench/components/do_bench/run.py
@@ -49,7 +49,7 @@ class Latency:
         self.times = self._remove_outliers_iqr(times) if remove_outliers else times
 
     def __str__(self):
-        """By default, use mean"""
+        """By default, use p50"""
         return self.to_str()
 
     def _remove_outliers_iqr(self, data):
@@ -133,7 +133,7 @@ class Latency:
             other.p50 // self.p50 if isinstance(other, Latency) else other // self.p50
         )
 
-    def to_str(self, mode="mean") -> str:
+    def to_str(self, mode="p50") -> str:
         if mode == "p50":
             return str(self.p50)
         elif mode == "with_variance":


### PR DESCRIPTION
1. Add verbose mode for ciq_autotune - save all tritonbench run logs
2. Enable power analysis for distributed runs.
3. Improve ptxas_check

Test plan:

power_analysis:

https://www.internalfb.com/mlhub/pipelines/runs/mast/conda-torchrun-xzhao9-gjtqdxb0?job_attempt=0&version=0&tab=logs

compileiq:

https://www.internalfb.com/mlhub/pipelines/runs/mast/conda-torchrun-xzhao9-bm39c9q9?job_attempt=0&version=0&tab=summary

```
[ptxas-check] PTXAS Options Compatibility Check
[ptxas-check] PTXAS_OPTIONS: --apply-controls=/tmp/ptxas_check_manifold_xkjsl16s/conda-torchrun-xzhao9-bm39c9q9_v0_attempt0/gemm_tlx_matmul_ws_nt-1-893.6727202927771.acf
[ptxas-check] Config file: /tmp/ptxas_check_manifold_xkjsl16s/conda-torchrun-xzhao9-bm39c9q9_v0_attempt0/gemm_tlx_matmul_ws_nt.yaml
[ptxas-check] Extra args: []

[ptxas-check] === Run 1: WITH PTXAS_OPTIONS ===

[ptxas-check] === Run 2: WITHOUT PTXAS_OPTIONS ===

[ptxas-check] WARNING: Run with PTXAS_OPTIONS exited with code None
[ptxas-check] WARNING: Run without PTXAS_OPTIONS exited with code None
[ptxas-check] === COMPARISON ===
[ptxas-check] Comparing outputs:
[ptxas-check]   With PTXAS_OPTIONS: /data/users/xzhao9/tritonbench/.benchmarks/ptxas_check/run-20260909104912/with_ptxas_options
[ptxas-check]   Without PTXAS_OPTIONS: /data/users/xzhao9/tritonbench/.benchmarks/ptxas_check/run-20260909104912/without_ptxas_options

[ptxas-check] perf check: (893.6727202927771,) -> (894.5198098895746,) ✓
[ptxas-check] Warning: Autotune config missing in stderr.log files.
[ptxas-check] x_(1024, 12800, 1152)-input.pt: numerics match ✓
[ptxas-check] x_(1024, 12800, 1152)-tlx_matmul_ws-fwd-output.pt: numerics match ✓
[ptxas-check] === REPORT ===
[ptxas-check] ✓ SUCCESS: Outputs and configs match!
[ptxas-check] PTXAS_OPTIONS does not affect benchmark results.
```
