### PR TITLE
Add and optimize causal Hopper pingpong attention

### DIFF
--- a/tritonbench/operators/flash_attention/operator.py
+++ b/tritonbench/operators/flash_attention/operator.py
@@ -426,16 +426,12 @@ class Operator(BenchmarkOperator):
         if IS_HOPPER:
             if self.D_HEAD < 128:
                 raise NotImplementedError("Skip")
-            if self.causal:
-                raise NotImplementedError(
-                    "Hopper TLX FA does not support causal attention"
-                )
 
             tlx_attention = _tlx_hopper_fa
             assert tlx_attention is not None
 
             def fn(q, k, v):
-                return tlx_attention(q, k, v, self.sm_scale)
+                return tlx_attention(q, k, v, self.sm_scale, self.causal)
 
             return preproc_noop, fn
 


### PR DESCRIPTION
Summary:
Add compile-time causal forward and backward paths to the Hopper TLX pingpong attention kernel and optimize their persistent execution while preserving dense behavior.

Forward restricts K/V traversal to the visible prefix and masks only the diagonal tile before the online-softmax recurrence. For S1024 and S2048, it reverses the causal row order on alternate heads so persistent workers receive a balanced mix of short and long prefixes while retaining all 132 workers. S8192 keeps its bijective 64-row permutation with alternating head-pair reversal. For BF16 B=4, H=48, S=4096, D=128 causal forward, it selects 131 persistent workers and reduces the steady-state producer and consumer loop unroll factor from two to one. The worker stride is then coprime with the 32 query rows, while the smaller loop body reduces instruction-delivery stalls without changing the two-slot ring schedule. The final row log normalization and finalized M stores execute in the final asynchronous PV window without changing accumulator semantics, Q/V release points, named barriers, ring phases, or descriptor geometry.

Backward skips Q blocks preceding each K/V tile and masks overlapping blocks. It uses the Q-empty barrier as the shared Q/dO reuse gate after both consumers finish their dO-dependent work, removing a redundant dO empty-barrier protocol while preserving two-consumer arrival counts, gradient ownership, and ring phases.

Expose `causal=False` through the public autograd API, retain compatibility with the previous positional `config` argument, add dense/causal correctness coverage, and enable Tritonbench causal execution for the TLX provider.

Performance:
Measured on H100 GPU 6, BF16, B=4, H=48, D=128, causal=True, with GPU-event timing. `fbcode/triton/scripts/denoise.sh` held the GPU at a 700 W power cap and 1980 MHz SM clock across the batch. TLX and FA3 were measured in the same Tritonbench process for each shape with fresh per-shape Triton caches. The Average row first averages each provider's seven TFLOP/s values and then computes TLX / FA3 from those averages.

Causal forward:

| SeqLen | FA3 TFLOP/s | TLX TFLOP/s | TLX / FA3 |
| ---: | ---: | ---: | ---: |
| 128 | 40.265 | 33.962 | 84.35% |
| 256 | 91.180 | 84.876 | 93.09% |
| 512 | 190.650 | 167.772 | 88.00% |
| 1024 | 366.465 | 359.432 | 98.08% |
| 2048 | 561.776 | 514.573 | 91.60% |
| 4096 | 651.921 | 608.381 | 93.32% |
| 8192 | 678.407 | 632.578 | 93.24% |
| Average | 368.666 | 343.082 | 93.06% |

Causal backward:

| SeqLen | FA3 TFLOP/s | TLX TFLOP/s | TLX / FA3 |
| ---: | ---: | ---: | ---: |
| 128 | 24.152 | 26.852 | 111.18% |
| 256 | 49.992 | 57.839 | 115.70% |
| 512 | 94.697 | 116.508 | 123.03% |
| 1024 | 181.277 | 219.489 | 121.08% |
| 2048 | 314.321 | 346.823 | 110.34% |
| 4096 | 438.919 | 458.410 | 104.44% |
| 8192 | 517.265 | 521.769 | 100.87% |
| Average | 231.518 | 249.670 | 107.84% |

TLX causal backward outperforms FA3 at every measured shape, with a throughput-average advantage of 7.84%. Causal forward reaches 93.06% of FA3 throughput on average, 98.08% at S1024, 93.32% at S4096, and 93.24% at S8192.

Reviewed By: stashuk-olek

Differential Revision: D119239333


