### PR TITLE
Ignore empty entries in `--op` list

### DIFF
--- a/tritonbench/utils/run_utils.py
+++ b/tritonbench/utils/run_utils.py
@@ -595,7 +595,7 @@ def tritonbench_run(args: Optional[List[str]] = None):
         assert torch.tpu.is_available(), "No TPU device available for --device tpu"
 
     if args.op:
-        ops = args.op.split(",")
+        ops = [op for op in args.op.split(",") if op]
     else:
         ops = list_operators_by_collection(args.op_collection)
 


### PR DESCRIPTION
Summary: A trailing comma in `--op <name>,` makes `args.op.split(",")` yield a phantom empty op (`["<name>", ""]`), which then fails `assert op, "If op_args is none, op must not be None."` in `run_in_task` after the real benchmark already completed. Filter empty entries so stray commas are harmless.

Differential Revision: D118372501


