### PR TITLE
[ci] create softlink for cublas library

### DIFF
--- a/.ci/tritonbench/setup-nvidia-path.sh
+++ b/.ci/tritonbench/setup-nvidia-path.sh
@@ -23,6 +23,35 @@ NVIDIA_LIB_PATHS=(
     "$(realpath "${PYTORCH_DIR}/../nvidia/nvshmem/lib")"
 )
 
+# Create libcublas.so / libcublasLt.so soft links when only versioned libraries
+# (e.g. libcublas.so.13) are shipped, mirroring
+# ../triton/.ci/tritonbench/setup-ld-library.sh.
+CUBLAS_LIB_DIR="${PYTORCH_DIR}/../nvidia/cu13/lib"
+if [ ! -f "${CUBLAS_LIB_DIR}/libcublas.so" ]; then
+    for cublas_library in "${CUBLAS_LIB_DIR}"/libcublas.so.*; do
+        if [ -f "${cublas_library}" ]; then
+            ln -sf "${cublas_library}" "${CUBLAS_LIB_DIR}/libcublas.so"
+            break
+        fi
+    done
+    for cublas_library in "${CUBLAS_LIB_DIR}"/libcublasLt.so.*; do
+        if [ -f "${cublas_library}" ]; then
+            ln -sf "${cublas_library}" "${CUBLAS_LIB_DIR}/libcublasLt.so"
+            break
+        fi
+    done
+fi
+
+if [ ! -f "${CUBLAS_LIB_DIR}/libcublas.so" ]; then
+    echo "ERROR: Neither libcublas.so nor libcublas.so.* exists in ${CUBLAS_LIB_DIR}" >&2
+    exit 1
+fi
+
+if [ ! -f "${CUBLAS_LIB_DIR}/libcublasLt.so" ]; then
+    echo "ERROR: Neither libcublasLt.so nor libcublasLt.so.* exists in ${CUBLAS_LIB_DIR}" >&2
+    exit 1
+fi
+
 for NVIDIA_LIB_PATH in "${NVIDIA_LIB_PATHS[@]}"; do
     if [ -e "${NVIDIA_LIB_PATH}" ]; then
         cat <<EOF >> "${SETUP_SCRIPT}"


### PR DESCRIPTION
Downstream triton test requires cublas library to be added to LD_LIBRARY_PATH.

Follow-up PR of https://github.com/facebookexperimental/triton/pull/3530

Test plan:

CI